### PR TITLE
Make variation presets geometry-aware

### DIFF
--- a/4D-ROTATION-GUIDE.md
+++ b/4D-ROTATION-GUIDE.md
@@ -1,0 +1,397 @@
+# 4D Rotation Choreography Guide
+
+## 🌀 Understanding 4D Rotations
+
+The VIB34D system uses **true 4D mathematics** to create impossible geometry. This isn't fake - it's actual 4D rotation projected to 3D space.
+
+---
+
+## 📐 The Three Rotation Planes
+
+In 4D space, there are **6 possible rotation planes**, but we expose the 3 most visually interesting:
+
+### **rot4dXW** - X-W Plane Rotation
+- Rotates the **horizontal axis** through the **4th dimension**
+- Visual effect: Shapes spin left/right while morphing through impossible forms
+- Range: `-2` to `2` (radians)
+- Musical use: **Verse foundations**, steady left-right morphing
+
+### **rot4dYW** - Y-W Plane Rotation
+- Rotates the **vertical axis** through the **4th dimension**
+- Visual effect: Shapes spin up/down while transforming
+- Range: `-2` to `2` (radians)
+- Musical use: **Builds**, adding vertical energy
+
+### **rot4dZW** - Z-W Plane Rotation
+- Rotates the **depth axis** through the **4th dimension**
+- Visual effect: Shapes spin forward/backward through hyperdimensional space
+- Range: `-2` to `2` (radians)
+- Musical use: **Drops**, adding the third dimension of rotation
+
+---
+
+## 🎵 Musical Choreography with 4D Rotations
+
+### **Intro/Breakdown (Minimal)**
+```json
+{
+  "rot4dXW": 0.2,
+  "rot4dYW": 0,
+  "rot4dZW": 0,
+  "gridDensity": 10,
+  "speed": 0.4
+}
+```
+**Effect**: Slow, single-plane rotation. Clean and minimal.
+
+---
+
+### **Verse (Steady Foundation)**
+```json
+{
+  "rot4dXW": 0.4,
+  "rot4dYW": 0.2,
+  "rot4dZW": 0,
+  "gridDensity": 25,
+  "speed": 0.5
+}
+```
+**Effect**: Two-plane rotation creates steady morphing. Foundation for the song.
+
+---
+
+### **Build (Progressive Energy)**
+```json
+{
+  "sweeps": {
+    "rot4dXW": [0.4, 1.0],
+    "rot4dYW": [0.2, 0.7],
+    "rot4dZW": [0, 0.4],
+    "gridDensity": [25, 60],
+    "chaos": [0.2, 0.6]
+  },
+  "speed": 0.6
+}
+```
+**Effect**: All three rotation planes engage progressively. Tension builds.
+
+---
+
+### **Drop (Full 4D Showcase)**
+```json
+{
+  "rot4dXW": 1.2,
+  "rot4dYW": 0.9,
+  "rot4dZW": 0.7,
+  "gridDensity": 95,
+  "morphFactor": 1.8,
+  "chaos": 0.8,
+  "speed": 0.4,
+  "geometry": 5  // Fractal
+}
+```
+**Effect**: **ALL THREE PLANES** rotating at high speeds creates impossible 4D morphing. High density creates fractal detail. SLOW speed lets you SEE the complexity.
+
+---
+
+### **Counter-Rotation (Breakdown)**
+```json
+{
+  "rot4dXW": -0.2,
+  "rot4dYW": 0.3,
+  "rot4dZW": -0.1,
+  "gridDensity": 12,
+  "speed": 0.25
+}
+```
+**Effect**: Negative rotations = reverse spin. Creates otherworldly counter-motion.
+
+---
+
+## 🔁 Rotation Dynamics - Polyrhythmic Motion
+
+Instead of **static rotation**, use **oscillating rotation**:
+
+```json
+{
+  "rotDynamics": {
+    "xw": {
+      "base": 0.5,    // Center value
+      "freq": 0.5,    // Oscillation frequency (Hz)
+      "amp": 0.8      // Oscillation amplitude
+    },
+    "yw": {
+      "base": 0.3,
+      "freq": 0.33,   // 3:2 polyrhythm with xw
+      "amp": 0.5
+    },
+    "zw": {
+      "base": -0.2,
+      "freq": 0.25,   // 2:1 polyrhythm
+      "amp": 0.6
+    }
+  }
+}
+```
+
+**What happens**:
+- `xw` oscillates: `0.5 + sin(t * 0.5 * 2π) * 0.8`
+- Range: `-0.3` to `1.3` (0.5 ± 0.8)
+- Each plane oscillates at different rates = **polyrhythmic 4D motion**
+- Visual effect: Complex, never-repeating 4D choreography
+
+**Frequency guide**:
+- `0.5 Hz` = 2 seconds per cycle = 120 BPM half-notes
+- `0.33 Hz` = 3 seconds per cycle = 120 BPM dotted half-notes (3:2 polyrhythm)
+- `0.25 Hz` = 4 seconds per cycle = 120 BPM whole notes
+- `0.66 Hz` = 1.5 seconds per cycle = 120 BPM quarter-notes (double-time)
+
+---
+
+## 📊 Grid Density - Fractal Detail Control
+
+The shader does this:
+```glsl
+vec4 pos = fract(p * u_gridDensity * 0.08);
+```
+
+**Higher density = more repetitions = fractal detail!**
+
+### **Density Guide**
+
+| Density | Visual Effect | Musical Use |
+|---------|---------------|-------------|
+| 4-8 | Minimal, wide spacing | Silent intros |
+| 10-15 | Clean patterns | Breakdowns, ambient |
+| 20-30 | Moderate detail | Verses, foundations |
+| 40-60 | Dense fractals | Choruses, pre-drops |
+| 70-85 | Intense detail | Build climaxes |
+| 90-100 | **FRACTAL EXPLOSION** | **DROPS** |
+
+---
+
+## 🎨 Geometry Types & 4D Rotation
+
+Different geometries react to 4D rotation differently:
+
+| Geometry | ID | Best For | 4D Rotation Visibility |
+|----------|-----|----------|------------------------|
+| Tetrahedron | 0 | Intros, minimal | Low (simple) |
+| **Hypercube** | **1** | **Drops** | **⭐ BEST** (cubic lattice shows 4D clearly) |
+| Sphere | 2 | Breakdowns | Medium (concentric) |
+| Torus | 3 | Builds | High (donut warping) |
+| Klein Bottle | 4 | Experimental | Very High (impossible topology) |
+| **Fractal** | **5** | **Drops** | **⭐ MAXIMUM** (recursive patterns) |
+| Wave | 6 | Rhythmic sections | Medium (interference) |
+| Crystal | 7 | Sharp drops | High (prismatic) |
+
+**For drops**: Use **Fractal (5)** or **Hypercube (1)** with high rotation values.
+
+---
+
+## 💡 Example: Complete Drop Sequence
+
+```json
+{
+  "name": "DROP 1 - 4D Fractal Explosion",
+  "time": 60,
+  "dur": 16,
+  "sys": "faceted",
+  "par": {
+    "geometry": 5,           // FRACTAL
+    "rot4dXW": 1.2,          // High X-W rotation
+    "rot4dYW": 0.9,          // High Y-W rotation
+    "rot4dZW": 0.7,          // High Z-W rotation
+    "gridDensity": 95,       // MAXIMUM fractal detail
+    "morphFactor": 1.8,      // Heavy shape morphing
+    "chaos": 0.8,            // Controlled chaos
+    "speed": 0.4,            // SLOW to see rotation
+    "hue": 280,              // Purple
+    "intensity": 0.7,
+    "saturation": 0.9
+  },
+  "densityReact": 5,         // Small (already at 95)
+  "morphReact": 0.2,
+  "chaosReact": 0.15,
+  "intensityReact": 0.25,
+  "rotDynamics": {
+    "xw": {"base": 1.2, "freq": 0.5, "amp": 0.4},
+    "yw": {"base": 0.9, "freq": 0.33, "amp": 0.5},
+    "zw": {"base": 0.7, "freq": 0.4, "amp": 0.3}
+  },
+  "sweeps": {
+    "hue": [280, 320],       // Purple → Pink
+    "chaos": [0.7, 0.9]      // Chaos builds
+  }
+}
+```
+
+**What you'll see**:
+1. **Fractal geometry** with 95 density = intricate recursive patterns
+2. **Three-plane 4D rotation** at 1.2/0.9/0.7 = impossible morphing
+3. **Polyrhythmic oscillation** = rotation speeds pulse at different rates
+4. **Color sweep** = purple gradually shifts to pink
+5. **Chaos builds** = 0.7 → 0.9 over 16 seconds
+6. **Slow speed** (0.4) = you can SEE all the complexity
+
+---
+
+## 🎼 Complete Song Structure Example
+
+```json
+[
+  {
+    "name": "Intro",
+    "time": 0,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 0,
+      "rot4dXW": 0.2, "rot4dYW": 0, "rot4dZW": 0,
+      "gridDensity": 10,
+      "speed": 0.4,
+      "hue": 200
+    }
+  },
+  {
+    "name": "Verse 1",
+    "time": 16,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 1,
+      "rot4dXW": 0.4, "rot4dYW": 0.2, "rot4dZW": 0,
+      "gridDensity": 25,
+      "speed": 0.5,
+      "hue": 210
+    }
+  },
+  {
+    "name": "Build 1",
+    "time": 48,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 1,
+      "rot4dXW": 0.6, "rot4dYW": 0.4, "rot4dZW": 0.2,
+      "gridDensity": 40,
+      "speed": 0.7,
+      "hue": 240
+    },
+    "sweeps": {
+      "rot4dXW": [0.6, 1.0],
+      "rot4dYW": [0.4, 0.7],
+      "rot4dZW": [0.2, 0.5],
+      "gridDensity": [40, 70],
+      "chaos": [0.2, 0.6]
+    }
+  },
+  {
+    "name": "DROP 1 - 4D Fractal Explosion",
+    "time": 64,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 5,
+      "rot4dXW": 1.2, "rot4dYW": 0.9, "rot4dZW": 0.7,
+      "gridDensity": 95,
+      "morphFactor": 1.8,
+      "chaos": 0.8,
+      "speed": 0.4,
+      "hue": 280,
+      "intensity": 0.7
+    },
+    "rotDynamics": {
+      "xw": {"base": 1.2, "freq": 0.5, "amp": 0.4},
+      "yw": {"base": 0.9, "freq": 0.33, "amp": 0.5},
+      "zw": {"base": 0.7, "freq": 0.4, "amp": 0.3}
+    }
+  },
+  {
+    "name": "Breakdown",
+    "time": 96,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 2,
+      "rot4dXW": -0.1, "rot4dYW": 0.2, "rot4dZW": -0.05,
+      "gridDensity": 12,
+      "speed": 0.25,
+      "hue": 200
+    }
+  },
+  {
+    "name": "Verse 2",
+    "time": 112,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 1,
+      "rot4dXW": 0.45, "rot4dYW": 0.25, "rot4dZW": 0,
+      "gridDensity": 28,
+      "speed": 0.55,
+      "hue": 215
+    }
+  },
+  {
+    "name": "Build 2",
+    "time": 144,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 5,
+      "rot4dXW": 0.7, "rot4dYW": 0.5, "rot4dZW": 0.3,
+      "gridDensity": 50,
+      "speed": 0.8,
+      "hue": 260
+    },
+    "sweeps": {
+      "rot4dXW": [0.7, 1.5],
+      "rot4dYW": [0.5, 1.2],
+      "rot4dZW": [0.3, 1.0],
+      "gridDensity": [50, 100],
+      "chaos": [0.3, 0.9]
+    }
+  },
+  {
+    "name": "FINAL DROP - Maximum 4D",
+    "time": 160,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 5,
+      "rot4dXW": 1.5, "rot4dYW": 1.2, "rot4dZW": 1.0,
+      "gridDensity": 100,
+      "morphFactor": 2.0,
+      "chaos": 0.9,
+      "speed": 0.35,
+      "hue": 300,
+      "intensity": 0.8
+    },
+    "rotDynamics": {
+      "xw": {"base": 1.5, "freq": 0.66, "amp": 0.5},
+      "yw": {"base": 1.2, "freq": 0.5, "amp": 0.6},
+      "zw": {"base": 1.0, "freq": 0.4, "amp": 0.4}
+    }
+  }
+]
+```
+
+---
+
+## 🔑 Key Takeaways
+
+1. **4D rotations are the star** - Use all three planes (XW, YW, ZW) for drops
+2. **Slow speed during complex rotation** - speed: 0.3-0.5 lets you SEE the 4D math
+3. **High grid density = fractal detail** - 90-100 for drops
+4. **Polyrhythmic motion** - rotDynamics with different frequencies per plane
+5. **Geometry matters** - Fractal (5) or Hypercube (1) show 4D rotation best
+6. **Progressive builds** - Use sweeps to gradually increase rotation
+7. **Counter-rotations** - Negative values create otherworldly breakdown effects
+8. **Musical repetition** - Verse 1 ≈ Verse 2, but each drop is MORE extreme
+
+---
+
+**The AI now understands all of this and will generate sequences that SHOWCASE the 4D mathematics instead of random parameter chaos!**
+
+Test it with: https://domusgpt.github.io/vib34d-music-video-choreographer-alternative/index-ULTIMATE-V2.html

--- a/V3-PLAN.md
+++ b/V3-PLAN.md
@@ -1,0 +1,428 @@
+# V3 System - Complete Rebuild Plan
+
+## 🔍 What I Found (Deep Analysis)
+
+### **Rotation Parameters - ALL WORKING**
+Checked all 3 systems:
+- ✅ **Faceted**: rot4dXW/YW/ZW with correct 4D rotation matrices
+- ✅ **Quantum**: rot4dXW/YW/ZW with correct 4D rotation matrices
+- ⚠️ **Holographic**: rot4dXW/YW/ZW BUT adds `+ time * 0.2` automatically
+
+**Issue**: Holographic system auto-rotates, making manual control harder to perceive
+
+### **What's Actually Broken**
+1. **Audio reactivity is TOO SIMPLE** - just 3 frequency bands (bass/mid/high)
+2. **No temporal smoothing** - values jump instantly, can't see rhythm
+3. **No ADSR envelopes** - parameters don't have attack/decay/release
+4. **No onset detection** - can't detect kicks/snares/transients
+5. **No spectral features** - missing brightness, flux, rolloff
+6. **Limited parameter mapping** - only additive, no curves/thresholds
+
+---
+
+## 🎯 V3 System Architecture
+
+### **1. Advanced Audio Analysis Engine**
+
+```javascript
+class AudioAnalyzer {
+    constructor(audioContext) {
+        this.ctx = audioContext;
+        this.analyser = this.ctx.createAnalyser();
+        this.analyser.fftSize = 4096; // Higher resolution
+
+        // Multi-band analysis
+        this.bands = {
+            subBass: { low: 20, high: 60 },
+            bass: { low: 60, high: 250 },
+            lowMid: { low: 250, high: 500 },
+            mid: { low: 500, high: 2000 },
+            highMid: { low: 2000, high: 4000 },
+            high: { low: 4000, high: 8000 },
+            air: { low: 8000, high: 20000 }
+        };
+
+        // Feature extraction
+        this.features = {
+            spectralCentroid: 0,
+            spectralRolloff: 0,
+            spectralFlux: 0,
+            rms: 0,
+            zcr: 0
+        };
+
+        // Onset detection
+        this.onsetThreshold = 1.5;
+        this.lastOnsetTime = 0;
+        this.onsetHistory = [];
+
+        // Beat tracking
+        this.bpm = 120;
+        this.beatPhase = 0;
+        this.beatConfidence = 0;
+    }
+
+    analyze() {
+        const freqData = new Uint8Array(this.analyser.frequencyBinCount);
+        const timeData = new Uint8Array(this.analyser.fftSize);
+
+        this.analyser.getByteFrequencyData(freqData);
+        this.analyser.getByteTimeDomainData(timeData);
+
+        return {
+            bands: this.analyzeBands(freqData),
+            spectralCentroid: this.calcSpectralCentroid(freqData),
+            spectralFlux: this.calcSpectralFlux(freqData),
+            onset: this.detectOnset(freqData),
+            beat: this.detectBeat(),
+            rms: this.calcRMS(timeData)
+        };
+    }
+
+    calcSpectralCentroid(freqData) {
+        let weightedSum = 0;
+        let sum = 0;
+
+        for (let i = 0; i < freqData.length; i++) {
+            weightedSum += i * freqData[i];
+            sum += freqData[i];
+        }
+
+        return sum > 0 ? weightedSum / sum : 0;
+    }
+
+    detectOnset(freqData) {
+        const flux = this.calcSpectralFlux(freqData);
+        const now = Date.now();
+
+        if (flux > this.onsetThreshold && now - this.lastOnsetTime > 100) {
+            this.lastOnsetTime = now;
+            this.onsetHistory.push(now);
+            return { detected: true, strength: flux };
+        }
+
+        return { detected: false, strength: flux };
+    }
+}
+```
+
+### **2. ADSR Envelope System**
+
+```javascript
+class ADSREnvelope {
+    constructor(attackMs, decayMs, sustain, releaseMs) {
+        this.attack = attackMs;
+        this.decay = decayMs;
+        this.sustain = sustain;
+        this.release = releaseMs;
+
+        this.state = 'idle'; // idle, attack, decay, sustain, release
+        this.currentValue = 0;
+        this.targetValue = 0;
+        this.startTime = 0;
+        this.startValue = 0;
+    }
+
+    trigger(value) {
+        this.targetValue = value;
+        this.startValue = this.currentValue;
+        this.startTime = Date.now();
+        this.state = 'attack';
+    }
+
+    release() {
+        this.startValue = this.currentValue;
+        this.startTime = Date.now();
+        this.state = 'release';
+    }
+
+    update() {
+        const now = Date.now();
+        const elapsed = now - this.startTime;
+
+        switch (this.state) {
+            case 'attack':
+                if (elapsed < this.attack) {
+                    const progress = elapsed / this.attack;
+                    this.currentValue = this.startValue + (this.targetValue - this.startValue) * progress;
+                } else {
+                    this.currentValue = this.targetValue;
+                    this.state = 'decay';
+                    this.startTime = now;
+                    this.startValue = this.targetValue;
+                }
+                break;
+
+            case 'decay':
+                if (elapsed < this.decay) {
+                    const progress = elapsed / this.decay;
+                    this.currentValue = this.targetValue + (this.targetValue * this.sustain - this.targetValue) * progress;
+                } else {
+                    this.currentValue = this.targetValue * this.sustain;
+                    this.state = 'sustain';
+                }
+                break;
+
+            case 'sustain':
+                // Hold at sustain level
+                break;
+
+            case 'release':
+                if (elapsed < this.release) {
+                    const progress = elapsed / this.release;
+                    this.currentValue = this.startValue * (1 - progress);
+                } else {
+                    this.currentValue = 0;
+                    this.state = 'idle';
+                }
+                break;
+        }
+
+        return this.currentValue;
+    }
+}
+```
+
+### **3. Parameter Mapping Engine**
+
+```javascript
+class ParameterMapper {
+    constructor() {
+        this.mappings = {
+            // Rotation mappings
+            rot4dXW: {
+                source: 'bass',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(200, 500, 0.6, 1000),
+                smoothing: 0.8
+            },
+            rot4dYW: {
+                source: 'mid',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(150, 400, 0.7, 800),
+                smoothing: 0.7
+            },
+            rot4dZW: {
+                source: 'high',
+                curve: 'logarithmic',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(100, 300, 0.8, 600),
+                smoothing: 0.6
+            },
+
+            // Density mapping
+            gridDensity: {
+                source: 'spectralCentroid',
+                curve: 's-curve',
+                range: [10, 100],
+                envelope: new ADSREnvelope(300, 600, 0.5, 1200),
+                threshold: 0.2
+            },
+
+            // Hue mapping
+            hue: {
+                source: 'spectralRolloff',
+                curve: 'linear',
+                range: [0, 360],
+                smoothing: 0.9 // Very smooth color changes
+            },
+
+            // Chaos mapping (onsets)
+            chaos: {
+                source: 'onset',
+                curve: 'threshold',
+                range: [0.2, 0.9],
+                envelope: new ADSREnvelope(50, 200, 0.3, 500),
+                threshold: 0.5
+            }
+        };
+
+        this.smoothedValues = {};
+    }
+
+    map(paramName, audioFeatures) {
+        const mapping = this.mappings[paramName];
+        if (!mapping) return null;
+
+        // Get source value
+        let value = audioFeatures[mapping.source] || 0;
+
+        // Apply threshold
+        if (mapping.threshold && value < mapping.threshold) {
+            value = 0;
+        }
+
+        // Apply curve
+        value = this.applyCurve(value, mapping.curve);
+
+        // Apply envelope
+        if (mapping.envelope) {
+            if (value > (this.smoothedValues[paramName] || 0)) {
+                mapping.envelope.trigger(value);
+            } else if (value < 0.1) {
+                mapping.envelope.release();
+            }
+            value = mapping.envelope.update();
+        }
+
+        // Apply smoothing
+        if (mapping.smoothing) {
+            const prev = this.smoothedValues[paramName] || value;
+            value = prev * mapping.smoothing + value * (1 - mapping.smoothing);
+            this.smoothedValues[paramName] = value;
+        }
+
+        // Map to range
+        const [min, max] = mapping.range;
+        value = min + value * (max - min);
+
+        return value;
+    }
+
+    applyCurve(value, curve) {
+        switch (curve) {
+            case 'linear':
+                return value;
+            case 'exponential':
+                return Math.pow(value, 2);
+            case 'logarithmic':
+                return Math.log(1 + value * 9) / Math.log(10);
+            case 's-curve':
+                return 1 / (1 + Math.exp(-10 * (value - 0.5)));
+            case 'threshold':
+                return value > 0.5 ? 1 : 0;
+            default:
+                return value;
+        }
+    }
+}
+```
+
+### **4. Sequence System with Advanced Mapping**
+
+```json
+{
+  "name": "DROP 1 - Spectral Explosion",
+  "time": 60,
+  "dur": 32,
+  "sys": "faceted",
+
+  "baseParams": {
+    "geometry": 5,
+    "speed": 0.4,
+    "morphFactor": 1.5
+  },
+
+  "audioMappings": {
+    "rot4dXW": {
+      "source": "bass",
+      "curve": "exponential",
+      "range": [0.5, 1.8],
+      "attack": 100,
+      "decay": 300,
+      "sustain": 0.7,
+      "release": 800
+    },
+    "rot4dYW": {
+      "source": "spectralCentroid",
+      "curve": "s-curve",
+      "range": [0.3, 1.5],
+      "attack": 150,
+      "release": 600
+    },
+    "gridDensity": {
+      "source": "spectralFlux",
+      "curve": "exponential",
+      "range": [60, 100],
+      "threshold": 0.3,
+      "attack": 200,
+      "release": 1000
+    },
+    "hue": {
+      "source": "beat",
+      "curve": "step",
+      "values": [280, 300, 320, 340],
+      "smoothing": 0.9
+    },
+    "chaos": {
+      "source": "onset",
+      "curve": "threshold",
+      "range": [0.5, 0.9],
+      "attack": 50,
+      "release": 400
+    }
+  },
+
+  "sweeps": {
+    "morphFactor": [1.5, 2.0],
+    "intensity": [0.6, 0.9]
+  }
+}
+```
+
+---
+
+## 🎵 Expected Results
+
+### **Drops**:
+- **Bass hits trigger rot4dXW** with 100ms attack, 300ms decay
+- **Spectral brightness controls density** (bright = high density)
+- **Onsets trigger chaos spikes** that decay over 400ms
+- **Beat-synced hue changes** with smooth transitions
+- **Everything feels MUSICAL** not random
+
+### **Builds**:
+- **Progressive parameter sweeps** over duration
+- **Spectral centroid increases** = brighter colors, more density
+- **Attack times shorten** = more responsive
+- **Multiple layers reacting differently** to different features
+
+### **Breakdowns**:
+- **Long release times** (2000ms+) = smooth fadeouts
+- **Low spectral centroid** = darker colors, less density
+- **Minimal onset detection** = calm, flowing
+
+---
+
+## 📊 Parameter Mappings Table
+
+| Parameter | Audio Source | Curve | Attack | Release | Musical Effect |
+|-----------|-------------|-------|--------|---------|----------------|
+| rot4dXW | Bass | Exponential | 100ms | 800ms | Punchy rotation on kicks |
+| rot4dYW | Spectral Centroid | S-curve | 150ms | 600ms | Brightness = rotation |
+| rot4dZW | High | Logarithmic | 100ms | 600ms | Hi-hats add Z rotation |
+| gridDensity | Spectral Flux | Exponential | 200ms | 1000ms | Change = more detail |
+| hue | Beat Phase | Step | - | - | Color cycles with beat |
+| chaos | Onset | Threshold | 50ms | 400ms | Hits = chaos spikes |
+| morphFactor | Mid | Linear | 300ms | 1200ms | Smooth shape changes |
+| intensity | RMS | Exponential | 100ms | 500ms | Loudness = brightness |
+
+---
+
+## 🚀 Implementation Priority
+
+1. ✅ **Research complete** - Found all issues
+2. ✅ **Test page created** - test-parameters.html
+3. 🔄 **Build AudioAnalyzer** - Multi-band + spectral features
+4. 🔄 **Build ADSREnvelope** - Temporal smoothing
+5. 🔄 **Build ParameterMapper** - Advanced mapping engine
+6. ⏳ **Create V3 HTML** - Full integration
+7. ⏳ **Test with real music** - Verify improvements
+8. ⏳ **Update AI prompts** - Generate sequences with new mapping format
+
+---
+
+## 📁 Files
+
+- ✅ `test-parameters.html` - Manual testing
+- ✅ `V3-PLAN.md` - This document
+- ⏳ `index-V3-ULTIMATE.html` - Complete V3 system
+- ⏳ `src/audio/AudioAnalyzer.js` - Advanced analysis
+- ⏳ `src/audio/ADSREnvelope.js` - Envelope system
+- ⏳ `src/audio/ParameterMapper.js` - Mapping engine
+
+---
+
+**V3 will have PROFESSIONAL audio-visual dynamics instead of simple additive reactivity!**

--- a/index-FINAL.html
+++ b/index-FINAL.html
@@ -160,6 +160,22 @@
             cursor: pointer;
         }
 
+        .geometry-legend {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            font-size: 10px;
+            line-height: 1.4;
+            opacity: 0.8;
+        }
+
+        .geometry-legend span {
+            background: rgba(0, 255, 255, 0.12);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+
         .system-pills {
             display: flex;
             gap: 6px;
@@ -419,6 +435,7 @@
             <div class="param-row">
                 <label>Type <span class="param-value" id="v-geometry">0</span></label>
                 <input type="range" id="geometry" min="0" max="7" value="0" oninput="window.updateParam('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend"></div>
             </div>
         </div>
 
@@ -528,6 +545,7 @@
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
         // System state
         let canvasManager = new CanvasManager();
@@ -552,12 +570,15 @@
 
         let reactivity = { bassDensity: 50, midMorph: 50, highChaos: 60 };
         let sequences = [];
+        let geometryNames = GeometryLibrary.getGeometryNames();
+        let geometrySubscriptionCleanup = null;
 
         const engineClasses = { VIB34DIntegratedEngine, QuantumEngine, RealHolographicSystem };
 
         // Initialize
         (async function() {
             currentEngine = await canvasManager.switchToSystem('faceted', engineClasses);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAudio);
             audio.addEventListener('timeupdate', updatePlayhead);
             audio.addEventListener('ended', () => window.stop());
@@ -569,18 +590,91 @@
             document.getElementById('status-bar').textContent = '🎵 ' + msg;
         }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const numeric = Number(index);
+            if (!Number.isFinite(numeric)) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(numeric)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span>${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                if (Number(slider.max) !== maxIndex) {
+                    slider.max = maxIndex;
+                }
+                const normalized = clampGeometry(params.geometry ?? 0);
+                params.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        geometrySubscriptionCleanup = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
         window.switchSystem = async function(sys) {
             currentEngine = await canvasManager.switchToSystem(sys, engineClasses);
             currentSystem = sys;
             document.querySelectorAll('.system-pill').forEach(p => p.classList.toggle('active', p.dataset.system === sys));
             applyAllParams();
+            refreshGeometryControls();
             setStatus(`Switched to ${sys.toUpperCase()}`);
         };
 
         window.updateParam = function(param, val) {
             params[param] = parseFloat(val);
-            document.getElementById('v-' + param).textContent = param === 'hue' ? val + '°' :
-                param === 'geometry' || param === 'gridDensity' ? parseInt(val) : parseFloat(val).toFixed(2);
+            if (param === 'geometry') {
+                params[param] = clampGeometry(params[param]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = params[param];
+                updateGeometryReadout(params[param]);
+            } else {
+                document.getElementById('v-' + param).textContent = param === 'hue' ? val + '°' :
+                    (param === 'gridDensity' ? parseInt(val) : parseFloat(val).toFixed(2));
+            }
             applyParam(param, params[param]);
         };
 
@@ -603,7 +697,10 @@
         window.randomize = function() {
             Object.keys(params).forEach(p => {
                 let val;
-                if (p === 'geometry') val = Math.floor(Math.random() * 8);
+                if (p === 'geometry') {
+                    const count = geometryCount();
+                    val = count > 0 ? Math.floor(Math.random() * count) : 0;
+                }
                 else if (p.startsWith('rot4d')) val = Math.random() * 12.56 - 6.28;
                 else if (p === 'gridDensity') val = 5 + Math.random() * 95;
                 else if (p === 'morphFactor') val = Math.random() * 2;
@@ -774,6 +871,14 @@
                 console.error(err);
             }
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof geometrySubscriptionCleanup === 'function') {
+                try { geometrySubscriptionCleanup(); }
+                catch (err) { console.warn('Geometry unsubscribe failed', err); }
+                geometrySubscriptionCleanup = null;
+            }
+        });
 
         window.exportVideo = async function() {
             if (!audio.src) return alert('Load audio first');

--- a/index-MASTER.html
+++ b/index-MASTER.html
@@ -121,7 +121,8 @@
             <h3>🔷 Geometry</h3>
             <div class="param">
                 <label>Type <span class="param-val" id="v-geometry">0</span></label>
-                <input type="range" id="geometry" min="0" max="7" value="0" oninput="P('geometry', this.value)">
+                <input type="range" id="geometry" min="0" max="0" value="0" oninput="P('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend" style="margin-top:6px;font-size:10px;line-height:1.4;display:flex;flex-wrap:wrap;gap:4px;opacity:0.8;"></div>
             </div>
         </div>
 
@@ -214,6 +215,7 @@
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
 
         let mgr = new CanvasManager();
@@ -228,6 +230,7 @@
         let play = false;
         let par = { geometry: 0, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0, gridDensity: 15, morphFactor: 1.0, chaos: 0.2, speed: 1.0, hue: 200, intensity: 0.5, saturation: 0.8 };
         let seqs = [];
+        let geometryNames = GeometryLibrary.getGeometryNames();
 
         // Beat detection
         let lastBeatTime = 0;
@@ -238,6 +241,7 @@
 
         (async function() {
             eng = await mgr.switchToSystem('faceted', cls);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAud);
             aud.addEventListener('timeupdate', upd);
             aud.addEventListener('ended', () => window.stop());
@@ -247,18 +251,100 @@
 
         function stat(m) { document.getElementById('status').textContent = '🎵 ' + m; }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const clamped = Math.max(0, Math.min(count - 1, Math.round(index)));
+            return clamped;
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span style="background:rgba(0,255,255,0.08);padding:2px 4px;border-radius:3px;">${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                slider.max = maxIndex;
+                const normalized = clampGeometry(par.geometry ?? 0);
+                par.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        let unsubscribeGeometry = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof unsubscribeGeometry === 'function') {
+                try { unsubscribeGeometry(); } catch (err) {
+                    console.warn('Geometry unsubscribe failed', err);
+                }
+                unsubscribeGeometry = null;
+            }
+        });
+
+        window.refreshGeometryControls = refreshGeometryControls;
+
         window.switchSys = async function(s) {
             eng = await mgr.switchToSystem(s, cls);
             sys = s;
             document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.dataset.sys === s));
+            refreshGeometryControls();
             applyAll();
             stat(`Switched to ${s.toUpperCase()}`);
         };
 
         window.P = function(p, v) {
             par[p] = parseFloat(v);
-            const val = p === 'hue' ? v + '°' : (p === 'geometry' || p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
-            document.getElementById('v-' + p).textContent = val;
+            if (p === 'geometry') {
+                par[p] = clampGeometry(par[p]);
+                if (document.getElementById('geometry')) {
+                    document.getElementById('geometry').value = par[p];
+                }
+                updateGeometryReadout(par[p]);
+            } else {
+                const val = p === 'hue' ? v + '°' : (p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+                document.getElementById('v-' + p).textContent = val;
+            }
             apply(p, par[p]);
         };
 
@@ -276,7 +362,9 @@
         }
 
         window.randomize = function() {
-            par.geometry = Math.floor(Math.random() * 8);
+            geometryCount();
+            const count = Math.max(geometryNames.length, 1);
+            par.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             par.rot4dXW = Math.random() * 12.56 - 6.28;
             par.rot4dYW = Math.random() * 12.56 - 6.28;
             par.rot4dZW = Math.random() * 12.56 - 6.28;
@@ -456,14 +544,23 @@
 
         window.genAI = async function() {
             const prompt = document.getElementById('ai-prompt').value;
-            if (!prompt) return alert('Enter description');
+            if (!prompt) {
+                alert('Enter description');
+                return;
+            }
 
-            const key = document.getElementById('api-key').value || 'AIzaSyD1dHwFcwVxg6r-Lt8I7U6CgznDfwn4GeI';
+            const key = document.getElementById('api-key').value.trim();
+            if (!key) {
+                alert('Enter a Gemini API key');
+                stat('AI failed: API key required');
+                return;
+            }
+
             const dur = aud.duration || 180;
             stat('AI generating with beat sync...');
 
             try {
-                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${key}`;
+                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${encodeURIComponent(key)}`;
                 const resp = await fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -475,7 +572,7 @@
 🔥 YOUR CREATIVE FREEDOM - GO WILD:
 
 PARAMETERS (use FULL ranges - don't be shy!):
-- geometry: 0-7 (0=tetrahedron, 1=hypercube, 2=sphere, 3=torus, 4=klein, 5=fractal, 6=wave, 7=crystal)
+- geometry: use the legend above (indices expand automatically as new shapes register)
 - rot4dXW/YW/ZW: -6.28 to 6.28 (FULL rotations - use extremes!)
 - gridDensity: 5-100 (5=minimal, 100=INSANE detail)
 - morphFactor: 0-2 (2=MAXIMUM morphing)
@@ -532,98 +629,126 @@ Return ONLY the JSON array. Make it INSANE. Be a VISUAL GENIUS.`
                     })
                 });
 
+                if (!resp.ok) {
+                    throw new Error(`HTTP ${resp.status}`);
+                }
+
                 const data = await resp.json();
-                const txt = data.candidates[0].content.parts[0].text;
-                const json = txt.match(/\[[\s\S]*\]/)[0];
-                seqs = JSON.parse(json);
+                const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (!text) {
+                    throw new Error('No choreography returned');
+                }
+
+                const match = text.match(/\[[\s\S]*\]/);
+                if (!match) {
+                    throw new Error('Response missing choreography array');
+                }
+
+                seqs = JSON.parse(match[0]);
                 rend();
                 beatCount = 0;
                 stat(`AI: ${seqs.length} seqs with beat sync!`);
                 window.closeAI();
             } catch (err) {
+                console.error('AI generation failed', err);
                 stat('AI failed: ' + err.message);
-                console.error(err);
             }
         };
 
-        window.exportVid = function() {
-            if (!aud.src) return alert('Load audio first');
+        window.exportVid = async function() {
+            if (!aud.src) {
+                alert('Load audio first');
+                return;
+            }
+
+            if (typeof MediaRecorder === 'undefined') {
+                stat('Export failed: MediaRecorder not supported in this browser');
+                return;
+            }
 
             stat('Preparing export...');
 
-            // Get the first visible canvas
             const canvas = document.querySelector('canvas');
-            if (!canvas) return alert('No canvas found');
-
-            // Try different MediaRecorder mimeTypes for compatibility
-            let mimeType = 'video/webm;codecs=vp9';
-            if (!MediaRecorder.isTypeSupported(mimeType)) {
-                mimeType = 'video/webm;codecs=vp8';
-                if (!MediaRecorder.isTypeSupported(mimeType)) {
-                    mimeType = 'video/webm';
-                }
+            if (!canvas || !canvas.captureStream) {
+                stat('Export failed: Unable to capture canvas stream');
+                return;
             }
 
+            const mimeCandidates = [
+                'video/webm;codecs=vp9',
+                'video/webm;codecs=vp8',
+                'video/webm'
+            ];
+            const mimeType = mimeCandidates.find(type => {
+                try {
+                    return MediaRecorder.isTypeSupported(type);
+                } catch (err) {
+                    return false;
+                }
+            }) || '';
+
             try {
-                // Create video stream from canvas
                 const videoStream = canvas.captureStream(60);
+                const exportDest = ctx.createMediaStreamDestination();
+                let fallbackAudioStream = null;
 
-                // Create a second AudioContext for export to avoid conflicts
-                const exportCtx = new AudioContext();
-                const exportDest = exportCtx.createMediaStreamDestination();
+                try {
+                    anl.connect(exportDest);
+                } catch (err) {
+                    console.warn('Export: analyser connect failed', err);
+                }
 
-                // Create a gain node to tap the audio without disrupting playback
-                const gainNode = ctx.createGain();
-                gainNode.gain.value = 1.0;
+                const combinedStream = new MediaStream();
+                videoStream.getVideoTracks().forEach(track => combinedStream.addTrack(track));
 
-                // Insert gain node into audio chain: source -> analyser -> gain -> destination
-                // We'll connect gain to export destination
-                const srcNode = ctx.createMediaStreamSource(exportDest.stream);
+                const audioTracks = exportDest.stream.getAudioTracks();
+                if (audioTracks.length) {
+                    audioTracks.forEach(track => combinedStream.addTrack(track));
+                } else if (aud.captureStream) {
+                    fallbackAudioStream = aud.captureStream();
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getAudioTracks().forEach(track => combinedStream.addTrack(track));
+                    }
+                }
 
-                // Alternative: Use MediaElementAudioSourceNode if audio isn't playing
-                // Create audio element clone for export
-                const exportAudio = new Audio(aud.src);
-                exportAudio.currentTime = 0;
+                if (combinedStream.getAudioTracks().length === 0) {
+                    stat('Export failed: No audio track available for recording');
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    videoStream.getTracks().forEach(track => track.stop());
+                    return;
+                }
 
-                const exportAudioSource = exportCtx.createMediaElementSource(exportAudio);
-                exportAudioSource.connect(exportDest);
-                exportAudioSource.connect(exportCtx.destination);
-
-                // Combine video + audio streams
-                const combinedStream = new MediaStream([
-                    ...videoStream.getVideoTracks(),
-                    ...exportDest.stream.getAudioTracks()
-                ]);
-
-                // Create MediaRecorder
                 const recorder = new MediaRecorder(combinedStream, {
                     mimeType: mimeType,
                     videoBitsPerSecond: 8000000
                 });
 
                 const chunks = [];
+                const cleanup = () => {
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    exportDest.stream.getTracks().forEach(track => track.stop());
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getTracks().forEach(track => track.stop());
+                    }
+                    videoStream.getTracks().forEach(track => track.stop());
+                };
 
-                recorder.ondataavailable = e => {
-                    if (e.data && e.data.size > 0) {
-                        chunks.push(e.data);
+                recorder.ondataavailable = (event) => {
+                    if (event.data && event.data.size > 0) {
+                        chunks.push(event.data);
                         stat(`Recording... ${chunks.length} chunks`);
                     }
                 };
 
                 recorder.onstop = () => {
-                    console.log('Recorder stopped, chunks:', chunks.length);
+                    cleanup();
 
-                    exportCtx.close();
-                    exportAudio.pause();
-
-                    if (chunks.length === 0) {
+                    if (!chunks.length) {
                         stat('Export failed: No data recorded');
                         return;
                     }
 
-                    const blob = new Blob(chunks, { type: 'video/webm' });
-                    console.log('Blob size:', blob.size);
-
+                    const blob = new Blob(chunks, { type: mimeType || 'video/webm' });
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement('a');
                     a.href = url;
@@ -631,43 +756,41 @@ Return ONLY the JSON array. Make it INSANE. Be a VISUAL GENIUS.`
                     document.body.appendChild(a);
                     a.click();
                     document.body.removeChild(a);
-
                     setTimeout(() => URL.revokeObjectURL(url), 1000);
                     stat('Export complete! Downloaded');
                 };
 
-                recorder.onerror = e => {
-                    console.error('Recorder error:', e);
-                    stat('Export failed: ' + e.error);
-                    exportCtx.close();
-                    exportAudio.pause();
+                recorder.onerror = (event) => {
+                    console.error('Recorder error:', event);
+                    cleanup();
+                    stat('Export failed: ' + (event.error?.message || event.name || 'Unknown error'));
                 };
 
-                // Start recording
-                console.log('Starting recorder with mimeType:', mimeType);
-                recorder.start(100); // Collect data every 100ms
+                if (ctx.state === 'suspended') {
+                    await ctx.resume();
+                }
 
-                // Play both audios in sync
                 aud.currentTime = 0;
-                exportAudio.currentTime = 0;
                 beatCount = 0;
 
-                Promise.all([aud.play(), exportAudio.play()]).then(() => {
-                    stat('Recording... 0 chunks');
-                }).catch(err => {
-                    console.error('Play error:', err);
-                    stat('Playback failed: ' + err.message);
-                    recorder.stop();
-                });
+                recorder.start(100);
 
-                // Stop recording when audio ends
-                exportAudio.onended = () => {
-                    console.log('Audio ended, stopping recorder');
+                try {
+                    await aud.play();
+                    stat('Recording... 0 chunks');
+                } catch (err) {
+                    console.error('Playback failed', err);
+                    recorder.stop();
+                    return;
+                }
+
+                const stopRecording = () => {
                     if (recorder.state === 'recording') {
                         recorder.stop();
                     }
                 };
 
+                aud.addEventListener('ended', stopRecording, { once: true });
             } catch (err) {
                 console.error('Export setup error:', err);
                 stat('Export failed: ' + err.message);

--- a/index-ULTIMATE-V2.html
+++ b/index-ULTIMATE-V2.html
@@ -36,6 +36,22 @@
         input[type="range"]::-webkit-slider-thumb { appearance: none; width: 14px; height: 14px;
             background: linear-gradient(135deg, #0ff, #f0f); border-radius: 50%; cursor: pointer; }
 
+        .geometry-legend {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            font-size: 10px;
+            line-height: 1.4;
+            opacity: 0.8;
+        }
+
+        .geometry-legend span {
+            background: rgba(0, 255, 255, 0.12);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+
         .pills { display: flex; gap: 6px; margin-bottom: 10px; }
         .pill { flex: 1; padding: 8px; background: rgba(0,255,255,0.1); border: 2px solid #0ff; border-radius: 6px;
             text-align: center; font-size: 9px; cursor: pointer; transition: all 0.2s; }
@@ -112,6 +128,7 @@
             <div class="param">
                 <label>Type <span class="param-val" id="v-geometry">0</span></label>
                 <input type="range" id="geometry" min="0" max="7" value="0" oninput="P('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend"></div>
             </div>
         </div>
 
@@ -205,6 +222,7 @@
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
         let mgr = new CanvasManager();
         let eng = null;
@@ -232,11 +250,14 @@
 
         let seqs = [];
         let currentSeq = null;
+        let geometryNames = GeometryLibrary.getGeometryNames();
+        let geometrySubscriptionCleanup = null;
 
         const cls = { VIB34DIntegratedEngine, QuantumEngine, RealHolographicSystem };
 
         (async function() {
             eng = await mgr.switchToSystem('faceted', cls);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAud);
             aud.addEventListener('timeupdate', upd);
             aud.addEventListener('ended', () => window.stop());
@@ -246,18 +267,91 @@
 
         function stat(m) { document.getElementById('status').textContent = '🎵 ' + m; }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const numeric = Number(index);
+            if (!Number.isFinite(numeric)) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(numeric)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span>${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                if (Number(slider.max) !== maxIndex) {
+                    slider.max = maxIndex;
+                }
+                const normalized = clampGeometry(par.geometry ?? 0);
+                par.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        geometrySubscriptionCleanup = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
         window.switchSys = async function(s) {
             eng = await mgr.switchToSystem(s, cls);
             sys = s;
             document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.dataset.sys === s));
+            refreshGeometryControls();
             applyAll();
             stat(`Switched to ${s.toUpperCase()}`);
         };
 
         window.P = function(p, v) {
             par[p] = parseFloat(v);
-            const val = p === 'hue' ? v + '°' : (p === 'geometry' || p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
-            document.getElementById('v-' + p).textContent = val;
+            if (p === 'geometry') {
+                par[p] = clampGeometry(par[p]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = par[p];
+                updateGeometryReadout(par[p]);
+            } else {
+                const val = p === 'hue' ? v + '°' : (p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+                document.getElementById('v-' + p).textContent = val;
+            }
             apply(p, par[p]);
         };
 
@@ -273,7 +367,8 @@
         }
 
         window.randomize = function() {
-            par.geometry = Math.floor(Math.random() * 8);
+            const count = geometryCount();
+            par.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             par.rot4dXW = Math.random() * 4 - 2;
             par.rot4dYW = Math.random() * 4 - 2;
             par.rot4dZW = Math.random() * 4 - 2;
@@ -611,6 +706,14 @@ Return ONLY JSON array.`
                 console.error(err);
             }
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof geometrySubscriptionCleanup === 'function') {
+                try { geometrySubscriptionCleanup(); }
+                catch (err) { console.warn('Geometry unsubscribe failed', err); }
+                geometrySubscriptionCleanup = null;
+            }
+        });
 
         window.exportVid = function() {
             stat('Video export not yet implemented in V2');

--- a/index-ULTIMATE.html
+++ b/index-ULTIMATE.html
@@ -110,7 +110,8 @@
             <h3>🔷 Geometry</h3>
             <div class="param">
                 <label>Type <span class="param-val" id="v-geometry">0</span></label>
-                <input type="range" id="geometry" min="0" max="7" value="0" oninput="P('geometry', this.value)">
+                <input type="range" id="geometry" min="0" max="0" value="0" oninput="P('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend" style="margin-top:6px;font-size:10px;line-height:1.4;display:flex;flex-wrap:wrap;gap:4px;opacity:0.8;"></div>
             </div>
         </div>
 
@@ -203,6 +204,7 @@
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
 
         let mgr = new CanvasManager();
@@ -217,6 +219,7 @@
         let play = false;
         let par = { geometry: 0, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0, gridDensity: 15, morphFactor: 1.0, chaos: 0.2, speed: 1.0, hue: 200, intensity: 0.5, saturation: 0.8 };
         let seqs = [];
+        let geometryNames = GeometryLibrary.getGeometryNames();
         let recChunks = [];
         let rec = null;
 
@@ -224,6 +227,7 @@
 
         (async function() {
             eng = await mgr.switchToSystem('faceted', cls);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAud);
             aud.addEventListener('timeupdate', upd);
             aud.addEventListener('ended', () => window.stop());
@@ -233,17 +237,98 @@
 
         function stat(m) { document.getElementById('status').textContent = '🎵 ' + m; }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(index)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span style="background:rgba(0,255,255,0.08);padding:2px 4px;border-radius:3px;">${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                slider.max = maxIndex;
+                const normalized = clampGeometry(par.geometry ?? 0);
+                par.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        let unsubscribeGeometry = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof unsubscribeGeometry === 'function') {
+                try { unsubscribeGeometry(); } catch (err) {
+                    console.warn('Geometry unsubscribe failed', err);
+                }
+                unsubscribeGeometry = null;
+            }
+        });
+
+        window.refreshGeometryControls = refreshGeometryControls;
+
         window.switchSys = async function(s) {
             eng = await mgr.switchToSystem(s, cls);
             sys = s;
             document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.dataset.sys === s));
+            refreshGeometryControls();
             applyAll();
             stat(`Switched to ${s.toUpperCase()}`);
         };
 
         window.P = function(p, v) {
             par[p] = parseFloat(v);
-            document.getElementById('v-' + p).textContent = p === 'hue' ? v + '°' : (p === 'geometry' || p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+            if (p === 'geometry') {
+                par[p] = clampGeometry(par[p]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = par[p];
+                updateGeometryReadout(par[p]);
+            } else {
+                const val = p === 'hue' ? v + '°' : (p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+                document.getElementById('v-' + p).textContent = val;
+            }
             apply(p, par[p]);
         };
 
@@ -259,7 +344,9 @@
         }
 
         window.randomize = function() {
-            par.geometry = Math.floor(Math.random() * 8);
+            geometryCount();
+            const count = Math.max(geometryNames.length, 1);
+            par.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             par.rot4dXW = Math.random() * 12.56 - 6.28;
             par.rot4dYW = Math.random() * 12.56 - 6.28;
             par.rot4dZW = Math.random() * 12.56 - 6.28;
@@ -396,14 +483,23 @@
 
         window.genAI = async function() {
             const prompt = document.getElementById('ai-prompt').value;
-            if (!prompt) return alert('Enter description');
+            if (!prompt) {
+                alert('Enter description');
+                return;
+            }
 
-            const key = document.getElementById('api-key').value || 'AIzaSyD1dHwFcwVxg6r-Lt8I7U6CgznDfwn4GeI';
+            const key = document.getElementById('api-key').value.trim();
+            if (!key) {
+                alert('Enter a Gemini API key');
+                stat('AI failed: API key required');
+                return;
+            }
+
             const dur = aud.duration || 180; // Use actual duration or default 3min
             stat('AI analyzing full song structure...');
 
             try {
-                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${key}`;
+                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${encodeURIComponent(key)}`;
                 const resp = await fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -429,7 +525,7 @@ For each sequence, create:
 - time: start time in seconds
 - dur: duration in seconds
 - sys: system type (faceted, quantum, or holographic)
-- geometry: 0-7 (switch at transitions for impact)
+- geometry: consult the live legend (indices expand automatically as new shapes load)
 - rot4dXW, rot4dYW, rot4dZW: -6.28 to 6.28 (use extreme values for drops)
 - gridDensity: 5-100 (pulse between low/high for oomf)
 - morphFactor: 0-2 (high for chaotic, low for clean)
@@ -454,60 +550,167 @@ Return ONLY valid JSON array with 10-15 sequences covering the full ${dur.toFixe
                     })
                 });
 
+                if (!resp.ok) {
+                    throw new Error(`HTTP ${resp.status}`);
+                }
+
                 const data = await resp.json();
-                const txt = data.candidates[0].content.parts[0].text;
-                const json = txt.match(/\[[\s\S]*\]/)[0];
-                seqs = JSON.parse(json);
+                const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (!text) {
+                    throw new Error('No choreography returned');
+                }
+
+                const match = text.match(/\[[\s\S]*\]/);
+                if (!match) {
+                    throw new Error('Response missing choreography array');
+                }
+
+                seqs = JSON.parse(match[0]);
                 rend();
                 stat(`AI choreographed ${seqs.length} sequences - ${dur.toFixed(0)}s full song!`);
                 window.closeAI();
             } catch (err) {
+                console.error('AI generation failed', err);
                 stat('AI failed: ' + err.message);
-                console.error(err);
             }
         };
 
         window.exportVid = async function() {
-            if (!aud.src) return alert('Load audio first');
+            if (!aud.src) {
+                alert('Load audio first');
+                return;
+            }
+
+            if (typeof MediaRecorder === 'undefined') {
+                stat('Export failed: MediaRecorder not supported in this browser');
+                return;
+            }
 
             stat('Preparing export...');
-            const canv = document.querySelector('canvas');
-            const stream = canv.captureStream(60);
 
-            // Create new audio context for export to avoid "already connected" error
-            const expCtx = new AudioContext();
-            const expSrc = expCtx.createMediaElementSource(aud);
-            const expDest = expCtx.createMediaStreamDestination();
-            expSrc.connect(expDest);
-            expSrc.connect(expCtx.destination);
+            const canvas = document.querySelector('canvas');
+            if (!canvas || !canvas.captureStream) {
+                stat('Export failed: Unable to capture canvas stream');
+                return;
+            }
 
-            stream.addTrack(expDest.stream.getAudioTracks()[0]);
-
-            rec = new MediaRecorder(stream, { mimeType: 'video/webm;codecs=vp9', videoBitsPerSecond: 8000000 });
-            recChunks = [];
-
-            rec.ondataavailable = e => recChunks.push(e.data);
-            rec.onstop = () => {
-                const blob = new Blob(recChunks, { type: 'video/webm' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = `vib34d-ultimate-${Date.now()}.webm`;
-                a.click();
-                expCtx.close();
-                stat('Export complete!');
-            };
-
-            rec.start();
-            aud.currentTime = 0;
-            await aud.play();
-            stat('Recording... (will auto-stop at end)');
-
-            aud.onended = () => {
-                if (rec && rec.state === 'recording') {
-                    rec.stop();
+            const mimeCandidates = [
+                'video/webm;codecs=vp9',
+                'video/webm;codecs=vp8',
+                'video/webm'
+            ];
+            const mimeType = mimeCandidates.find(type => {
+                try {
+                    return MediaRecorder.isTypeSupported(type);
+                } catch (err) {
+                    return false;
                 }
-            };
+            }) || '';
+
+            try {
+                const stream = canvas.captureStream(60);
+                const exportDest = ctx.createMediaStreamDestination();
+                let fallbackAudioStream = null;
+
+                try {
+                    anl.connect(exportDest);
+                } catch (err) {
+                    console.warn('Export: analyser connect failed', err);
+                }
+
+                const combinedStream = new MediaStream();
+                stream.getVideoTracks().forEach(track => combinedStream.addTrack(track));
+
+                let audioTracks = exportDest.stream.getAudioTracks();
+                if (!audioTracks.length && aud.captureStream) {
+                    fallbackAudioStream = aud.captureStream();
+                    if (fallbackAudioStream) {
+                        audioTracks = fallbackAudioStream.getAudioTracks();
+                    }
+                }
+
+                audioTracks.forEach(track => combinedStream.addTrack(track));
+
+                if (combinedStream.getAudioTracks().length === 0) {
+                    stat('Export failed: No audio track available for recording');
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    stream.getTracks().forEach(track => track.stop());
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getTracks().forEach(track => track.stop());
+                    }
+                    return;
+                }
+
+                rec = new MediaRecorder(combinedStream, { mimeType, videoBitsPerSecond: 8000000 });
+                recChunks = [];
+
+                const cleanup = () => {
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    exportDest.stream.getTracks().forEach(track => track.stop());
+                    stream.getTracks().forEach(track => track.stop());
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getTracks().forEach(track => track.stop());
+                    }
+                };
+
+                rec.ondataavailable = (event) => {
+                    if (event.data && event.data.size > 0) {
+                        recChunks.push(event.data);
+                        stat(`Recording... ${recChunks.length} chunks`);
+                    }
+                };
+
+                rec.onstop = () => {
+                    cleanup();
+
+                    if (!recChunks.length) {
+                        stat('Export failed: No data recorded');
+                        return;
+                    }
+
+                    const blob = new Blob(recChunks, { type: mimeType || 'video/webm' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `vib34d-ultimate-${Date.now()}.webm`;
+                    a.click();
+                    stat('Export complete!');
+                    setTimeout(() => URL.revokeObjectURL(url), 1000);
+                };
+
+                rec.onerror = (event) => {
+                    console.error('Recorder error:', event);
+                    cleanup();
+                    stat('Export failed: ' + (event.error?.message || event.name || 'Unknown error'));
+                };
+
+                if (ctx.state === 'suspended') {
+                    await ctx.resume();
+                }
+
+                aud.currentTime = 0;
+                rec.start(100);
+
+                try {
+                    await aud.play();
+                    stat('Recording... (will auto-stop at end)');
+                } catch (err) {
+                    console.error('Playback failed', err);
+                    rec.stop();
+                    return;
+                }
+
+                const stopRecording = () => {
+                    if (rec && rec.state === 'recording') {
+                        rec.stop();
+                    }
+                };
+
+                aud.addEventListener('ended', stopRecording, { once: true });
+            } catch (err) {
+                console.error('Export setup error:', err);
+                stat('Export failed: ' + err.message);
+            }
         };
     </script>
 </body>

--- a/index-ULTRA.html
+++ b/index-ULTRA.html
@@ -112,6 +112,22 @@
             cursor: pointer;
         }
 
+        .geometry-legend {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            font-size: 10px;
+            line-height: 1.4;
+            opacity: 0.8;
+        }
+
+        .geometry-legend span {
+            background: rgba(0, 255, 255, 0.12);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+
         .param-value {
             float: right;
             color: #f0f;
@@ -390,6 +406,7 @@
             <div class="param-group">
                 <label>Geometry <span class="param-value" id="geometry-value">0</span></label>
                 <input type="range" id="geometry" min="0" max="7" step="1" value="0" oninput="updateParam('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend"></div>
             </div>
         </div>
 
@@ -499,6 +516,7 @@
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
         let canvasManager = null;
         let currentEngine = null;
@@ -528,6 +546,8 @@
         // Sequences
         let sequences = [];
         let currentTime = 0;
+        let geometryNames = GeometryLibrary.getGeometryNames();
+        let geometrySubscriptionCleanup = null;
 
         const engineClasses = {
             VIB34DIntegratedEngine,
@@ -539,6 +559,7 @@
         (async function init() {
             canvasManager = new CanvasManager();
             currentEngine = await canvasManager.switchToSystem('faceted', engineClasses);
+            refreshGeometryControls();
 
             document.getElementById('audio-file').addEventListener('change', loadAudio);
             audioElement.addEventListener('timeupdate', updatePlayhead);
@@ -547,6 +568,71 @@
             startVisualization();
             console.log('✅ ULTRA System initialized');
         })();
+
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const numeric = Number(index);
+            if (!Number.isFinite(numeric)) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(numeric)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span>${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('geometry-value');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                if (Number(slider.max) !== maxIndex) {
+                    slider.max = maxIndex;
+                }
+                const normalized = clampGeometry(params.geometry ?? 0);
+                params.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        geometrySubscriptionCleanup = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
 
         window.switchSystem = async function(system) {
             currentEngine = await canvasManager.switchToSystem(system, engineClasses);
@@ -557,12 +643,20 @@
             });
 
             applyAllParams();
+            refreshGeometryControls();
         };
 
         window.updateParam = function(param, value) {
             params[param] = parseFloat(value);
-            document.getElementById(param + '-value').textContent =
-                param === 'hue' ? value + '°' : parseFloat(value).toFixed(param === 'gridDensity' || param === 'geometry' ? 0 : 2);
+            if (param === 'geometry') {
+                params[param] = clampGeometry(params[param]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = params[param];
+                updateGeometryReadout(params[param]);
+            } else {
+                document.getElementById(param + '-value').textContent =
+                    param === 'hue' ? value + '°' : parseFloat(value).toFixed(param === 'gridDensity' ? 0 : 2);
+            }
 
             applyParam(param, params[param]);
         };
@@ -609,7 +703,8 @@
         };
 
         window.randomizeAll = function() {
-            params.geometry = Math.floor(Math.random() * 8);
+            const count = geometryCount();
+            params.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             params.rot4dXW = Math.random() * 12.56 - 6.28;
             params.rot4dYW = Math.random() * 12.56 - 6.28;
             params.rot4dZW = Math.random() * 12.56 - 6.28;
@@ -720,6 +815,14 @@
             sequences.sort((a, b) => a.time - b.time);
             renderSequences();
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof geometrySubscriptionCleanup === 'function') {
+                try { geometrySubscriptionCleanup(); }
+                catch (err) { console.warn('Geometry unsubscribe failed', err); }
+                geometrySubscriptionCleanup = null;
+            }
+        });
 
         function renderSequences() {
             const track = document.getElementById('sequence-track');

--- a/index.html
+++ b/index.html
@@ -472,6 +472,10 @@
         };
 
         async function initChoreographer(mode) {
+            if (choreographer && typeof choreographer.destroy === 'function') {
+                choreographer.destroy();
+            }
+
             const { MusicVideoChoreographer } = await import('./music-choreographer-engine.js');
             choreographer = new MusicVideoChoreographer(mode);
             window.choreographer = choreographer;
@@ -502,6 +506,12 @@
             if (!choreographer) return;
             choreographer.importChoreography();
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (choreographer && typeof choreographer.destroy === 'function') {
+                choreographer.destroy();
+            }
+        });
     </script>
 </body>
 </html>

--- a/music-choreographer-engine.js
+++ b/music-choreographer-engine.js
@@ -6,6 +6,8 @@
 import { VIB34DIntegratedEngine } from './src/core/Engine.js';
 import { QuantumEngine } from './src/quantum/QuantumEngine.js';
 import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+import { DynamicParameterBridge } from './src/choreography/DynamicParameterBridge.js';
+import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
 export class MusicVideoChoreographer {
     constructor(mode = 'reactive') {
@@ -18,6 +20,7 @@ export class MusicVideoChoreographer {
         this.currentEngine = null;
         this.isPlaying = false;
         this.animationId = null;
+        this.canvasManager = null;
 
         // Beat detection
         this.beatThreshold = 0.7;
@@ -28,6 +31,16 @@ export class MusicVideoChoreographer {
         // Choreography sequences (for choreographed mode)
         this.sequences = [];
         this.currentSequence = null;
+        this.dynamicBridge = new DynamicParameterBridge(this);
+
+        // Geometry controls
+        this.geometryModes = new Set(['hold', 'cycle', 'morph', 'random', 'explosive']);
+        this.lastGeometryIndex = 0;
+        this.refreshGeometryMetadata();
+        this.resetGeometryState(false);
+        this.geometrySubscription = GeometryLibrary.subscribe(() => {
+            this.refreshGeometryMetadata();
+        });
 
         // Audio reactivity multipliers (for reactive mode)
         this.reactivitySettings = {
@@ -41,6 +54,119 @@ export class MusicVideoChoreographer {
         this.init();
     }
 
+    refreshGeometryMetadata() {
+        this.geometryNames = GeometryLibrary.getGeometryNames();
+        this.geometryCount = this.geometryNames.length;
+        this.geometryNameLookup = new Map(
+            this.geometryNames.map((name, index) => [name.toLowerCase(), index])
+        );
+        this.geometryIndexList = Array.from({ length: this.geometryCount }, (_, index) => index);
+
+        if (this.geometryCount > 0) {
+            this.lastGeometryIndex = this.normalizeGeometryIndex(this.lastGeometryIndex);
+        } else {
+            this.lastGeometryIndex = 0;
+        }
+
+        if (this.currentEngine && this.currentEngine.parameterManager && this.currentEngine.parameterManager.updateGeometryRange) {
+            this.currentEngine.parameterManager.updateGeometryRange(this.geometryCount);
+        }
+
+        this.applyGeometryMetadataToUI();
+    }
+
+    applyGeometryMetadataToUI() {
+        if (typeof document === 'undefined') return;
+
+        const slider = document.getElementById('geometry');
+        if (slider) {
+            const maxIndex = Math.max(this.geometryCount - 1, 0);
+            if (slider.max !== String(maxIndex)) {
+                slider.max = String(maxIndex);
+            }
+            if (Number(slider.value) > maxIndex) {
+                slider.value = String(maxIndex);
+            }
+        }
+
+        const sliderWrapper = slider?.parentElement;
+        if (sliderWrapper) {
+            let legend = sliderWrapper.querySelector('.geometry-legend');
+            if (!legend) {
+                legend = document.createElement('div');
+                legend.className = 'geometry-legend';
+                legend.style.marginTop = '6px';
+                legend.style.display = 'flex';
+                legend.style.flexWrap = 'wrap';
+                legend.style.gap = '4px';
+                legend.style.fontSize = '9px';
+                legend.style.lineHeight = '1.4';
+                legend.style.opacity = '0.8';
+                sliderWrapper.appendChild(legend);
+            }
+
+            legend.innerHTML = this.geometryNames.map((name, index) => {
+                return `<span style="background:rgba(0,255,255,0.08);padding:2px 4px;border-radius:3px;">${index}: ${name}</span>`;
+            }).join('');
+        }
+
+        this.updateGeometryReadout(this.lastGeometryIndex);
+    }
+
+    destroy() {
+        if (typeof this.geometrySubscription === 'function') {
+            try {
+                this.geometrySubscription();
+            } catch (err) {
+                console.warn('[MusicVideoChoreographer] geometry unsubscribe failed', err);
+            }
+            this.geometrySubscription = null;
+        }
+    }
+
+    getGeometryName(index) {
+        if (!Number.isFinite(index)) {
+            return 'UNKNOWN';
+        }
+        if (!this.geometryNames || !this.geometryNames.length) {
+            return `#${index}`;
+        }
+        const normalized = this.normalizeGeometryIndex(index);
+        return this.geometryNames[normalized] || `#${index}`;
+    }
+
+    updateGeometryReadout(index) {
+        if (typeof document === 'undefined') return;
+        const readout = document.getElementById('v-geometry');
+        if (!readout) return;
+
+        if (index === null || index === undefined) {
+            readout.textContent = '--';
+            return;
+        }
+
+        const geometryName = this.getGeometryName(index);
+        readout.textContent = `${index} · ${geometryName}`;
+    }
+
+    registerGeometryIfNeeded(name) {
+        if (!name) return null;
+        const normalized = GeometryLibrary.normalizeName(name);
+        if (!normalized) return null;
+
+        const key = normalized.toLowerCase();
+        if (this.geometryNameLookup && this.geometryNameLookup.has(key)) {
+            return this.geometryNameLookup.get(key);
+        }
+
+        const added = GeometryLibrary.registerGeometry(normalized);
+        if (added) {
+            this.refreshGeometryMetadata();
+        }
+
+        return this.geometryNameLookup?.get(key) ?? null;
+    }
+
     async init() {
         console.log(`🎵 Initializing Music Video Choreographer in ${this.mode.toUpperCase()} mode`);
 
@@ -52,9 +178,13 @@ export class MusicVideoChoreographer {
 
         // Initialize default engine
         await this.switchSystem('faceted');
+        this.dynamicBridge.bindToEngine(this.currentEngine);
 
         // Setup event listeners
         this.setupEventListeners();
+
+        // Expose AI choreography ingestion for external tooling / UI overlays
+        window.loadAIChoreography = (data) => this.ingestAIChoreography(data);
 
         // Initialize mode-specific features
         if (this.mode === 'choreographed') {
@@ -121,86 +251,218 @@ export class MusicVideoChoreographer {
         this.sequences = [
             {
                 time: 0,
-                duration: 15,
+                duration: 14,
                 effects: {
                     system: 'faceted', // Start with Faceted
                     geometry: 'cycle',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'smooth',
                     chaos: 0.1,
-                    speed: 0.5,
+                    speed: 0.6,
                     colorShift: 'slow',
-                    densityBoost: 0
+                    densityBoost: 0,
+                    parameters: {
+                        gridDensity: {
+                            value: 20,
+                            audioAxis: 'bass',
+                            scale: 55,
+                            allowOverflow: true,
+                            range: [12, 160]
+                        },
+                        morphFactor: {
+                            value: 0.9,
+                            audioAxis: 'mid',
+                            scale: 1.3,
+                            allowOverflow: true,
+                            range: [0, 3]
+                        },
+                        hue: {
+                            value: 210,
+                            audioAxis: 'energy',
+                            scale: 60,
+                            mode: 'mix'
+                        }
+                    }
                 }
             },
             {
-                time: 15,
-                duration: 15,
+                time: 14,
+                duration: 14,
                 effects: {
-                    system: 'faceted', // Stay on Faceted
+                    system: 'faceted', // stay on Faceted but build energy
                     geometry: 'morph',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'accelerate',
-                    chaos: 0.3,
-                    speed: 1.0,
+                    chaos: 0.28,
+                    speed: 1.1,
                     colorShift: 'medium',
-                    densityBoost: 10
+                    densityBoost: 16,
+                    parameters: {
+                        chaos: {
+                            value: 0.35,
+                            audioAxis: 'high',
+                            scale: 0.6,
+                            mode: 'add',
+                            range: [0, 1]
+                        },
+                        speed: {
+                            value: 1.2,
+                            audioAxis: 'energy',
+                            scale: 0.9,
+                            allowOverflow: true,
+                            range: [0.8, 3.5]
+                        }
+                    }
                 }
             },
             {
-                time: 30,
-                duration: 20,
+                time: 28,
+                duration: 18,
                 effects: {
-                    system: 'quantum', // SWITCH to Quantum for drop
+                    system: 'quantum', // SWITCH to Quantum for the first drop
                     geometry: 'random',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'chaos',
-                    chaos: 0.8,
-                    speed: 2.0,
+                    chaos: 0.75,
+                    speed: 2.1,
                     colorShift: 'fast',
-                    densityBoost: 20
+                    densityBoost: 28,
+                    parameters: {
+                        gridDensity: {
+                            value: 48,
+                            audioAxis: ['bass', 'energy'],
+                            scale: 65,
+                            randomize: 8,
+                            allowOverflow: true,
+                            range: [25, 180]
+                        },
+                        intensity: {
+                            value: 0.9,
+                            audioAxis: 'energy',
+                            scale: 0.8,
+                            mode: 'max',
+                            range: [0, 2],
+                            allowOverflow: true
+                        },
+                        saturation: {
+                            value: 1.1,
+                            audioAxis: 'bass',
+                            scale: 0.6,
+                            allowOverflow: true,
+                            range: [0, 2]
+                        }
+                    },
+                    actions: ['triggerClick']
                 }
             },
             {
-                time: 50,
-                duration: 10,
+                time: 46,
+                duration: 12,
                 effects: {
-                    system: 'holographic', // SWITCH to Holographic
+                    system: 'holographic', // ethereal breakdown
                     geometry: 'explosive',
-                    rotation: 'extreme',
-                    chaos: 0.9,
-                    speed: 2.5,
-                    colorShift: 'rainbow',
-                    densityBoost: 30
-                }
-            },
-            {
-                time: 60,
-                duration: 15,
-                effects: {
-                    system: 'faceted', // BACK to Faceted for breakdown
-                    geometry: 'hold',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'minimal',
-                    chaos: 0.05,
-                    speed: 0.3,
+                    chaos: 0.22,
+                    speed: 0.7,
                     colorShift: 'freeze',
-                    baseHue: 240,
-                    densityBoost: -5
+                    baseHue: 260,
+                    densityBoost: -8,
+                    parameters: {
+                        hue: {
+                            value: 240,
+                            wave: { speed: 0.35, amplitude: 45 },
+                            allowOverflow: true,
+                            range: [120, 420]
+                        },
+                        saturation: {
+                            value: 0.35,
+                            audioAxis: 'mid',
+                            scale: -0.4,
+                            mode: 'mix',
+                            range: [0, 1]
+                        },
+                        intensity: {
+                            value: 0.45,
+                            audioAxis: 'energy',
+                            scale: 0.35,
+                            range: [0, 2]
+                        }
+                    }
                 }
             },
             {
-                time: 75,
+                time: 58,
+                duration: 16,
+                effects: {
+                    system: 'faceted', // rebuild
+                    geometry: 'cycle',
+                    rotation: 'smooth',
+                    chaos: 0.18,
+                    speed: 1.3,
+                    colorShift: 'medium',
+                    densityBoost: 12,
+                    parameters: {
+                        morphFactor: {
+                            value: 1.1,
+                            audioAxis: 'mid',
+                            scale: 1.4,
+                            allowOverflow: true,
+                            range: [0.2, 2.8]
+                        },
+                        gridDensity: {
+                            value: 26,
+                            audioAxis: 'bass',
+                            scale: 40,
+                            mode: 'mix',
+                            allowOverflow: true,
+                            range: [12, 140]
+                        }
+                    }
+                }
+            },
+            {
+                time: 74,
                 duration: 999,
                 effects: {
                     system: 'quantum', // Final drop on Quantum
                     geometry: 'explosive',
                     rotation: 'extreme',
                     chaos: 1.0,
-                    speed: 3.0,
+                    speed: 3.2,
                     colorShift: 'rainbow',
-                    densityBoost: 40
+                    densityBoost: 42,
+                    parameters: {
+                        gridDensity: {
+                            value: 60,
+                            audioAxis: 'bass',
+                            scale: 75,
+                            allowOverflow: true,
+                            range: [30, 220]
+                        },
+                        chaos: {
+                            value: 0.8,
+                            audioAxis: 'energy',
+                            scale: 0.3,
+                            mode: 'max',
+                            range: [0, 1]
+                        },
+                        speed: {
+                            value: 2.4,
+                            audioAxis: 'energy',
+                            scale: 1.2,
+                            allowOverflow: true,
+                            range: [1.2, 4]
+                        }
+                    },
+                    actions: ['triggerClick']
                 }
             }
         ];
 
+        this.resetGeometryState(false);
         this.renderSequenceList();
+        this.scanGeometryDescriptors(this.sequences);
         console.log('🎬 Generated default choreography with system switching');
     }
 
@@ -208,7 +470,26 @@ export class MusicVideoChoreographer {
         const list = document.getElementById('sequence-list');
         if (!list) return;
 
-        list.innerHTML = this.sequences.map((seq, index) => `
+        const legendMarkup = `
+            <div class="geometry-legend-panel" style="margin-bottom:10px;padding:8px;border-radius:6px;background:rgba(0,255,255,0.06);border:1px solid rgba(0,255,255,0.2);font-size:10px;line-height:1.5;">
+                <strong>Available Geometries (${this.geometryNames.length})</strong><br>
+                ${this.geometryNames.map((name, idx) => `<span style="display:inline-block;margin:2px 4px;padding:2px 6px;border-radius:4px;background:rgba(0,255,255,0.08);">${idx}: ${name}</span>`).join(' ')}
+            </div>
+        `;
+
+        const sequenceMarkup = this.sequences.length ? this.sequences.map((seq, index) => {
+            const dynamicSummary = this.renderDynamicSummary(seq.effects);
+            const startIndex = this.resolveGeometryDescriptor(seq.effects.geometryStart);
+            const geometryListValue = this.describeGeometryListInput(seq.effects.geometryList);
+            const intervalValue = seq.effects.geometryInterval ?? '';
+            const cyclesValue = seq.effects.geometryCycles ?? '';
+            const thresholdValue = seq.effects.geometryEnergyThreshold ?? '';
+            const axisValue = seq.effects.geometryAudioAxis ?? '';
+            const geometryValue = seq.effects.geometry;
+            const numericGeometryTarget = (typeof geometryValue === 'number' && Number.isFinite(geometryValue))
+                ? this.normalizeGeometryIndex(geometryValue)
+                : null;
+            return `
             <div class="sequence-item">
                 <h4>Sequence ${index + 1} (${seq.time}s - ${seq.time + seq.duration}s)</h4>
                 <div class="sequence-controls">
@@ -232,7 +513,36 @@ export class MusicVideoChoreographer {
                         <option value="morph" ${seq.effects.geometry === 'morph' ? 'selected' : ''}>Morph</option>
                         <option value="random" ${seq.effects.geometry === 'random' ? 'selected' : ''}>Random</option>
                         <option value="explosive" ${seq.effects.geometry === 'explosive' ? 'selected' : ''}>Explosive</option>
+                        ${this.geometryNames.map((name, idx) => {
+                            const normalized = name.toLowerCase();
+                            const isSelected = (typeof geometryValue === 'string' && geometryValue.toLowerCase() === normalized)
+                                || (numericGeometryTarget !== null && numericGeometryTarget === idx);
+                            return `<option value="${name}" ${isSelected ? 'selected' : ''}>${name}</option>`;
+                        }).join('')}
                     </select>
+
+                    <label>Start Geometry</label>
+                    <select onchange="choreographer.updateSequence(${index}, 'geometryStart', this.value)">
+                        <option value="" ${startIndex === null || startIndex === undefined ? 'selected' : ''}>Auto (carry over)</option>
+                        ${this.geometryNames.map((name, idx) => `<option value="${idx}" ${startIndex === idx ? 'selected' : ''}>${idx}: ${name}</option>`).join('')}
+                    </select>
+
+                    <label>Geometry List</label>
+                    <input type="text" value="${geometryListValue}" placeholder="e.g. Tetrahedron, Wave, 3" onchange="choreographer.updateSequence(${index}, 'geometryList', this.value)">
+
+                    <label>Geometry Interval (s)</label>
+                    <input type="number" step="0.1" min="0.1" value="${intervalValue}" placeholder="2" onchange="choreographer.updateSequence(${index}, 'geometryInterval', this.value)">
+
+                    <label>Geometry Cycles</label>
+                    <input type="number" step="1" min="1" value="${cyclesValue}" placeholder="1" onchange="choreographer.updateSequence(${index}, 'geometryCycles', this.value)">
+
+                    <label>Geometry Audio Axis</label>
+                    <select onchange="choreographer.updateSequence(${index}, 'geometryAudioAxis', this.value)">
+                        ${this.renderGeometryAxisOptions(axisValue)}
+                    </select>
+
+                    <label>Random Threshold</label>
+                    <input type="number" step="0.05" min="0" max="1" value="${thresholdValue}" placeholder="${seq.effects.geometry === 'explosive' ? 0.4 : 0.6}" onchange="choreographer.updateSequence(${index}, 'geometryEnergyThreshold', this.value)">
 
                     <label>Rotation</label>
                     <select onchange="choreographer.updateSequence(${index}, 'rotation', this.value)">
@@ -261,9 +571,138 @@ export class MusicVideoChoreographer {
                 <div style="font-size: 9px; color: #666; margin-top: 5px; padding: 5px; background: rgba(0,255,255,0.05); border-radius: 3px;">
                     ℹ️ Audio reactivity is ALWAYS active - these are base values that audio modulates
                 </div>
+                ${dynamicSummary}
                 <button onclick="choreographer.deleteSequence(${index})" style="margin-top: 10px; background: #f44; font-size: 10px; padding: 5px;">Delete</button>
             </div>
-        `).join('');
+        `;
+        }).join('') : `<div class="sequence-empty" style="padding:12px;border:1px dashed rgba(0,255,255,0.3);border-radius:6px;font-size:11px;color:#7ff;">No sequences defined yet.</div>`;
+
+        list.innerHTML = legendMarkup + sequenceMarkup;
+    }
+
+    describeGeometryStrategy(effects = {}) {
+        if (!effects) return '';
+
+        const summaryParts = [];
+        const geometry = effects.geometry;
+
+        if (geometry !== undefined && geometry !== null) {
+            if (typeof geometry === 'string') {
+                const trimmed = geometry.trim();
+                if (this.geometryModes.has(trimmed.toLowerCase())) {
+                    summaryParts.push(`Mode: ${trimmed}`);
+                } else {
+                    const index = this.resolveGeometryDescriptor(trimmed);
+                    if (index !== null && index !== undefined) {
+                        summaryParts.push(`Target: ${this.getGeometryName(index)} (#${index})`);
+                    } else {
+                        summaryParts.push(`Target: ${GeometryLibrary.normalizeName(trimmed)}`);
+                    }
+                }
+            } else if (typeof geometry === 'number' && Number.isFinite(geometry)) {
+                const normalized = this.normalizeGeometryIndex(geometry);
+                summaryParts.push(`Target #: ${this.getGeometryName(normalized)} (#${normalized})`);
+            } else if (typeof geometry === 'object') {
+                const mode = geometry.mode || geometry.behavior || geometry.type;
+                if (mode) {
+                    summaryParts.push(`Mode: ${mode}`);
+                }
+                if (geometry.name) {
+                    const index = this.resolveGeometryDescriptor(geometry.name);
+                    if (index !== null && index !== undefined) {
+                        summaryParts.push(`Target: ${this.getGeometryName(index)} (#${index})`);
+                    } else {
+                        summaryParts.push(`Target: ${GeometryLibrary.normalizeName(geometry.name)}`);
+                    }
+                }
+                if (geometry.list) {
+                    const listSummary = this.describeGeometryListInput(geometry.list);
+                    if (listSummary) {
+                        summaryParts.push(`List: ${listSummary}`);
+                    }
+                }
+            }
+        }
+
+        const startIndex = this.resolveGeometryDescriptor(effects.geometryStart);
+        if (startIndex !== null && startIndex !== undefined) {
+            summaryParts.push(`Start ➜ ${this.getGeometryName(startIndex)} (#${startIndex})`);
+        }
+
+        const listValue = this.describeGeometryListInput(effects.geometryList);
+        if (listValue) {
+            summaryParts.push(`List ➜ ${listValue}`);
+        }
+
+        if (effects.geometryInterval !== undefined && effects.geometryInterval !== null) {
+            summaryParts.push(`Interval ${Number(effects.geometryInterval).toFixed(2)}s`);
+        }
+
+        if (effects.geometryCycles !== undefined && effects.geometryCycles !== null) {
+            summaryParts.push(`Cycles ×${Math.round(effects.geometryCycles)}`);
+        }
+
+        if (effects.geometryAudioAxis) {
+            summaryParts.push(`Axis ${effects.geometryAudioAxis}`);
+        }
+
+        if (effects.geometryEnergyThreshold !== undefined) {
+            summaryParts.push(`Threshold ${Number(effects.geometryEnergyThreshold).toFixed(2)}`);
+        }
+
+        if (!summaryParts.length) {
+            return '';
+        }
+
+        return summaryParts.join(' | ');
+    }
+
+    renderDynamicSummary(effects = {}) {
+        const parts = [];
+        const geometrySummary = this.describeGeometryStrategy(effects);
+        if (geometrySummary) {
+            parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(0,170,255,0.08);font-size:10px;line-height:1.4;"><strong>Geometry</strong><br>${geometrySummary}</div>`);
+        }
+        if (effects.parameters && Object.keys(effects.parameters).length) {
+            const entries = Object.entries(effects.parameters).map(([name, descriptor]) => {
+                if (typeof descriptor === 'number') {
+                    return `${name}: ${descriptor}`;
+                }
+                if (typeof descriptor === 'object') {
+                    const details = [];
+                    if (descriptor.audioAxis || descriptor.audio) {
+                        details.push(`↔ audio:${descriptor.audioAxis || descriptor.audio}`);
+                    }
+                    if (descriptor.range) {
+                        details.push(`range:${JSON.stringify(descriptor.range)}`);
+                    }
+                    if (descriptor.mode) {
+                        details.push(`mode:${descriptor.mode}`);
+                    }
+                    return `${name}: ${descriptor.value ?? descriptor.base ?? 'auto'}${details.length ? ' (' + details.join(', ') + ')' : ''}`;
+                }
+                return `${name}: ${descriptor}`;
+            }).join('<br>');
+            parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(0,255,255,0.05);font-size:10px;line-height:1.4;"><strong>Dynamic Parameters</strong><br>${entries}</div>`);
+        }
+
+        if (effects.actions && effects.actions.length) {
+            const entries = effects.actions.map(action => {
+                if (typeof action === 'string') return action;
+                if (action.type) {
+                    const suffix = action.args ? ` → ${JSON.stringify(action.args)}` : '';
+                    return `${action.type}${suffix}`;
+                }
+                return JSON.stringify(action);
+            }).join('<br>');
+            parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(255,0,255,0.05);font-size:10px;line-height:1.4;"><strong>Actions</strong><br>${entries}</div>`);
+        }
+
+        if (!parts.length) {
+            return '';
+        }
+
+        return `<div class="dynamic-insight">${parts.join('')}</div>`;
     }
 
     updateSequence(index, property, value) {
@@ -274,21 +713,89 @@ export class MusicVideoChoreographer {
             seq[property] = parseFloat(value);
         } else if (property === 'chaos' || property === 'speed') {
             seq.effects[property] = parseFloat(value);
+        } else if (property === 'geometry') {
+            const resolved = this.normalizeGeometryBehaviorValue(value);
+            if (resolved === null) {
+                delete seq.effects.geometry;
+            } else {
+                seq.effects.geometry = resolved;
+            }
+        } else if (property === 'geometryStart') {
+            const resolved = this.coerceGeometryIndexDescriptor(value);
+            if (resolved === null || resolved === undefined) {
+                delete seq.effects.geometryStart;
+            } else {
+                seq.effects.geometryStart = resolved;
+            }
+        } else if (property === 'geometryList') {
+            const list = this.coerceGeometryList(value);
+            if (list && list.length) {
+                seq.effects.geometryList = list;
+            } else {
+                delete seq.effects.geometryList;
+            }
+        } else if (property === 'geometryInterval') {
+            const numeric = parseFloat(value);
+            if (Number.isFinite(numeric)) {
+                seq.effects.geometryInterval = Math.max(0.05, numeric);
+            } else {
+                delete seq.effects.geometryInterval;
+            }
+        } else if (property === 'geometryCycles') {
+            const numeric = parseInt(value, 10);
+            if (Number.isFinite(numeric)) {
+                seq.effects.geometryCycles = Math.max(1, numeric);
+            } else {
+                delete seq.effects.geometryCycles;
+            }
+        } else if (property === 'geometryAudioAxis') {
+            const axis = value ? value.toString().toLowerCase() : '';
+            if (!axis) {
+                delete seq.effects.geometryAudioAxis;
+            } else {
+                seq.effects.geometryAudioAxis = axis;
+            }
+        } else if (property === 'geometryEnergyThreshold') {
+            const numeric = parseFloat(value);
+            if (Number.isFinite(numeric)) {
+                seq.effects.geometryEnergyThreshold = Math.min(1, Math.max(0, numeric));
+            } else {
+                delete seq.effects.geometryEnergyThreshold;
+            }
         } else {
             seq.effects[property] = value;
         }
 
+        if ([
+            'time',
+            'duration',
+            'geometry',
+            'geometryList',
+            'geometryInterval',
+            'geometryStart',
+            'geometryCycles',
+            'geometryAudioAxis',
+            'geometryEnergyThreshold'
+        ].includes(property)) {
+            this.resetGeometryState(true);
+        }
+
+        this.scanGeometryDescriptors(this.sequences);
+        this.renderSequenceList();
         console.log(`Updated sequence ${index}:`, seq);
     }
 
     deleteSequence(index) {
         this.sequences.splice(index, 1);
+        this.resetGeometryState(true);
         this.renderSequenceList();
     }
 
     addSequenceToTimeline(newSeq) {
         this.sequences.push(newSeq);
         this.sequences.sort((a, b) => a.time - b.time);
+        this.scanGeometryDescriptors(this.sequences);
+        this.resetGeometryState(true);
         this.renderSequenceList();
     }
 
@@ -342,6 +849,8 @@ export class MusicVideoChoreographer {
             }
 
             this.currentSystem = systemName;
+            this.canvasManager = this.currentEngine?.canvasManager || null;
+            this.dynamicBridge.bindToEngine(this.currentEngine);
 
             // Update UI
             document.querySelectorAll('.system-btn').forEach(btn => {
@@ -349,6 +858,7 @@ export class MusicVideoChoreographer {
             });
 
             console.log('✅ Switched to', systemName, 'system');
+            this.refreshGeometryMetadata();
         } catch (error) {
             console.error('Failed to switch system:', error);
         }
@@ -519,16 +1029,26 @@ export class MusicVideoChoreographer {
             this.switchSystem(effects.system);
         }
 
-        // Geometry choreography
-        if (effects.geometry === 'cycle') {
-            const geomIndex = Math.floor((currentTime - activeSequence.time) / 2) % 9;
-            setParam('geometry', geomIndex);
-        } else if (effects.geometry === 'random' && audioData.energy > 0.6) {
-            const geomIndex = Math.floor(Math.random() * 9);
-            setParam('geometry', geomIndex);
-        } else if (effects.geometry === 'explosive' && Math.random() < 0.1) {
-            const geomIndex = Math.floor(Math.random() * 9);
-            setParam('geometry', geomIndex);
+        const sequenceId = this.sequences.indexOf(activeSequence);
+        if (sequenceId !== this.geometryState.activeSequenceId) {
+            this.geometryState.activeSequenceId = sequenceId;
+            this.geometryState.sequenceStartGeometry = this.lastGeometryIndex;
+            this.geometryState.lastRandomIndex = this.lastGeometryIndex;
+            this.geometryState.lastRandomChangeTime = -Infinity;
+        }
+
+        const geometryIndex = this.computeGeometryTarget(
+            effects,
+            activeSequence,
+            currentTime,
+            audioData
+        );
+
+        if (geometryIndex !== null && geometryIndex !== undefined) {
+            setParam('geometry', geometryIndex);
+            this.lastGeometryIndex = geometryIndex;
+            this.geometryState.lastRandomIndex = geometryIndex;
+            this.updateGeometryReadout(geometryIndex);
         }
 
         // Rotation choreography (WITH audio overlay)
@@ -598,6 +1118,467 @@ export class MusicVideoChoreographer {
         if (this.currentEngine && this.currentEngine.audioEnabled !== undefined) {
             this.currentEngine.audioEnabled = true;
         }
+
+        // Allow AI-defined parameters and actions to override / extend the base behaviour
+        this.dynamicBridge.apply(effects, audioData);
+    }
+
+    computeGeometryTarget(effects, activeSequence, currentTime, audioData) {
+        if (!effects) return null;
+
+        const geometrySetting = effects.geometry;
+        if (geometrySetting === undefined || geometrySetting === null) {
+            return null;
+        }
+
+        if (typeof geometrySetting === 'number' && Number.isFinite(geometrySetting)) {
+            return this.normalizeGeometryIndex(geometrySetting);
+        }
+
+        if (typeof geometrySetting === 'string') {
+            const key = geometrySetting.toLowerCase().trim();
+            if (this.geometryNameLookup.has(key)) {
+                return this.geometryNameLookup.get(key);
+            }
+            return this.computeGeometryByMode(
+                key,
+                effects,
+                activeSequence,
+                currentTime,
+                audioData,
+                {}
+            );
+        }
+
+        if (typeof geometrySetting === 'object') {
+            if (typeof geometrySetting.index === 'number') {
+                return this.normalizeGeometryIndex(geometrySetting.index);
+            }
+
+            if (geometrySetting.name) {
+                const nameKey = String(geometrySetting.name).toLowerCase().trim();
+                if (this.geometryNameLookup.has(nameKey)) {
+                    return this.geometryNameLookup.get(nameKey);
+                }
+            }
+
+            const modeSource = geometrySetting.mode || geometrySetting.behavior || geometrySetting.type;
+            if (modeSource) {
+                const modeKey = String(modeSource).toLowerCase().trim();
+                return this.computeGeometryByMode(
+                    modeKey,
+                    effects,
+                    activeSequence,
+                    currentTime,
+                    audioData,
+                    geometrySetting
+                );
+            }
+        }
+
+        return null;
+    }
+
+    computeGeometryByMode(mode, effects, activeSequence, currentTime, audioData, config = {}) {
+        if (!mode) return null;
+
+        const normalizedList = this.normalizeGeometryList(config.list ?? effects.geometryList);
+        const interval = Math.max(0.1, config.interval ?? effects.geometryInterval ?? 2);
+        const direction = (config.direction === 'reverse' || config.direction === 'backward' || config.direction === -1)
+            ? -1
+            : 1;
+
+        switch (mode) {
+            case 'hold':
+                return this.lastGeometryIndex;
+            case 'cycle': {
+                const elapsed = Math.max(0, currentTime - activeSequence.time);
+                const rawSteps = Math.floor(elapsed / interval);
+
+                if (normalizedList && normalizedList.length) {
+                    const listLength = normalizedList.length;
+                    const stepIndex = rawSteps % listLength;
+                    const pointer = direction >= 0
+                        ? stepIndex
+                        : (listLength - ((stepIndex % listLength) + 1));
+                    return normalizedList[(pointer + listLength) % listLength];
+                }
+
+                const startIndex = this.normalizeGeometryIndex(
+                    config.startIndex ?? config.start ?? effects.geometryStart ?? this.geometryState.sequenceStartGeometry ?? this.lastGeometryIndex
+                );
+                return this.normalizeGeometryIndex(startIndex + rawSteps * direction);
+            }
+            case 'morph': {
+                const list = (normalizedList && normalizedList.length)
+                    ? normalizedList
+                    : this.geometryIndexList;
+                if (!list.length) {
+                    return this.lastGeometryIndex;
+                }
+
+                const duration = Math.max(activeSequence.duration || 0.001, 0.001);
+                const progress = Math.max(0, currentTime - activeSequence.time) / duration;
+                const cycles = Math.max(1, config.cycles ?? config.repeats ?? effects.geometryCycles ?? 1);
+                const scaled = progress * list.length * cycles;
+                const indexInList = Math.floor(scaled) % list.length;
+                return list[indexInList];
+            }
+            case 'random':
+            case 'explosive': {
+                const list = (normalizedList && normalizedList.length)
+                    ? normalizedList
+                    : this.geometryIndexList;
+                if (!list.length) {
+                    return this.lastGeometryIndex;
+                }
+
+                const axisKey = config.axis || config.audioAxis || effects.geometryAudioAxis;
+                const audioMetric = axisKey && audioData && audioData[axisKey] !== undefined
+                    ? audioData[axisKey]
+                    : (audioData?.energy ?? 0);
+                const threshold = config.threshold ?? effects.geometryEnergyThreshold ?? (mode === 'explosive' ? 0.4 : 0.6);
+                const minInterval = Math.max(0.05, config.interval ?? effects.geometryInterval ?? (mode === 'explosive' ? 0.4 : 0.75));
+                const force = config.always === true;
+
+                if ((force || audioMetric >= threshold) && (currentTime - this.geometryState.lastRandomChangeTime >= minInterval)) {
+                    let nextIndex = list[Math.floor(Math.random() * list.length)];
+                    if (config.avoidRepeats !== false && list.length > 1) {
+                        let attempts = 0;
+                        while (nextIndex === this.geometryState.lastRandomIndex && attempts < 5) {
+                            nextIndex = list[Math.floor(Math.random() * list.length)];
+                            attempts++;
+                        }
+                    }
+                    this.geometryState.lastRandomIndex = nextIndex;
+                    this.geometryState.lastRandomChangeTime = currentTime;
+                    return nextIndex;
+                }
+
+                return this.geometryState.lastRandomIndex;
+            }
+            default:
+                if (this.geometryNameLookup.has(mode)) {
+                    return this.geometryNameLookup.get(mode);
+                }
+                return this.lastGeometryIndex;
+        }
+    }
+
+    normalizeGeometryIndex(index) {
+        if (!Number.isFinite(index) || this.geometryCount <= 0) {
+            return 0;
+        }
+
+        const base = Math.floor(index);
+        const wrapped = ((base % this.geometryCount) + this.geometryCount) % this.geometryCount;
+        return wrapped;
+    }
+
+    normalizeGeometryList(source) {
+        if (!source) return null;
+        const list = Array.isArray(source) ? source : [source];
+        const normalized = list
+            .map((item, idx) => this.geometryDescriptorToIndex(item, idx))
+            .filter(value => value !== null && value !== undefined);
+        return normalized.length ? normalized : null;
+    }
+
+    geometryDescriptorToIndex(descriptor, fallback = 0) {
+        if (descriptor === undefined || descriptor === null) {
+            return this.normalizeGeometryIndex(fallback);
+        }
+
+        if (typeof descriptor === 'number' && Number.isFinite(descriptor)) {
+            return this.normalizeGeometryIndex(descriptor);
+        }
+
+        if (typeof descriptor === 'string') {
+            const key = descriptor.toLowerCase().trim();
+            if (this.geometryNameLookup.has(key)) {
+                return this.geometryNameLookup.get(key);
+            }
+        }
+
+        if (typeof descriptor === 'object') {
+            if (typeof descriptor.index === 'number') {
+                return this.normalizeGeometryIndex(descriptor.index);
+            }
+            if (descriptor.name) {
+                const key = String(descriptor.name).toLowerCase().trim();
+                if (this.geometryNameLookup.has(key)) {
+                    return this.geometryNameLookup.get(key);
+                }
+            }
+        }
+
+        return this.normalizeGeometryIndex(fallback);
+    }
+
+    resolveGeometryDescriptor(descriptor) {
+        if (descriptor === undefined || descriptor === null) {
+            return null;
+        }
+
+        if (typeof descriptor === 'number' && Number.isFinite(descriptor)) {
+            return this.normalizeGeometryIndex(descriptor);
+        }
+
+        if (typeof descriptor === 'string') {
+            const trimmed = descriptor.trim();
+            if (!trimmed) return null;
+            if (/^-?\d+$/.test(trimmed)) {
+                return this.normalizeGeometryIndex(Number(trimmed));
+            }
+            const key = GeometryLibrary.normalizeName(trimmed).toLowerCase();
+            if (this.geometryNameLookup.has(key)) {
+                return this.geometryNameLookup.get(key);
+            }
+            return null;
+        }
+
+        if (typeof descriptor === 'object') {
+            if (typeof descriptor.index === 'number') {
+                return this.normalizeGeometryIndex(descriptor.index);
+            }
+            if (descriptor.name) {
+                return this.resolveGeometryDescriptor(descriptor.name);
+            }
+        }
+
+        return null;
+    }
+
+    describeGeometryListInput(list) {
+        if (!list) return '';
+
+        const entries = Array.isArray(list)
+            ? list
+            : (typeof list === 'string' ? list.split(',') : [list]);
+
+        const formatted = entries.map((item) => {
+            if (item === undefined || item === null) return '';
+            if (typeof item === 'number' && Number.isFinite(item)) {
+                return this.getGeometryName(item);
+            }
+            if (typeof item === 'string') {
+                const trimmed = item.trim();
+                if (!trimmed) return '';
+                if (/^-?\d+$/.test(trimmed)) {
+                    return this.getGeometryName(Number(trimmed));
+                }
+                return GeometryLibrary.normalizeName(trimmed);
+            }
+            if (typeof item === 'object') {
+                if (typeof item.index === 'number') {
+                    return this.getGeometryName(item.index);
+                }
+                if (item.name) {
+                    return GeometryLibrary.normalizeName(item.name);
+                }
+            }
+            return '';
+        }).filter(Boolean);
+
+        return formatted.join(', ');
+    }
+
+    renderGeometryAxisOptions(selected) {
+        const normalized = (selected || '').toString().toLowerCase();
+        const options = [
+            { value: '', label: 'Auto (energy mix)' },
+            { value: 'bass', label: 'Bass' },
+            { value: 'mid', label: 'Mid' },
+            { value: 'high', label: 'High' },
+            { value: 'energy', label: 'Energy' }
+        ];
+
+        return options.map(({ value, label }) => {
+            const isSelected = value === '' ? !normalized : normalized === value;
+            return `<option value="${value}" ${isSelected ? 'selected' : ''}>${label}</option>`;
+        }).join('');
+    }
+
+    normalizeGeometryBehaviorValue(value) {
+        if (value === undefined || value === null) {
+            return null;
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return this.normalizeGeometryIndex(value);
+        }
+
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            if (/^-?\d+$/.test(trimmed)) {
+                return this.normalizeGeometryIndex(Number(trimmed));
+            }
+            const lower = trimmed.toLowerCase();
+            if (this.geometryModes.has(lower)) {
+                return lower;
+            }
+            const normalized = GeometryLibrary.normalizeName(trimmed);
+            const index = this.registerGeometryIfNeeded(normalized);
+            if (index !== null && index !== undefined) {
+                return this.getGeometryName(index);
+            }
+            return normalized;
+        }
+
+        if (typeof value === 'object') {
+            if (Array.isArray(value)) {
+                return value.slice();
+            }
+            return { ...value };
+        }
+
+        return value;
+    }
+
+    coerceGeometryIndexDescriptor(value) {
+        if (value === undefined || value === null) {
+            return null;
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return this.normalizeGeometryIndex(value);
+        }
+
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            if (/^-?\d+$/.test(trimmed)) {
+                return this.normalizeGeometryIndex(Number(trimmed));
+            }
+            const normalized = GeometryLibrary.normalizeName(trimmed);
+            const index = this.registerGeometryIfNeeded(normalized);
+            if (index !== null && index !== undefined) {
+                return index;
+            }
+            return null;
+        }
+
+        if (typeof value === 'object') {
+            if (typeof value.index === 'number') {
+                return this.normalizeGeometryIndex(value.index);
+            }
+            if (value.name) {
+                return this.coerceGeometryIndexDescriptor(value.name);
+            }
+        }
+
+        return null;
+    }
+
+    coerceGeometryList(value) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        let entries;
+        if (Array.isArray(value)) {
+            entries = value;
+        } else if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            entries = trimmed.split(',').map(token => token.trim()).filter(Boolean);
+        } else {
+            entries = [value];
+        }
+
+        const mapped = entries
+            .map(item => this.coerceGeometryIndexDescriptor(item))
+            .filter(idx => idx !== null && idx !== undefined);
+
+        return mapped.length ? mapped : null;
+    }
+
+    scanGeometryDescriptors(sequences) {
+        if (!Array.isArray(sequences)) return;
+
+        let needsRefresh = false;
+
+        const registerName = (candidate) => {
+            if (!candidate) return;
+            const normalized = GeometryLibrary.normalizeName(candidate);
+            if (!normalized) return;
+            const lower = normalized.toLowerCase();
+            if (this.geometryModes.has(lower)) return;
+            if (/^-?\d+$/.test(normalized)) return;
+            if (this.geometryNameLookup && this.geometryNameLookup.has(lower)) return;
+            if (GeometryLibrary.registerGeometry(normalized)) {
+                needsRefresh = true;
+            }
+        };
+
+        const visitDescriptor = (descriptor) => {
+            if (descriptor === undefined || descriptor === null) return;
+            if (Array.isArray(descriptor)) {
+                descriptor.forEach(item => visitDescriptor(item));
+                return;
+            }
+            if (typeof descriptor === 'number') return;
+            if (typeof descriptor === 'string') {
+                registerName(descriptor);
+                return;
+            }
+            if (typeof descriptor === 'object') {
+                if (typeof descriptor.index === 'number') return;
+                if (descriptor.name) {
+                    registerName(descriptor.name);
+                }
+                if (descriptor.list) {
+                    visitDescriptor(descriptor.list);
+                }
+            }
+        };
+
+        sequences.forEach(seq => {
+            const effects = seq.effects || {};
+            visitDescriptor(effects.geometry);
+            visitDescriptor(effects.geometryStart);
+            visitDescriptor(effects.geometryEnd);
+            visitDescriptor(effects.geometryList);
+        });
+
+        if (needsRefresh) {
+            this.refreshGeometryMetadata();
+        }
+    }
+
+    resetGeometryState(preserveLast = false) {
+        const baseIndex = preserveLast && Number.isFinite(this.lastGeometryIndex)
+            ? this.normalizeGeometryIndex(this.lastGeometryIndex)
+            : 0;
+
+        this.lastGeometryIndex = baseIndex;
+        this.geometryState = {
+            activeSequenceId: null,
+            sequenceStartGeometry: baseIndex,
+            lastRandomIndex: baseIndex,
+            lastRandomChangeTime: -Infinity
+        };
+
+        this.updateGeometryReadout(this.lastGeometryIndex);
+    }
+
+    ingestAIChoreography(sequenceData) {
+        try {
+            const normalized = this.dynamicBridge.normalizeSequences(sequenceData);
+            this.sequences = normalized.map(seq => ({
+                time: seq.time,
+                duration: seq.duration,
+                effects: seq.effects
+            }));
+            this.scanGeometryDescriptors(this.sequences);
+            this.resetGeometryState(true);
+            this.renderSequenceList();
+            this.updateStatus(`AI choreography loaded (${this.sequences.length} sequences)`);
+        } catch (error) {
+            console.error('Failed to ingest AI choreography', error);
+            this.updateStatus('AI choreography failed: ' + error.message);
+        }
     }
 
     updateTimeline() {
@@ -635,8 +1616,8 @@ export class MusicVideoChoreographer {
             const reader = new FileReader();
             reader.onload = (event) => {
                 try {
-                    this.sequences = JSON.parse(event.target.result);
-                    this.renderSequenceList();
+                    const data = JSON.parse(event.target.result);
+                    this.ingestAIChoreography(data);
                     console.log('📂 Imported choreography');
                 } catch (error) {
                     console.error('Failed to import choreography:', error);

--- a/music-video-choreographer.html
+++ b/music-video-choreographer.html
@@ -662,6 +662,12 @@
         // Initialize choreographer
         const choreographer = new MusicVideoChoreographer();
 
+        window.addEventListener('beforeunload', () => {
+            if (choreographer && typeof choreographer.destroy === 'function') {
+                choreographer.destroy();
+            }
+        });
+
         // Handle window resize
         window.addEventListener('resize', () => {
             document.querySelectorAll('canvas').forEach(canvas => {

--- a/src/choreography/DynamicParameterBridge.js
+++ b/src/choreography/DynamicParameterBridge.js
@@ -1,0 +1,453 @@
+export class DynamicParameterBridge {
+    constructor(choreographer) {
+        this.choreographer = choreographer;
+        this.parameterRegistry = new Map();
+        this.actionHandlers = new Map();
+    }
+
+    registerParameter(name, definition = {}) {
+        if (!name) return;
+        const existing = this.parameterRegistry.get(name) || {};
+        const merged = { ...existing, ...definition };
+        this.parameterRegistry.set(name, merged);
+
+        this._registerWithEngine(name, merged);
+    }
+
+    bindToEngine(engine) {
+        if (!engine) return;
+        this.parameterRegistry.forEach((definition, name) => {
+            this._registerWithEngine(name, definition, engine);
+        });
+    }
+
+    registerAction(type, handler) {
+        if (!type || typeof handler !== 'function') return;
+        this.actionHandlers.set(type, handler);
+    }
+
+    normalizeSequences(rawSequences) {
+        if (!Array.isArray(rawSequences)) {
+            throw new Error('Choreography data must be an array');
+        }
+
+        return rawSequences.map((entry, index) => {
+            const safeEntry = entry || {};
+            const time = this._coerceNumber(
+                safeEntry.time,
+                safeEntry.start,
+                safeEntry.startTime,
+                safeEntry.begin,
+                0
+            );
+            const duration = Math.max(0.5, this._coerceNumber(
+                safeEntry.duration,
+                safeEntry.length,
+                safeEntry.dur,
+                safeEntry.span,
+                8
+            ));
+
+            const effectsSource = typeof safeEntry.effects === 'object' && safeEntry.effects !== null
+                ? { ...safeEntry.effects }
+                : {};
+
+            const effects = {
+                ...effectsSource,
+            };
+
+            if (safeEntry.system && !effects.system) effects.system = safeEntry.system;
+            if (safeEntry.geometry && !effects.geometry) effects.geometry = safeEntry.geometry;
+            if (safeEntry.rotation && !effects.rotation) effects.rotation = safeEntry.rotation;
+            if (safeEntry.colorShift && !effects.colorShift) effects.colorShift = safeEntry.colorShift;
+
+            const parameters = safeEntry.parameters || safeEntry.dynamicParameters || effects.parameters;
+            if (parameters) {
+                effects.parameters = { ...parameters };
+            }
+
+            const actions = safeEntry.actions || effects.actions;
+            if (actions) {
+                effects.actions = Array.isArray(actions) ? actions.slice() : [actions];
+            }
+
+            const definitions = safeEntry.define || effects.define;
+            if (definitions && typeof definitions === 'object') {
+                Object.entries(definitions).forEach(([name, definition]) => {
+                    this.registerParameter(name, definition);
+                });
+                delete effects.define;
+            }
+
+            return {
+                time,
+                duration,
+                effects,
+                index
+            };
+        }).sort((a, b) => a.time - b.time);
+    }
+
+    apply(effects, audioData) {
+        if (!effects) return;
+
+        if (effects.define && typeof effects.define === 'object') {
+            Object.entries(effects.define).forEach(([name, definition]) => {
+                this.registerParameter(name, definition);
+            });
+        }
+
+        if (effects.parameters) {
+            this._applyParameters(effects.parameters, audioData);
+        }
+
+        if (effects.actions) {
+            this._executeActions(effects.actions, audioData);
+        }
+    }
+
+    _applyParameters(parameters, audioData) {
+        Object.entries(parameters).forEach(([name, descriptor]) => {
+            const resolvedValue = this._resolveDescriptor(descriptor, audioData, name);
+            this._setEngineParameter(name, resolvedValue, descriptor);
+        });
+    }
+
+    _executeActions(actions, audioData) {
+        const list = Array.isArray(actions) ? actions : [actions];
+        list.forEach(action => {
+            if (!action) return;
+
+            if (typeof action === 'string') {
+                this._invokeAction({ type: action }, audioData);
+                return;
+            }
+
+            this._invokeAction(action, audioData);
+        });
+    }
+
+    _invokeAction(action, audioData) {
+        const { type, method, target = 'engine' } = action;
+        const handler = type && this.actionHandlers.get(type);
+        if (handler) {
+            try {
+                handler({ action, audioData, choreographer: this.choreographer });
+                return;
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] custom action failed', type, err);
+                return;
+            }
+        }
+
+        const engine = this.choreographer.currentEngine;
+        if (!engine) return;
+
+        const methodName = method || type;
+        if (!methodName) return;
+
+        const args = Array.isArray(action.args) ? action.args : (action.payload ? [action.payload] : []);
+        let context = engine;
+
+        if (target === 'manager' && this.choreographer.canvasManager) {
+            context = this.choreographer.canvasManager;
+        } else if (target === 'audio' && this.choreographer.audioContext) {
+            context = this.choreographer.audioContext;
+        }
+
+        const fn = context && context[methodName];
+        if (typeof fn === 'function') {
+            try {
+                fn.apply(context, [...args, audioData]);
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] action invocation failed', methodName, err);
+            }
+        }
+    }
+
+    _resolveDescriptor(descriptor, audioData, name) {
+        if (typeof descriptor === 'number' || Array.isArray(descriptor)) {
+            return descriptor;
+        }
+
+        if (typeof descriptor === 'string') {
+            if (audioData && descriptor in audioData) {
+                return audioData[descriptor];
+            }
+            return descriptor;
+        }
+
+        if (!descriptor || typeof descriptor !== 'object') {
+            return descriptor;
+        }
+
+        const registryMeta = this.parameterRegistry.get(name) || {};
+        const base = descriptor.value ?? descriptor.base ?? registryMeta.base ?? registryMeta.default ?? 0;
+        let value = base;
+
+        if (descriptor.randomize) {
+            const amount = typeof descriptor.randomize === 'number'
+                ? descriptor.randomize
+                : (descriptor.randomize.amount ?? 0);
+            value += (Math.random() * 2 - 1) * amount;
+        }
+
+        if (descriptor.audioAxis || descriptor.audio) {
+            const axis = descriptor.audioAxis || descriptor.audio;
+            const axisValue = this._sampleAudioAxis(axis, audioData);
+            const scale = descriptor.scale ?? descriptor.multiplier ?? 1;
+            const bias = descriptor.offset ?? descriptor.bias ?? 0;
+            value += axisValue * scale + bias;
+        }
+
+        if (descriptor.expression && audioData) {
+            try {
+                const fn = new Function('audio', `return (${descriptor.expression});`);
+                value = fn(audioData);
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] expression failed', err);
+            }
+        }
+
+        if (descriptor.wave) {
+            const { speed = 1, amplitude = 1, phase = 0 } = descriptor.wave;
+            const t = this.choreographer.audio ? this.choreographer.audio.currentTime : 0;
+            value += Math.sin(t * speed + phase) * amplitude;
+        }
+
+        if (descriptor.mode) {
+            const current = this._getCurrentParameterValue(name);
+            value = this._applyMode(current, value, descriptor.mode, descriptor);
+        }
+
+        const range = descriptor.range || registryMeta.range;
+        if (range) {
+            value = this._applyRange(value, range);
+        }
+
+        if (descriptor.precision !== undefined && typeof value === 'number') {
+            const factor = Math.pow(10, descriptor.precision);
+            value = Math.round(value * factor) / factor;
+        }
+
+        return value;
+    }
+
+    _sampleAudioAxis(axis, audioData) {
+        if (!audioData) return 0;
+        if (typeof axis === 'string' && axis in audioData) {
+            return audioData[axis];
+        }
+        if (Array.isArray(axis)) {
+            return axis
+                .map(key => (typeof key === 'string' && key in audioData) ? audioData[key] : 0)
+                .reduce((acc, val) => acc + val, 0) / axis.length;
+        }
+        if (typeof axis === 'function') {
+            try {
+                return axis(audioData);
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] audio axis fn failed', err);
+            }
+        }
+        return 0;
+    }
+
+    _applyRange(value, range) {
+        if (!range) return value;
+        if (Array.isArray(range)) {
+            const [min, max] = range;
+            if (typeof value === 'number') {
+                return Math.min(max ?? value, Math.max(min ?? value, value));
+            }
+            return value;
+        }
+        if (typeof range === 'object') {
+            const min = range.min ?? range.lower;
+            const max = range.max ?? range.upper;
+            if (typeof value === 'number') {
+                return Math.min(max ?? value, Math.max(min ?? value, value));
+            }
+        }
+        return value;
+    }
+
+    _applyMode(current, incoming, mode, descriptor) {
+        if (current === undefined || current === null || typeof current !== 'number') {
+            return incoming;
+        }
+
+        switch (mode) {
+            case 'add':
+            case 'additive':
+                return current + incoming;
+            case 'multiply':
+            case 'mult':
+                return current * incoming;
+            case 'mix': {
+                const weight = descriptor?.weight ?? descriptor?.mix ?? 0.5;
+                return current * (1 - weight) + incoming * weight;
+            }
+            case 'max':
+                return Math.max(current, incoming);
+            case 'min':
+                return Math.min(current, incoming);
+            default:
+                return incoming;
+        }
+    }
+
+    _getCurrentParameterValue(name) {
+        const engine = this.choreographer.currentEngine;
+        if (!engine) return undefined;
+
+        try {
+            if (engine.parameterManager) {
+                if (engine.parameterManager.getParameterValue) {
+                    return engine.parameterManager.getParameterValue(name);
+                }
+                if (engine.parameterManager.getParameter) {
+                    return engine.parameterManager.getParameter(name);
+                }
+            }
+        } catch (err) {
+            console.warn('[DynamicParameterBridge] getParameterValue failed', name, err);
+        }
+
+        if (name in engine) {
+            return engine[name];
+        }
+
+        return undefined;
+    }
+
+    _setEngineParameter(name, value, descriptor) {
+        const engine = this.choreographer.currentEngine;
+        if (!engine) return;
+
+        const meta = (descriptor && typeof descriptor === 'object') ? descriptor : {};
+        const registryMeta = this.parameterRegistry.get(name) || {};
+        const methodName = meta.method || registryMeta.method;
+        const target = meta.target || registryMeta.target || 'engine';
+        const allowOverflow = meta.allowOverflow ?? registryMeta.allowOverflow ?? false;
+        const definition = meta.definition || registryMeta.definition || registryMeta;
+
+        const applyToEngine = (eng) => {
+            if (!eng) return false;
+
+            if (methodName && typeof eng[methodName] === 'function') {
+                try {
+                    eng[methodName](value, meta, this.choreographer, registryMeta);
+                    return true;
+                } catch (err) {
+                    console.warn('[DynamicParameterBridge] method application failed', methodName, err);
+                }
+            }
+
+            if (eng.parameterManager) {
+                const definitionPayload = this._createParameterDefinition(definition);
+                if (eng.parameterManager.setParameterExternal && eng.parameterManager.setParameterExternal(name, value, {
+                    allowOverflow,
+                    register: !!(definitionPayload && (allowOverflow || this.parameterRegistry.has(name))),
+                    definition: definitionPayload,
+                    defaultValue: definitionPayload?.defaultValue ?? registryMeta.base ?? 0
+                })) {
+                    return true;
+                }
+
+                if (eng.parameterManager.setParameter && eng.parameterManager.setParameter(name, value)) {
+                    return true;
+                }
+            }
+
+            if (eng.updateParameter) {
+                try {
+                    eng.updateParameter(name, value);
+                    return true;
+                } catch (err) {
+                    console.warn('[DynamicParameterBridge] updateParameter failed', name, err);
+                }
+            }
+
+            if (eng.updateParameters) {
+                try {
+                    eng.updateParameters({ [name]: value });
+                    return true;
+                } catch (err) {
+                    console.warn('[DynamicParameterBridge] updateParameters failed', name, err);
+                }
+            }
+
+            if (name in eng) {
+                eng[name] = value;
+                return true;
+            }
+
+            return false;
+        };
+
+        if (target === 'manager' && this.choreographer.canvasManager) {
+            if (applyToEngine(this.choreographer.canvasManager)) return;
+        }
+
+        if (!applyToEngine(engine) && meta.fallbackToManager && this.choreographer.canvasManager) {
+            applyToEngine(this.choreographer.canvasManager);
+        }
+    }
+
+    _coerceNumber(...candidates) {
+        for (const candidate of candidates) {
+            if (candidate === undefined || candidate === null) continue;
+            const value = Number(candidate);
+            if (!Number.isNaN(value)) {
+                return value;
+            }
+        }
+        return 0;
+    }
+
+    _registerWithEngine(name, definition, engine = this.choreographer?.currentEngine) {
+        if (!engine || !engine.parameterManager || !engine.parameterManager.registerDynamicParameter) {
+            return;
+        }
+
+        const normalized = this._createParameterDefinition(definition);
+        if (!normalized) {
+            return;
+        }
+
+        engine.parameterManager.registerDynamicParameter(name, normalized);
+    }
+
+    _createParameterDefinition(definition = {}) {
+        if (!definition || typeof definition !== 'object') {
+            return null;
+        }
+
+        const output = {};
+
+        if (definition.range) {
+            if (Array.isArray(definition.range)) {
+                output.min = definition.range[0];
+                output.max = definition.range[1];
+            } else if (typeof definition.range === 'object') {
+                output.min = definition.range.min ?? definition.range.lower;
+                output.max = definition.range.max ?? definition.range.upper;
+            }
+        }
+
+        if (definition.min !== undefined) output.min = definition.min;
+        if (definition.max !== undefined) output.max = definition.max;
+        if (definition.step !== undefined) output.step = definition.step;
+        if (definition.type) output.type = definition.type;
+        if (definition.allowOverflow !== undefined) output.allowOverflow = definition.allowOverflow;
+        if (definition.default !== undefined) output.defaultValue = definition.default;
+        if (definition.base !== undefined && output.defaultValue === undefined) output.defaultValue = definition.base;
+
+        if (Object.keys(output).length === 0) {
+            return null;
+        }
+
+        return output;
+    }
+}

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -30,7 +30,7 @@ export class VIB34DIntegratedEngine {
         
         // Current state
         this.currentVariation = 0;
-        this.totalVariations = 100; // 30 default + 70 custom
+        this.totalVariations = this.variationManager?.totalVariations || 0;
         
         // Mouse interaction state
         this.mouseX = 0.5;
@@ -519,7 +519,11 @@ export class VIB34DIntegratedEngine {
                 visualizer.destroy();
             }
         });
-        
+
+        if (this.variationManager?.destroy) {
+            this.variationManager.destroy();
+        }
+
         console.log('🔄 VIB34D Engine destroyed');
     }
 }

--- a/src/variations/VariationManager.js
+++ b/src/variations/VariationManager.js
@@ -1,143 +1,297 @@
 /**
  * VIB34D Variation Management System
- * Manages 100 total variations: 30 default + 70 custom
+ * Dynamically manages default and custom variations using the live geometry library.
  */
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
 
+const DEFAULT_VARIATION_TARGET = 30;
+const CUSTOM_VARIATION_SLOTS = 70;
+const BASE_GEOMETRY_CLASS_MAP = {
+    'TETRAHEDRON': 'tetrahedron',
+    'HYPERCUBE': 'hypercube',
+    'SPHERE': 'sphere',
+    'TORUS': 'torus',
+    'KLEIN BOTTLE': 'klein',
+    'FRACTAL': 'fractal',
+    'WAVE': 'wave',
+    'CRYSTAL': 'crystal'
+};
+
 export class VariationManager {
     constructor(engine) {
         this.engine = engine;
-        
-        // Default variation names (30 total)
-        this.variationNames = [
-            // Tetrahedron Lattice (0-3)
-            'TETRAHEDRON LATTICE 1', 'TETRAHEDRON LATTICE 2', 'TETRAHEDRON LATTICE 3', 'TETRAHEDRON LATTICE 4',
-            
-            // Hypercube Lattice (4-7)
-            'HYPERCUBE LATTICE 1', 'HYPERCUBE LATTICE 2', 'HYPERCUBE LATTICE 3', 'HYPERCUBE LATTICE 4',
-            
-            // Sphere Lattice (8-11)
-            'SPHERE LATTICE 1', 'SPHERE LATTICE 2', 'SPHERE LATTICE 3', 'SPHERE LATTICE 4',
-            
-            // Torus Lattice (12-15)
-            'TORUS LATTICE 1', 'TORUS LATTICE 2', 'TORUS LATTICE 3', 'TORUS LATTICE 4',
-            
-            // Klein Bottle Lattice (16-19)
-            'KLEIN BOTTLE LATTICE 1', 'KLEIN BOTTLE LATTICE 2', 'KLEIN BOTTLE LATTICE 3', 'KLEIN BOTTLE LATTICE 4',
-            
-            // Fractal Lattice (20-22)
-            'FRACTAL LATTICE 1', 'FRACTAL LATTICE 2', 'FRACTAL LATTICE 3',
-            
-            // Wave Lattice (23-25)
-            'WAVE LATTICE 1', 'WAVE LATTICE 2', 'WAVE LATTICE 3',
-            
-            // Crystal Lattice (26-29)
-            'CRYSTAL LATTICE 1', 'CRYSTAL LATTICE 2', 'CRYSTAL LATTICE 3', 'CRYSTAL LATTICE 4'
-        ];
-        
-        // Custom variations storage (70 slots)
-        this.customVariations = new Array(70).fill(null);
-        
-        // Total variation count
-        this.totalVariations = 100;
+        this.defaultVariationTarget = DEFAULT_VARIATION_TARGET;
+        this.customSlotCount = CUSTOM_VARIATION_SLOTS;
+
+        this.geometryMetadata = [];
+        this.defaultVariations = [];
+        this.customVariations = new Array(this.customSlotCount).fill(null);
+
+        this.geometryUnsubscribe = null;
+        this.pendingGridRefresh = false;
+
+        this.handleGeometryUpdate(GeometryLibrary.getGeometryNames());
+        this.subscribeToGeometryLibrary();
     }
-    
-    /**
-     * Get variation name for display
-     */
-    getVariationName(index) {
-        if (index < 30) {
-            return this.variationNames[index];
-        } else {
-            const customIndex = index - 30;
-            const customVar = this.customVariations[customIndex];
-            return customVar ? customVar.name : `CUSTOM ${customIndex + 1}`;
+
+    subscribeToGeometryLibrary() {
+        if (typeof GeometryLibrary?.subscribe !== 'function') {
+            return;
+        }
+
+        this.geometryUnsubscribe = GeometryLibrary.subscribe(({ names }) => {
+            this.handleGeometryUpdate(names);
+        });
+    }
+
+    destroy() {
+        if (typeof this.geometryUnsubscribe === 'function') {
+            this.geometryUnsubscribe();
+            this.geometryUnsubscribe = null;
         }
     }
-    
-    /**
-     * Generate default variation parameters
-     */
-    generateDefaultVariation(index) {
-        if (index >= 30) return null;
-        
-        const geometryType = Math.floor(index / 4);
-        const level = index % 4;
-        
-        // Special handling for reduced geometry sets
-        let adjustedGeometryType = geometryType;
-        if (geometryType === 5 && level > 2) { // Fractal only has 3 levels
-            adjustedGeometryType = 5;
-            level = 2;
-        }
-        if (geometryType === 6 && level > 2) { // Wave only has 3 levels  
-            adjustedGeometryType = 6;
-            level = 2;
-        }
-        
-        return {
-            variation: index,
-            geometry: adjustedGeometryType,
-            gridDensity: 8 + adjustedGeometryType * 2 + level * 1.5,
-            morphFactor: 0.2 + level * 0.2,
-            chaos: level * 0.2,
-            speed: 0.8 + level * 0.2,
-            hue: (index * 12.27) % 360,
-            rot4dXW: (level - 1.5) * 0.3,
-            rot4dYW: (adjustedGeometryType % 2) * 0.2,
-            rot4dZW: ((adjustedGeometryType + level) % 3) * 0.15,
-            dimension: 3.2 + level * 0.2
-        };
+
+    handleGeometryUpdate(names) {
+        const resolvedNames = Array.isArray(names) && names.length
+            ? names
+            : GeometryLibrary.getGeometryNames();
+
+        this.geometryMetadata = this.buildGeometryMetadata(resolvedNames);
+        this.defaultVariations = this.buildDefaultVariationDefinitions(this.geometryMetadata);
+        this.updateEngineVariationMetadata();
+        this.syncCurrentVariationIndex();
+        this.refreshGridIfMounted();
     }
-    
-    /**
-     * Apply specific variation to the engine
-     */
-    applyVariation(index) {
-        if (index < 0 || index >= this.totalVariations) return false;
-        
-        let params;
-        
-        if (index < 30) {
-            // Default variation
-            params = this.generateDefaultVariation(index);
-        } else {
-            // Custom variation
-            const customIndex = index - 30;
-            const customVar = this.customVariations[customIndex];
-            
-            if (customVar) {
-                params = { ...customVar.parameters, variation: index };
-            } else {
-                // Empty slot - use current parameters
-                params = { ...this.engine.parameterManager.getAllParameters(), variation: index };
+
+    buildGeometryMetadata(names = []) {
+        const seen = new Set();
+        return names
+            .map(name => GeometryLibrary.normalizeName(name))
+            .filter(Boolean)
+            .map((normalized, index) => {
+                const key = normalized.toUpperCase();
+                if (seen.has(key)) {
+                    return null;
+                }
+                seen.add(key);
+                return {
+                    key,
+                    displayName: this.toDisplayName(normalized),
+                    cssClass: BASE_GEOMETRY_CLASS_MAP[key] || this.toCssClass(key, index),
+                    levels: this.getLevelCountForGeometry(key)
+                };
+            })
+            .filter(Boolean);
+    }
+
+    toDisplayName(name) {
+        return name
+            .split(' ')
+            .filter(Boolean)
+            .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+            .join(' ');
+    }
+
+    toCssClass(name, index) {
+        const base = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        if (!base) {
+            return `geometry-${index}`;
+        }
+        return `geometry-${base}`;
+    }
+
+    getLevelCountForGeometry(key) {
+        switch (key) {
+            case 'FRACTAL':
+            case 'WAVE':
+                return 3;
+            default:
+                return 4;
+        }
+    }
+
+    buildDefaultVariationDefinitions(metadata) {
+        if (!metadata.length) {
+            return [];
+        }
+
+        const perGeometry = metadata.map((meta, geometryIndex) => {
+            const levelCount = Math.max(1, meta.levels || 1);
+            const entries = [];
+            for (let level = 0; level < levelCount; level += 1) {
+                entries.push({
+                    geometryIndex,
+                    geometryKey: meta.key,
+                    cssClass: meta.cssClass,
+                    displayName: meta.displayName,
+                    level,
+                    label: `${meta.key} LATTICE ${level + 1}`,
+                    displayLabel: `${meta.displayName} Lattice ${level + 1}`,
+                    shortLabel: `Level ${level + 1}`
+                });
+            }
+            return entries;
+        });
+
+        const definitions = [];
+        let levelIndex = 0;
+        let added = true;
+
+        while (definitions.length < this.defaultVariationTarget && added) {
+            added = false;
+            perGeometry.forEach(entries => {
+                if (definitions.length >= this.defaultVariationTarget) {
+                    return;
+                }
+                if (entries[levelIndex]) {
+                    definitions.push(entries[levelIndex]);
+                    added = true;
+                }
+            });
+            levelIndex += 1;
+        }
+
+        if (!definitions.length) {
+            const fallback = perGeometry.find(list => list.length);
+            if (fallback && fallback.length) {
+                definitions.push(fallback[0]);
             }
         }
-        
-        if (params) {
-            this.engine.parameterManager.setParameters(params);
+
+        return definitions;
+    }
+
+    updateEngineVariationMetadata() {
+        this.totalVariations = this.defaultVariations.length + this.customVariations.length;
+
+        if (this.engine) {
+            this.engine.totalVariations = this.totalVariations;
+            if (this.engine.parameterManager?.updateVariationMetadata) {
+                this.engine.parameterManager.updateVariationMetadata({
+                    defaults: this.defaultVariations,
+                    customCount: this.customVariations.length,
+                    totalVariations: this.totalVariations
+                });
+            }
+        }
+    }
+
+    syncCurrentVariationIndex() {
+        if (!this.engine) {
+            return;
+        }
+
+        if (!this.totalVariations) {
+            this.engine.currentVariation = 0;
+            if (this.engine.parameterManager) {
+                this.engine.parameterManager.setParameter('variation', 0);
+            }
+            return;
+        }
+
+        if (this.engine.currentVariation >= this.totalVariations) {
+            const newIndex = this.totalVariations - 1;
+            this.engine.currentVariation = newIndex;
+            if (this.engine.parameterManager) {
+                this.engine.parameterManager.setParameter('variation', newIndex);
+            }
+        }
+    }
+
+    refreshGridIfMounted() {
+        const gridContainer = typeof document !== 'undefined'
+            ? document.getElementById('variationGrid')
+            : null;
+
+        if (gridContainer) {
+            this.populateGrid();
+        } else {
+            this.pendingGridRefresh = true;
+        }
+    }
+
+    getDefaultVariationCount() {
+        return this.defaultVariations.length;
+    }
+
+    getCustomOffset() {
+        return this.getDefaultVariationCount();
+    }
+
+    getGeometryDisplayName(index) {
+        const meta = this.geometryMetadata[index];
+        if (meta) {
+            return meta.displayName;
+        }
+
+        const rawName = GeometryLibrary.getGeometryName(index);
+        const normalized = GeometryLibrary.normalizeName(rawName);
+        return normalized ? this.toDisplayName(normalized) : 'Unknown';
+    }
+
+    getVariationName(index) {
+        const defaultCount = this.getDefaultVariationCount();
+        if (index < defaultCount) {
+            const definition = this.defaultVariations[index];
+            return definition ? definition.label : `VARIATION ${index + 1}`;
+        }
+
+        const customIndex = index - defaultCount;
+        const customVar = this.customVariations[customIndex];
+        return customVar ? customVar.name : `CUSTOM ${customIndex + 1}`;
+    }
+
+    generateDefaultVariation(index) {
+        if (index >= this.getDefaultVariationCount()) {
+            return null;
+        }
+
+        const params = this.engine?.parameterManager?.generateVariationParameters(index);
+        return params ? { ...params, variation: index } : null;
+    }
+
+    applyVariation(index) {
+        if (index < 0 || index >= this.totalVariations) {
+            return false;
+        }
+
+        const defaultCount = this.getDefaultVariationCount();
+
+        if (index < defaultCount) {
+            if (this.engine?.parameterManager?.applyVariation) {
+                this.engine.parameterManager.applyVariation(index);
+            }
             this.engine.currentVariation = index;
             return true;
         }
-        
+
+        const customIndex = index - defaultCount;
+        const customVar = this.customVariations[customIndex];
+
+        if (customVar) {
+            this.engine.parameterManager.setParameters({
+                ...customVar.parameters,
+                variation: index
+            });
+            this.engine.currentVariation = index;
+            return true;
+        }
+
+        this.engine.parameterManager.setParameter('variation', index);
+        this.engine.currentVariation = index;
         return false;
     }
-    
-    /**
-     * Save current state as custom variation
-     */
+
     saveCurrentAsCustom() {
-        // Find first empty custom slot
         const emptyIndex = this.customVariations.findIndex(slot => slot === null);
-        
         if (emptyIndex === -1) {
-            return -1; // No empty slots
+            return -1;
         }
-        
+
         const currentParams = this.engine.parameterManager.getAllParameters();
         const currentGeometry = GeometryLibrary.getGeometryName(currentParams.geometry);
-        
+
         const customVariation = {
             name: `${currentGeometry} CUSTOM ${emptyIndex + 1}`,
             timestamp: new Date().toISOString(),
@@ -147,127 +301,160 @@ export class VariationManager {
                 createdFrom: 'current-state'
             }
         };
-        
+
         this.customVariations[emptyIndex] = customVariation;
         this.saveCustomVariations();
-        
-        return 30 + emptyIndex; // Return absolute variation index
+        this.updateEngineVariationMetadata();
+
+        return this.getCustomOffset() + emptyIndex;
     }
-    
-    /**
-     * Delete custom variation
-     */
+
     deleteCustomVariation(customIndex) {
-        if (customIndex >= 0 && customIndex < 70) {
+        if (customIndex >= 0 && customIndex < this.customVariations.length) {
             this.customVariations[customIndex] = null;
             this.saveCustomVariations();
+            this.updateEngineVariationMetadata();
             return true;
         }
         return false;
     }
-    
-    /**
-     * Populate the variation grid UI
-     */
+
     populateGrid() {
         const gridContainer = document.getElementById('variationGrid');
-        if (!gridContainer) return;
-        
+        if (!gridContainer) {
+            this.pendingGridRefresh = true;
+            return;
+        }
+
+        this.pendingGridRefresh = false;
         gridContainer.innerHTML = '';
-        
-        // Create sections for different geometry types
-        const sections = [
-            { name: 'Tetrahedron', range: [0, 3], class: 'tetrahedron' },
-            { name: 'Hypercube', range: [4, 7], class: 'hypercube' },
-            { name: 'Sphere', range: [8, 11], class: 'sphere' },
-            { name: 'Torus', range: [12, 15], class: 'torus' },
-            { name: 'Klein Bottle', range: [16, 19], class: 'klein' },
-            { name: 'Fractal', range: [20, 22], class: 'fractal' },
-            { name: 'Wave', range: [23, 25], class: 'wave' },
-            { name: 'Crystal', range: [26, 29], class: 'crystal' }
-        ];
-        
-        // Add default variations
-        sections.forEach(section => {
+
+        const groups = this.getDefaultVariationGroups();
+        groups.forEach(group => {
+            if (!group.variations.length) {
+                return;
+            }
+
             const sectionDiv = document.createElement('div');
             sectionDiv.className = 'variation-section';
-            sectionDiv.innerHTML = `<h3>${section.name} Lattice</h3>`;
-            
+            sectionDiv.innerHTML = `<h3>${group.name}</h3>`;
+
             const buttonContainer = document.createElement('div');
             buttonContainer.className = 'variation-buttons';
-            
-            for (let i = section.range[0]; i <= section.range[1]; i++) {
-                if (i < this.variationNames.length) {
-                    const button = this.createVariationButton(i, true, section.class);
-                    buttonContainer.appendChild(button);
-                }
-            }
-            
+
+            group.variations.forEach(({ index, shortLabel }) => {
+                const definition = this.defaultVariations[index];
+                const button = this.createVariationButton(
+                    index,
+                    true,
+                    group.cssClass,
+                    shortLabel || definition?.shortLabel || 'Level'
+                );
+                buttonContainer.appendChild(button);
+            });
+
             sectionDiv.appendChild(buttonContainer);
             gridContainer.appendChild(sectionDiv);
         });
-        
-        // Add custom variations section
+
         const customSection = document.createElement('div');
         customSection.className = 'variation-section custom-section';
         customSection.innerHTML = '<h3>Custom Variations</h3>';
-        
+
         const customContainer = document.createElement('div');
         customContainer.className = 'variation-buttons custom-grid';
-        
-        for (let i = 0; i < 70; i++) {
-            const button = this.createVariationButton(30 + i, false, 'custom');
+
+        const customOffset = this.getCustomOffset();
+        for (let i = 0; i < this.customVariations.length; i += 1) {
+            const button = this.createVariationButton(customOffset + i, false, 'custom');
             customContainer.appendChild(button);
         }
-        
+
         customSection.appendChild(customContainer);
         gridContainer.appendChild(customSection);
+
+        this.updateVariationGrid();
     }
-    
-    /**
-     * Create individual variation button
-     */
-    createVariationButton(variationIndex, isDefault, geomClass) {
+
+    getDefaultVariationGroups() {
+        const groups = new Map();
+
+        this.defaultVariations.forEach((definition, index) => {
+            if (!definition) {
+                return;
+            }
+
+            const existing = groups.get(definition.geometryIndex);
+            if (!existing) {
+                groups.set(definition.geometryIndex, {
+                    geometryIndex: definition.geometryIndex,
+                    name: `${definition.displayName} Lattice`,
+                    cssClass: definition.cssClass || 'geometry',
+                    variations: []
+                });
+            }
+
+            groups.get(definition.geometryIndex).variations.push({
+                index,
+                level: definition.level ?? 0,
+                shortLabel: definition.shortLabel
+            });
+        });
+
+        return Array.from(groups.values()).map(group => ({
+            ...group,
+            variations: group.variations
+                .sort((a, b) => {
+                    if (a.level === b.level) {
+                        return a.index - b.index;
+                    }
+                    return a.level - b.level;
+                })
+                .map(({ index, shortLabel }) => ({ index, shortLabel }))
+        }));
+    }
+
+    createVariationButton(variationIndex, isDefault, geomClass, levelLabel = '') {
         const button = document.createElement('button');
         const name = this.getVariationName(variationIndex);
-        
-        button.className = `preset-btn ${geomClass} ${isDefault ? 'default-variation' : 'custom-variation'}`;
+        const numberLabel = (variationIndex + 1).toString().padStart(2, '0');
+
+        const classes = ['preset-btn', geomClass || 'geometry'];
+        classes.push(isDefault ? 'default-variation' : 'custom-variation');
+        button.className = classes.join(' ');
         button.dataset.variation = variationIndex;
         button.title = `${variationIndex + 1}. ${name}`;
-        
-        // Button content
+
         if (isDefault) {
             button.innerHTML = `
-                <div class="variation-number">${(variationIndex + 1).toString().padStart(2, '0')}</div>
-                <div class="variation-level">Level ${(variationIndex % 4) + 1}</div>
+                <div class="variation-number">${numberLabel}</div>
+                <div class="variation-level">${levelLabel}</div>
             `;
         } else {
-            const customIndex = variationIndex - 30;
+            const customIndex = variationIndex - this.getDefaultVariationCount();
             const hasCustom = this.customVariations[customIndex] !== null;
-            
+
             button.innerHTML = `
-                <div class="variation-number">${(variationIndex + 1).toString()}</div>
+                <div class="variation-number">${variationIndex + 1}</div>
                 <div class="variation-type">${hasCustom ? 'CUSTOM' : 'EMPTY'}</div>
             `;
-            
+
             if (!hasCustom) {
                 button.classList.add('empty-slot');
             }
         }
-        
-        // Click handler
+
         button.addEventListener('click', () => {
-            if (isDefault || this.customVariations[variationIndex - 30] !== null) {
+            if (isDefault || this.customVariations[variationIndex - this.getDefaultVariationCount()] !== null) {
                 this.engine.setVariation(variationIndex);
                 this.updateVariationGrid();
             }
         });
-        
-        // Right-click for custom variations (delete)
+
         if (!isDefault) {
-            button.addEventListener('contextmenu', (e) => {
-                e.preventDefault();
-                const customIndex = variationIndex - 30;
+            button.addEventListener('contextmenu', (event) => {
+                event.preventDefault();
+                const customIndex = variationIndex - this.getDefaultVariationCount();
                 if (this.customVariations[customIndex] !== null) {
                     if (confirm(`Delete custom variation ${variationIndex + 1}?`)) {
                         this.deleteCustomVariation(customIndex);
@@ -276,43 +463,38 @@ export class VariationManager {
                 }
             });
         }
-        
+
         return button;
     }
-    
-    /**
-     * Update variation grid to show current selection
-     */
+
     updateVariationGrid() {
         const buttons = document.querySelectorAll('.preset-btn');
         buttons.forEach(btn => {
             btn.classList.remove('active');
-            if (parseInt(btn.dataset.variation) === this.engine.currentVariation) {
+            if (parseInt(btn.dataset.variation, 10) === this.engine.currentVariation) {
                 btn.classList.add('active');
             }
         });
     }
-    
-    /**
-     * Load custom variations from localStorage
-     */
+
     loadCustomVariations() {
         try {
             const stored = localStorage.getItem('vib34d-custom-variations');
             if (stored) {
                 const parsed = JSON.parse(stored);
-                if (Array.isArray(parsed) && parsed.length === 70) {
-                    this.customVariations = parsed;
+                if (Array.isArray(parsed)) {
+                    this.customVariations = new Array(this.customSlotCount)
+                        .fill(null)
+                        .map((_, index) => parsed[index] || null);
                 }
             }
         } catch (error) {
             console.warn('Failed to load custom variations:', error);
         }
+
+        this.updateEngineVariationMetadata();
     }
-    
-    /**
-     * Save custom variations to localStorage
-     */
+
     saveCustomVariations() {
         try {
             localStorage.setItem('vib34d-custom-variations', JSON.stringify(this.customVariations));
@@ -320,10 +502,7 @@ export class VariationManager {
             console.warn('Failed to save custom variations:', error);
         }
     }
-    
-    /**
-     * Export all custom variations as JSON
-     */
+
     exportCustomVariations() {
         const exportData = {
             type: 'vib34d-custom-variations',
@@ -331,64 +510,58 @@ export class VariationManager {
             timestamp: new Date().toISOString(),
             variations: this.customVariations.filter(v => v !== null)
         };
-        
+
         const json = JSON.stringify(exportData, null, 2);
         const blob = new Blob([json], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
-        
+
         const link = document.createElement('a');
         link.href = url;
         link.download = 'vib34d-custom-variations.json';
         link.click();
-        
+
         URL.revokeObjectURL(url);
     }
-    
-    /**
-     * Import custom variations from JSON
-     */
+
     async importCustomVariations(file) {
         try {
             const text = await file.text();
             const data = JSON.parse(text);
-            
+
             if (data.type === 'vib34d-custom-variations' && Array.isArray(data.variations)) {
-                // Merge imported variations
                 let importCount = 0;
-                
+
                 data.variations.forEach(variation => {
                     const emptyIndex = this.customVariations.findIndex(slot => slot === null);
                     if (emptyIndex !== -1) {
                         this.customVariations[emptyIndex] = variation;
-                        importCount++;
+                        importCount += 1;
                     }
                 });
-                
+
                 this.saveCustomVariations();
                 this.populateGrid();
-                
+                this.updateEngineVariationMetadata();
+
                 return importCount;
             }
         } catch (error) {
             console.error('Failed to import custom variations:', error);
         }
-        
+
         return 0;
     }
-    
-    /**
-     * Get variation statistics
-     */
+
     getStatistics() {
         const customCount = this.customVariations.filter(v => v !== null).length;
-        
+
         return {
             totalVariations: this.totalVariations,
-            defaultVariations: 30,
+            defaultVariations: this.getDefaultVariationCount(),
             customVariations: customCount,
-            emptySlots: 70 - customCount,
+            emptySlots: this.customVariations.length - customCount,
             currentVariation: this.engine.currentVariation,
-            isCustom: this.engine.currentVariation >= 30
+            isCustom: this.engine.currentVariation >= this.getDefaultVariationCount()
         };
     }
 }

--- a/test-parameters.html
+++ b/test-parameters.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>VIB34D Parameter Test</title>
+    <style>
+        body { margin: 0; font-family: monospace; background: #000; color: #0ff; }
+        #test-container { display: flex; height: 100vh; }
+        #canvas-area { flex: 1; position: relative; }
+        #controls { width: 400px; padding: 20px; background: #111; overflow-y: auto; }
+        canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+        .param { margin: 15px 0; }
+        .param label { display: block; margin-bottom: 5px; }
+        .param input { width: 100%; }
+        .param .value { color: #f0f; float: right; }
+        button { width: 100%; padding: 10px; margin: 5px 0; background: #0ff; color: #000; border: none; cursor: pointer; }
+        #log { margin-top: 20px; font-size: 11px; max-height: 200px; overflow-y: auto; background: #000; padding: 10px; }
+        .log-entry { margin: 2px 0; }
+    </style>
+</head>
+<body>
+    <div id="test-container">
+        <div id="canvas-area">
+            <div class="holographic-layers" id="vib34dLayers"></div>
+            <div class="holographic-layers" id="quantumLayers" style="display:none;"></div>
+            <div class="holographic-layers" id="holographicLayers" style="display:none;"></div>
+        </div>
+        <div id="controls">
+            <h2>PARAMETER TEST</h2>
+
+            <div class="param">
+                <label>System</label>
+                <button onclick="switchTo('faceted')">FACETED</button>
+                <button onclick="switchTo('quantum')">QUANTUM</button>
+                <button onclick="switchTo('holographic')">HOLOGRAPHIC</button>
+            </div>
+
+            <div class="param">
+                <label>Geometry <span class="value" id="v-geometry">0</span></label>
+                <input type="range" id="geometry" min="0" max="7" value="0" step="1" oninput="update('geometry', this.value)">
+            </div>
+
+            <div class="param">
+                <label>rot4dXW <span class="value" id="v-rot4dXW">0.00</span></label>
+                <input type="range" id="rot4dXW" min="-2" max="2" value="0" step="0.1" oninput="update('rot4dXW', this.value)">
+            </div>
+
+            <div class="param">
+                <label>rot4dYW <span class="value" id="v-rot4dYW">0.00</span></label>
+                <input type="range" id="rot4dYW" min="-2" max="2" value="0" step="0.1" oninput="update('rot4dYW', this.value)">
+            </div>
+
+            <div class="param">
+                <label>rot4dZW <span class="value" id="v-rot4dZW">0.00</span></label>
+                <input type="range" id="rot4dZW" min="-2" max="2" value="0" step="0.1" oninput="update('rot4dZW', this.value)">
+            </div>
+
+            <div class="param">
+                <label>gridDensity <span class="value" id="v-gridDensity">15</span></label>
+                <input type="range" id="gridDensity" min="4" max="100" value="15" step="1" oninput="update('gridDensity', this.value)">
+            </div>
+
+            <div class="param">
+                <label>morphFactor <span class="value" id="v-morphFactor">1.00</span></label>
+                <input type="range" id="morphFactor" min="0" max="2" value="1" step="0.1" oninput="update('morphFactor', this.value)">
+            </div>
+
+            <div class="param">
+                <label>chaos <span class="value" id="v-chaos">0.20</span></label>
+                <input type="range" id="chaos" min="0" max="1" value="0.2" step="0.1" oninput="update('chaos', this.value)">
+            </div>
+
+            <div class="param">
+                <label>speed <span class="value" id="v-speed">1.00</span></label>
+                <input type="range" id="speed" min="0.1" max="3" value="1" step="0.1" oninput="update('speed', this.value)">
+            </div>
+
+            <div class="param">
+                <label>hue <span class="value" id="v-hue">200°</span></label>
+                <input type="range" id="hue" min="0" max="360" value="200" step="10" oninput="update('hue', this.value)">
+            </div>
+
+            <div class="param">
+                <label>intensity <span class="value" id="v-intensity">0.50</span></label>
+                <input type="range" id="intensity" min="0" max="1" value="0.5" step="0.1" oninput="update('intensity', this.value)">
+            </div>
+
+            <div class="param">
+                <label>saturation <span class="value" id="v-saturation">0.80</span></label>
+                <input type="range" id="saturation" min="0" max="1" value="0.8" step="0.1" oninput="update('saturation', this.value)">
+            </div>
+
+            <button onclick="testRotations()">🔄 TEST ALL ROTATIONS</button>
+            <button onclick="testDensity()">📊 TEST DENSITY RANGE</button>
+            <button onclick="testGeometries()">🔷 TEST ALL GEOMETRIES</button>
+
+            <div id="log">
+                <div class="log-entry">Ready to test parameters...</div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { VIB34DIntegratedEngine } from './src/core/Engine.js';
+        import { QuantumEngine } from './src/quantum/QuantumEngine.js';
+        import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { CanvasManager } from './src/core/CanvasManager.js';
+
+        let mgr = new CanvasManager();
+        let eng = null;
+        let currentSystem = 'faceted';
+
+        const cls = { VIB34DIntegratedEngine, QuantumEngine, RealHolographicSystem };
+
+        (async function() {
+            eng = await mgr.switchToSystem('faceted', cls);
+            log('✅ Faceted system initialized');
+        })();
+
+        function log(msg) {
+            const logDiv = document.getElementById('log');
+            const entry = document.createElement('div');
+            entry.className = 'log-entry';
+            entry.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+            logDiv.insertBefore(entry, logDiv.firstChild);
+            if (logDiv.children.length > 20) logDiv.lastChild.remove();
+        }
+
+        window.switchTo = async function(system) {
+            log(`Switching to ${system}...`);
+            eng = await mgr.switchToSystem(system, cls);
+            currentSystem = system;
+            log(`✅ ${system} active`);
+        };
+
+        window.update = function(param, value) {
+            const val = parseFloat(value);
+            const display = param === 'hue' ? val + '°' :
+                          (param === 'geometry' || param === 'gridDensity' ? Math.round(val) : val.toFixed(2));
+            document.getElementById('v-' + param).textContent = display;
+
+            if (!eng) return;
+
+            try {
+                if (eng.parameterManager) {
+                    eng.parameterManager.setParameter(param, val);
+                } else if (eng.updateParameter) {
+                    eng.updateParameter(param, val);
+                } else if (eng.updateParameters) {
+                    eng.updateParameters({ [param]: val });
+                } else if (eng.parameters) {
+                    eng.parameters.setParameter(param, val);
+                }
+                log(`Set ${param} = ${display}`);
+            } catch (err) {
+                log(`❌ Error setting ${param}: ${err.message}`);
+            }
+        };
+
+        window.testRotations = async function() {
+            log('🔄 Testing all rotation parameters...');
+
+            const tests = [
+                { name: 'XW only', xw: 1.5, yw: 0, zw: 0 },
+                { name: 'YW only', xw: 0, yw: 1.5, zw: 0 },
+                { name: 'ZW only', xw: 0, yw: 0, zw: 1.5 },
+                { name: 'All planes', xw: 1.2, yw: 0.9, zw: 0.7 },
+                { name: 'Counter-rotation', xw: -1.0, yw: 0.5, zw: -0.3 }
+            ];
+
+            for (const test of tests) {
+                log(`Testing: ${test.name}`);
+                document.getElementById('rot4dXW').value = test.xw;
+                document.getElementById('rot4dYW').value = test.yw;
+                document.getElementById('rot4dZW').value = test.zw;
+                window.update('rot4dXW', test.xw);
+                window.update('rot4dYW', test.yw);
+                window.update('rot4dZW', test.zw);
+                await new Promise(r => setTimeout(r, 2000));
+            }
+
+            log('✅ Rotation test complete');
+        };
+
+        window.testDensity = async function() {
+            log('📊 Testing density range...');
+
+            for (let d = 10; d <= 100; d += 20) {
+                log(`Density: ${d}`);
+                document.getElementById('gridDensity').value = d;
+                window.update('gridDensity', d);
+                await new Promise(r => setTimeout(r, 1500));
+            }
+
+            log('✅ Density test complete');
+        };
+
+        window.testGeometries = async function() {
+            log('🔷 Testing all geometries...');
+
+            const names = ['Tetrahedron', 'Hypercube', 'Sphere', 'Torus', 'Klein', 'Fractal', 'Wave', 'Crystal'];
+
+            for (let g = 0; g < 8; g++) {
+                log(`Geometry ${g}: ${names[g]}`);
+                document.getElementById('geometry').value = g;
+                window.update('geometry', g);
+                await new Promise(r => setTimeout(r, 2000));
+            }
+
+            log('✅ Geometry test complete');
+        };
+    </script>
+</body>
+</html>

--- a/ultimate-choreographer.html
+++ b/ultimate-choreographer.html
@@ -361,15 +361,7 @@
         <div class="section">
             <h3>🔮 GEOMETRY</h3>
             <div class="param-group">
-                <select id="geometry" onchange="choreographer.setParam('geometry', parseInt(this.value))">
-                    <option value="0">Tetrahedron</option>
-                    <option value="1" selected>Hypercube</option>
-                    <option value="2">Sphere</option>
-                    <option value="3">Torus</option>
-                    <option value="4">Klein Bottle</option>
-                    <option value="5">Fractal</option>
-                    <option value="6">Wave</option>
-                    <option value="7">Crystal</option>
+                <select id="geometry" onchange="choreographer.setParam('geometry', Number(this.value))">
                 </select>
             </div>
             <div class="param-group">
@@ -461,6 +453,18 @@
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
+
+        const DEFAULT_GEOMETRY_NAMES = [
+            'Tetrahedron',
+            'Hypercube',
+            'Sphere',
+            'Torus',
+            'Klein Bottle',
+            'Fractal',
+            'Wave',
+            'Crystal'
+        ];
 
         window.togglePanel = function() {
             document.getElementById('panel').classList.toggle('open');
@@ -482,15 +486,15 @@
                 this.currentSystem = 'faceted';
                 this.isPlaying = false;
 
-                // Geometry names
-                this.geometryNames = [
-                    'Tetrahedron', 'Hypercube', 'Sphere', 'Torus',
-                    'Klein Bottle', 'Fractal', 'Wave', 'Crystal'
-                ];
+                this.geometrySubscriptionCleanup = null;
+                this.geometryNames = this.buildGeometryList(GeometryLibrary.getGeometryNames());
+                if (!this.geometryNames.length) {
+                    this.geometryNames = [...DEFAULT_GEOMETRY_NAMES];
+                }
 
                 // Base parameters (user-set, NOT affected by audio)
                 this.baseParams = {
-                    geometry: 1,
+                    geometry: this.resolveGeometryIndex(1),
                     gridDensity: 15,
                     morphFactor: 1.0,
                     chaos: 0.2,
@@ -502,6 +506,9 @@
                     rot4dYW: 0.0,
                     rot4dZW: 0.0
                 };
+
+                this.subscribeToGeometryLibrary();
+                this.refreshGeometryUI();
 
                 // Audio reactivity settings
                 this.audioReactivityEnabled = true;
@@ -519,6 +526,184 @@
                 this.kickHistory = [];
 
                 this.init();
+            }
+
+            buildGeometryList(source = []) {
+                const list = Array.isArray(source) ? source : [];
+                const deduped = [];
+                const seen = new Set();
+
+                list.forEach(name => {
+                    const normalized = GeometryLibrary.normalizeName(name);
+                    if (!normalized) return;
+                    const key = normalized.toUpperCase();
+                    if (seen.has(key)) return;
+                    seen.add(key);
+                    deduped.push(this.formatGeometryName(normalized));
+                });
+
+                return deduped;
+            }
+
+            formatGeometryName(name) {
+                const normalized = GeometryLibrary.normalizeName(name);
+                if (!normalized) return 'Unknown';
+
+                if (normalized === normalized.toUpperCase()) {
+                    return normalized
+                        .toLowerCase()
+                        .split(' ')
+                        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+                        .join(' ');
+                }
+
+                return normalized;
+            }
+
+            escapeGeometryLabel(name) {
+                return String(name)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            geometryListsEqual(a = [], b = []) {
+                if (a.length !== b.length) {
+                    return false;
+                }
+
+                for (let i = 0; i < a.length; i += 1) {
+                    if (a[i] !== b[i]) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            getFallbackGeometryNames() {
+                return [...DEFAULT_GEOMETRY_NAMES];
+            }
+
+            resolveGeometryIndex(value) {
+                const names = this.geometryNames.length ? this.geometryNames : this.getFallbackGeometryNames();
+                if (!names.length) {
+                    return 0;
+                }
+
+                if (typeof value === 'string') {
+                    const normalized = GeometryLibrary.normalizeName(value);
+                    if (normalized) {
+                        const searchKey = normalized.toUpperCase();
+                        const foundIndex = names.findIndex(name => GeometryLibrary.normalizeName(name).toUpperCase() === searchKey);
+                        if (foundIndex !== -1) {
+                            return foundIndex;
+                        }
+                    }
+
+                    const parsed = Number(value);
+                    if (Number.isFinite(parsed)) {
+                        return this.resolveGeometryIndex(parsed);
+                    }
+
+                    return 0;
+                }
+
+                let numeric = Number(value);
+                if (!Number.isFinite(numeric)) {
+                    numeric = 0;
+                }
+
+                numeric = Math.round(numeric);
+                if (numeric < 0) {
+                    numeric = 0;
+                }
+                if (numeric >= names.length) {
+                    numeric = names.length - 1;
+                }
+
+                return numeric;
+            }
+
+            getGeometryCount() {
+                return this.geometryNames.length ? this.geometryNames.length : this.getFallbackGeometryNames().length;
+            }
+
+            refreshGeometryUI() {
+                const select = document.getElementById('geometry');
+                const label = document.getElementById('geometry-name');
+                const activeIndex = this.resolveGeometryIndex(this.baseParams.geometry);
+                const names = this.geometryNames.length ? this.geometryNames : this.getFallbackGeometryNames();
+
+                if (!this.geometryNames.length && names.length) {
+                    this.geometryNames = [...names];
+                }
+
+                if (select) {
+                    const optionsNeedUpdate = select.options.length !== names.length ||
+                        Array.from(select.options).some((option, index) => option.textContent !== names[index]);
+
+                    if (optionsNeedUpdate) {
+                        select.innerHTML = names
+                            .map((name, index) => `<option value="${index}">${this.escapeGeometryLabel(name)}</option>`)
+                            .join('');
+                    }
+
+                    select.value = String(activeIndex);
+                }
+
+                if (label) {
+                    label.textContent = names[activeIndex] || 'Unknown';
+                }
+            }
+
+            syncGeometrySelector(index) {
+                const select = document.getElementById('geometry');
+                if (select && select.value !== String(index)) {
+                    select.value = String(index);
+                }
+            }
+
+            subscribeToGeometryLibrary() {
+                if (typeof GeometryLibrary?.subscribe !== 'function') {
+                    return;
+                }
+
+                const handleUpdate = ({ names }) => {
+                    const nextNames = this.buildGeometryList(Array.isArray(names) ? names : []);
+                    const finalNames = nextNames.length ? nextNames : this.getFallbackGeometryNames();
+
+                    if (!this.geometryListsEqual(this.geometryNames, finalNames)) {
+                        this.geometryNames = finalNames;
+                        const clamped = this.resolveGeometryIndex(this.baseParams.geometry);
+                        if (clamped !== this.baseParams.geometry) {
+                            this.baseParams.geometry = clamped;
+                        }
+                        this.refreshGeometryUI();
+                        this.applyBaseParameters();
+                    } else {
+                        this.refreshGeometryUI();
+                    }
+                };
+
+                try {
+                    this.geometrySubscriptionCleanup = GeometryLibrary.subscribe(handleUpdate);
+                } catch (error) {
+                    console.warn('Failed to subscribe to GeometryLibrary', error);
+                }
+            }
+
+            destroy() {
+                if (typeof this.geometrySubscriptionCleanup === 'function') {
+                    try {
+                        this.geometrySubscriptionCleanup();
+                    } catch (error) {
+                        console.warn('Failed to dispose geometry subscription', error);
+                    }
+                    this.geometrySubscriptionCleanup = null;
+                }
             }
 
             async init() {
@@ -675,21 +860,28 @@
             }
 
             setParam(param, value) {
+                let nextValue = value;
+
+                if (param === 'geometry') {
+                    nextValue = this.resolveGeometryIndex(value);
+                }
+
                 // Store in BASE parameters (user-set values)
-                this.baseParams[param] = value;
+                this.baseParams[param] = nextValue;
 
                 // Apply to all engines
                 this.applyBaseParameters();
 
-                // Update UI
-                const valSpan = document.getElementById(`${param}-val`);
-                if (valSpan) {
-                    valSpan.textContent = typeof value === 'number' ? value.toFixed(2) : value;
+                if (param === 'geometry') {
+                    this.syncGeometrySelector(nextValue);
+                    this.refreshGeometryUI();
+                    return;
                 }
 
-                // Update geometry name
-                if (param === 'geometry') {
-                    document.getElementById('geometry-name').textContent = this.geometryNames[value];
+                // Update UI readouts for non-geometry params
+                const valSpan = document.getElementById(`${param}-val`);
+                if (valSpan) {
+                    valSpan.textContent = typeof nextValue === 'number' ? nextValue.toFixed(2) : nextValue;
                 }
             }
 
@@ -850,9 +1042,12 @@
             onKick(audioData) {
                 // Heavy kicks can trigger geometry change
                 if (audioData.bass > 0.85 && Math.random() < 0.3) {
-                    const nextGeom = (this.baseParams.geometry + 1) % 8;
-                    this.setParam('geometry', nextGeom);
-                    document.getElementById('geometry').value = nextGeom;
+                    const count = this.getGeometryCount();
+                    if (count > 0) {
+                        const current = this.resolveGeometryIndex(this.baseParams.geometry);
+                        const nextGeom = (current + 1) % count;
+                        this.setParam('geometry', nextGeom);
+                    }
                 }
             }
 
@@ -1002,7 +1197,10 @@
             }
 
             randomize() {
-                this.setParam('geometry', Math.floor(Math.random() * 8));
+                const geometryCount = this.getGeometryCount();
+                if (geometryCount > 0) {
+                    this.setParam('geometry', Math.floor(Math.random() * geometryCount));
+                }
                 this.setParam('gridDensity', Math.floor(5 + Math.random() * 95));
                 this.setParam('morphFactor', Math.random() * 3);
                 this.setParam('chaos', Math.random());
@@ -1016,7 +1214,7 @@
             }
 
             reset() {
-                this.setParam('geometry', 1);
+                this.setParam('geometry', this.geometryNames.length > 1 ? 1 : 0);
                 this.setParam('gridDensity', 15);
                 this.setParam('morphFactor', 1.0);
                 this.setParam('chaos', 0.2);
@@ -1039,12 +1237,18 @@
                     if (slider) slider.value = value;
                     if (valSpan) valSpan.textContent = typeof value === 'number' ? value.toFixed(2) : value;
                 });
+
+                this.refreshGeometryUI();
             }
         }
 
         // Initialize
         const choreographer = new UltimateChoreographer();
         window.choreographer = choreographer;
+
+        window.addEventListener('beforeunload', () => {
+            choreographer.destroy();
+        }, { once: true });
     </script>
 
     <!-- Signature -->


### PR DESCRIPTION
## Summary
- rebuild the variation manager to subscribe to GeometryLibrary updates, derive default presets dynamically, and refresh the preset grid with runtime geometries
- teach the parameter manager to consume variation metadata so sliders, labels, and generated defaults stay in sync with live geometry counts
- update the gallery and engine cleanup to respect the new variation totals and geometry display names

## Testing
- `npm test` *(fails: playwright: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9684b29c83299ff05503cdae64a6