### PR TITLE
Add advanced audio analysis toolkit

### DIFF
--- a/src/audio/ADSREnvelope.js
+++ b/src/audio/ADSREnvelope.js
@@ -1,0 +1,141 @@
+/**
+ * ADSREnvelope implements a simple Attack/Decay/Sustain/Release envelope that can be used
+ * to smooth sudden changes in audio driven parameters. The implementation is designed to
+ * work with millisecond timing to match the Web Audio API's high resolution clock but
+ * gracefully falls back to Date timing if `performance.now` is unavailable.
+ */
+export class ADSREnvelope {
+    constructor({ attack = 50, decay = 200, sustain = 0.7, release = 300 } = {}) {
+        this.attack = Math.max(0, attack);
+        this.decay = Math.max(0, decay);
+        this.sustain = Math.min(1, Math.max(0, sustain));
+        this.release = Math.max(0, release);
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = 0;
+        this.releaseStartValue = 0;
+    }
+
+    /**
+     * Trigger the envelope with a new target value.
+     */
+    trigger(targetValue, now = ADSREnvelope.now()) {
+        const clampedTarget = Math.max(0, targetValue);
+        this.targetValue = clampedTarget;
+        this.phase = this.attack === 0 ? 'decay' : 'attack';
+        this.phaseStartTime = now;
+        this.value = this.attack === 0 ? clampedTarget : 0;
+        this.releaseStartValue = this.value;
+        if (this.attack === 0 && this.decay === 0) {
+            this.phase = 'sustain';
+            this.value = clampedTarget * this.sustain;
+        }
+    }
+
+    /**
+     * Begin the release phase manually. Useful when the trigger condition is no longer met.
+     */
+    releaseEnvelope(now = ADSREnvelope.now()) {
+        if (this.phase === 'idle' || this.phase === 'release') {
+            return;
+        }
+        this.phase = this.release === 0 ? 'idle' : 'release';
+        this.phaseStartTime = now;
+        this.releaseStartValue = this.value;
+        if (this.release === 0) {
+            this.value = 0;
+        }
+    }
+
+    /**
+     * Update the envelope state and return the current value.
+     */
+    update(now = ADSREnvelope.now()) {
+        switch (this.phase) {
+            case 'attack':
+                if (this.attack === 0) {
+                    this.phase = 'decay';
+                    this.phaseStartTime = now;
+                    this.value = this.targetValue;
+                    break;
+                }
+                this.value = this.interpolate(0, this.targetValue, (now - this.phaseStartTime) / this.attack);
+                if (now - this.phaseStartTime >= this.attack) {
+                    this.phase = 'decay';
+                    this.phaseStartTime = now;
+                    this.value = this.targetValue;
+                }
+                break;
+
+            case 'decay':
+                if (this.decay === 0) {
+                    this.phase = 'sustain';
+                    this.value = this.targetValue * this.sustain;
+                    break;
+                }
+                this.value = this.interpolate(
+                    this.targetValue,
+                    this.targetValue * this.sustain,
+                    (now - this.phaseStartTime) / this.decay
+                );
+                if (now - this.phaseStartTime >= this.decay) {
+                    this.phase = 'sustain';
+                    this.value = this.targetValue * this.sustain;
+                }
+                break;
+
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+
+            case 'release':
+                if (this.release === 0) {
+                    this.phase = 'idle';
+                    this.value = 0;
+                    break;
+                }
+                this.value = this.interpolate(
+                    this.releaseStartValue,
+                    0,
+                    (now - this.phaseStartTime) / this.release
+                );
+                if (now - this.phaseStartTime >= this.release) {
+                    this.phase = 'idle';
+                    this.value = 0;
+                }
+                break;
+
+            case 'idle':
+            default:
+                this.value = 0;
+                break;
+        }
+
+        return this.value;
+    }
+
+    /**
+     * Reset the envelope back to the idle state immediately.
+     */
+    reset() {
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = 0;
+        this.releaseStartValue = 0;
+    }
+
+    interpolate(start, end, progress) {
+        const clamped = Math.min(1, Math.max(0, progress));
+        return start + (end - start) * clamped;
+    }
+
+    static now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}

--- a/src/audio/AudioAnalyzer.js
+++ b/src/audio/AudioAnalyzer.js
@@ -1,0 +1,216 @@
+/**
+ * AudioAnalyzer delivers a musically aware analysis layer on top of a Web Audio API
+ * AnalyserNode. It exposes seven frequency bands, spectral descriptors, RMS loudness,
+ * onset detection, and BPM estimation that can be consumed by any visualization system.
+ */
+export class AudioAnalyzer {
+    constructor(analyserNode, options = {}) {
+        if (!analyserNode) {
+            throw new Error('AudioAnalyzer requires a valid AnalyserNode instance');
+        }
+
+        this.analyser = analyserNode;
+        this.fftSize = options.fftSize || 2048;
+        this.smoothingTimeConstant = options.smoothingTimeConstant ?? 0.8;
+        this.sampleRate = options.sampleRate || analyserNode.context?.sampleRate || 44100;
+
+        this.analyser.fftSize = this.fftSize;
+        this.analyser.smoothingTimeConstant = this.smoothingTimeConstant;
+
+        this.frequencyBinCount = this.analyser.frequencyBinCount;
+        this.byteFrequencyData = new Uint8Array(this.frequencyBinCount);
+        this.byteTimeDomainData = new Uint8Array(this.analyser.fftSize);
+        this.prevSpectrum = new Float32Array(this.frequencyBinCount);
+
+        this.nyquist = this.sampleRate / 2;
+
+        this.bandDefinitions = [
+            { name: 'subBass', low: 20, high: 60 },
+            { name: 'bass', low: 60, high: 250 },
+            { name: 'lowMid', low: 250, high: 500 },
+            { name: 'mid', low: 500, high: 2000 },
+            { name: 'highMid', low: 2000, high: 4000 },
+            { name: 'high', low: 4000, high: 8000 },
+            { name: 'air', low: 8000, high: 20000 }
+        ];
+
+        this.bandState = {};
+        this.bandDefinitions.forEach(({ name }) => {
+            this.bandState[name] = 0;
+        });
+
+        this.smoothingFactor = options.bandSmoothing ?? 0.8;
+        this.smoothedBands = { ...this.bandState };
+
+        this.spectralCentroid = 0;
+        this.spectralRolloff = 0;
+        this.spectralFlux = 0;
+        this.rms = 0;
+
+        this.onsetThreshold = options.onsetThreshold ?? 0.18;
+        this.minOnsetInterval = options.minOnsetInterval ?? 120; // ms
+        this.lastOnsetTime = 0;
+        this.onsetHistory = [];
+        this.maxOnsetHistory = options.maxOnsetHistory ?? 32;
+        this.estimatedBPM = options.initialBPM || 120;
+
+    }
+
+    analyze() {
+        this.captureFrequencyData();
+        this.captureTimeDomainData();
+        this.analyzeBands();
+        this.calculateSpectralCentroid();
+        this.calculateSpectralRolloff();
+        this.calculateSpectralFlux();
+        this.calculateRMS();
+        const onset = this.detectOnset();
+        if (this.onsetHistory.length > 1) {
+            this.estimateBPM();
+        }
+
+        return {
+            bands: { ...this.smoothedBands },
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset,
+            bpm: this.estimatedBPM
+        };
+    }
+
+    captureFrequencyData() {
+        this.analyser.getByteFrequencyData(this.byteFrequencyData);
+    }
+
+    captureTimeDomainData() {
+        this.analyser.getByteTimeDomainData(this.byteTimeDomainData);
+    }
+
+    analyzeBands() {
+        this.bandDefinitions.forEach(({ name, low, high }) => {
+            const lowIndex = this.frequencyToIndex(low);
+            const highIndex = this.frequencyToIndex(high);
+            let sum = 0;
+            let count = 0;
+
+            for (let i = lowIndex; i <= highIndex; i += 1) {
+                const magnitude = this.byteFrequencyData[i] / 255;
+                sum += magnitude;
+                count += 1;
+            }
+
+            const average = count > 0 ? sum / count : 0;
+            this.bandState[name] = average;
+            this.smoothedBands[name] = this.smoothedBands[name] * this.smoothingFactor + average * (1 - this.smoothingFactor);
+        });
+    }
+
+    calculateSpectralCentroid() {
+        let numerator = 0;
+        let denominator = 0;
+
+        for (let i = 0; i < this.frequencyBinCount; i += 1) {
+            const amplitude = this.byteFrequencyData[i] / 255;
+            numerator += this.binToFrequency(i) * amplitude;
+            denominator += amplitude;
+        }
+
+        const centroid = denominator > 0 ? numerator / denominator : 0;
+        this.spectralCentroid = centroid / this.nyquist;
+    }
+
+    calculateSpectralRolloff() {
+        const totalEnergy = this.byteFrequencyData.reduce((acc, value) => acc + value, 0);
+        const threshold = totalEnergy * 0.85;
+        let cumulative = 0;
+        let rolloffFrequency = 0;
+
+        for (let i = 0; i < this.frequencyBinCount; i += 1) {
+            cumulative += this.byteFrequencyData[i];
+            if (cumulative >= threshold) {
+                rolloffFrequency = this.binToFrequency(i);
+                break;
+            }
+        }
+
+        this.spectralRolloff = rolloffFrequency / this.nyquist;
+    }
+
+    calculateSpectralFlux() {
+        let flux = 0;
+        for (let i = 0; i < this.frequencyBinCount; i += 1) {
+            const current = this.byteFrequencyData[i] / 255;
+            const previous = this.prevSpectrum[i];
+            const delta = current - previous;
+            if (delta > 0) {
+                flux += delta;
+            }
+            this.prevSpectrum[i] = current;
+        }
+
+        this.spectralFlux = flux / this.frequencyBinCount;
+    }
+
+    calculateRMS() {
+        let sumSquares = 0;
+        for (let i = 0; i < this.byteTimeDomainData.length; i += 1) {
+            const centered = (this.byteTimeDomainData[i] - 128) / 128;
+            sumSquares += centered * centered;
+        }
+        this.rms = Math.sqrt(sumSquares / this.byteTimeDomainData.length);
+    }
+
+    detectOnset() {
+        const now = AudioAnalyzer.now();
+        const isOnset = this.spectralFlux > this.onsetThreshold && (now - this.lastOnsetTime) >= this.minOnsetInterval;
+
+        if (isOnset) {
+            this.lastOnsetTime = now;
+            this.onsetHistory.push(now);
+            if (this.onsetHistory.length > this.maxOnsetHistory) {
+                this.onsetHistory.shift();
+            }
+        }
+
+        return isOnset;
+    }
+
+    estimateBPM() {
+        if (this.onsetHistory.length < 2) {
+            return;
+        }
+
+        const intervals = [];
+        for (let i = 1; i < this.onsetHistory.length; i += 1) {
+            intervals.push((this.onsetHistory[i] - this.onsetHistory[i - 1]) / 1000);
+        }
+
+        if (intervals.length === 0) {
+            return;
+        }
+
+        const averageInterval = intervals.reduce((acc, val) => acc + val, 0) / intervals.length;
+        if (averageInterval > 0) {
+            this.estimatedBPM = Math.round(60 / averageInterval);
+        }
+    }
+
+    frequencyToIndex(frequency) {
+        const clamped = Math.min(this.nyquist, Math.max(0, frequency));
+        const index = Math.round((clamped / this.nyquist) * (this.frequencyBinCount - 1));
+        return Math.min(this.frequencyBinCount - 1, Math.max(0, index));
+    }
+
+    binToFrequency(index) {
+        return (index / (this.frequencyBinCount - 1)) * this.nyquist;
+    }
+
+    static now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}

--- a/src/audio/ParameterMapper.js
+++ b/src/audio/ParameterMapper.js
@@ -1,0 +1,213 @@
+import { ADSREnvelope } from './ADSREnvelope.js';
+
+/**
+ * AudioParameterMapper translates analysed audio features into visualization parameters.
+ * Each mapping can define a source feature, transformation curve, scaling range, envelope,
+ * and smoothing behaviour.
+ */
+export class AudioParameterMapper {
+    constructor(mappings) {
+        this.mappings = mappings || this.createDefaultMappings();
+        this.envelopes = {};
+        this.previousValues = {};
+        this.previousRaw = {};
+    }
+
+    createDefaultMappings() {
+        return {
+            rot4dXW: {
+                source: 'bands.bass',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: {
+                    attack: 120,
+                    decay: 320,
+                    sustain: 0.55,
+                    release: 500,
+                    trigger: 'threshold',
+                    triggerThreshold: 0.18
+                }
+            },
+            rot4dYW: {
+                source: 'bands.mid',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: {
+                    attack: 80,
+                    decay: 260,
+                    sustain: 0.65,
+                    release: 420,
+                    trigger: 'threshold',
+                    triggerThreshold: 0.16
+                }
+            },
+            rot4dZW: {
+                source: 'bands.high',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: {
+                    attack: 50,
+                    decay: 200,
+                    sustain: 0.72,
+                    release: 320,
+                    trigger: 'threshold',
+                    triggerThreshold: 0.12
+                }
+            },
+            gridDensity: {
+                source: 'spectralFlux',
+                curve: 'threshold',
+                range: [10, 100],
+                threshold: 0.15,
+                envelope: {
+                    attack: 60,
+                    decay: 600,
+                    sustain: 0.4,
+                    release: 900,
+                    trigger: 'onset'
+                }
+            },
+            hue: {
+                source: 'spectralCentroid',
+                curve: 'linear',
+                range: [0, 360],
+                smoothing: 0.6
+            },
+            intensity: {
+                source: 'rms',
+                curve: 'logarithmic',
+                range: [0.3, 1.0],
+                envelope: {
+                    attack: 40,
+                    decay: 120,
+                    sustain: 0.8,
+                    release: 200,
+                    trigger: 'rising',
+                    triggerThreshold: 0.02
+                }
+            }
+        };
+    }
+
+    apply(audioFeatures, initialParams = {}) {
+        const now = AudioParameterMapper.now();
+        const result = { ...initialParams };
+
+        Object.entries(this.mappings).forEach(([parameter, mapping]) => {
+            const rawValue = this.extractSource(audioFeatures, mapping.source);
+            if (rawValue === undefined || Number.isNaN(rawValue)) {
+                return;
+            }
+
+            const curved = this.applyCurve(rawValue, mapping, parameter);
+            const ranged = this.applyRange(curved, mapping.range);
+            const enveloped = this.applyEnvelope(parameter, ranged, mapping.envelope, audioFeatures, now, rawValue);
+            const smoothed = this.applySmoothing(parameter, enveloped, mapping.smoothing);
+
+            result[parameter] = smoothed;
+            this.previousRaw[parameter] = rawValue;
+        });
+
+        return result;
+    }
+
+    extractSource(audioFeatures, source) {
+        if (!source) {
+            return undefined;
+        }
+
+        if (source.startsWith('bands.')) {
+            const band = source.split('.')[1];
+            return audioFeatures.bands?.[band];
+        }
+
+        return audioFeatures[source];
+    }
+
+    applyCurve(value, mapping, parameter) {
+        const curve = mapping.curve || 'linear';
+        switch (curve) {
+            case 'exponential':
+                return Math.pow(Math.max(0, value), mapping.power || 2);
+            case 'logarithmic':
+                return Math.log10(1 + Math.max(0, value) * 9) / Math.log10(10);
+            case 's-curve':
+                return 1 / (1 + Math.exp(-12 * (value - 0.5)));
+            case 'threshold': {
+                const threshold = mapping.threshold ?? mapping.triggerThreshold ?? 0.2;
+                return value > threshold ? 1 : 0;
+            }
+            default:
+                return value;
+        }
+    }
+
+    applyRange(value, range) {
+        if (!range) {
+            return value;
+        }
+
+        const [min, max] = range;
+        const clamped = Math.min(1, Math.max(0, value));
+        return min + (max - min) * clamped;
+    }
+
+    applyEnvelope(parameter, value, envelopeConfig, audioFeatures, now, rawValue) {
+        if (!envelopeConfig) {
+            return value;
+        }
+
+        const envelope = this.getEnvelope(parameter, envelopeConfig);
+        const triggerType = envelopeConfig.trigger || 'threshold';
+        const threshold = envelopeConfig.triggerThreshold ?? 0.1;
+        let shouldTrigger = false;
+
+        if (triggerType === 'onset') {
+            shouldTrigger = Boolean(audioFeatures.onset);
+        } else if (triggerType === 'rising') {
+            const previous = this.previousRaw[parameter] ?? 0;
+            shouldTrigger = rawValue > previous + threshold;
+        } else {
+            shouldTrigger = rawValue > threshold;
+        }
+
+        if (shouldTrigger) {
+            envelope.trigger(value, now);
+        } else if (envelopeConfig.autoRelease !== false && envelope.phase !== 'idle') {
+            envelope.releaseEnvelope(now);
+        }
+
+        return envelope.update(now);
+    }
+
+    applySmoothing(parameter, value, smoothing) {
+        if (typeof smoothing !== 'number') {
+            this.previousValues[parameter] = value;
+            return value;
+        }
+
+        const previous = this.previousValues[parameter] ?? value;
+        const result = previous * smoothing + value * (1 - smoothing);
+        this.previousValues[parameter] = result;
+        return result;
+    }
+
+    getEnvelope(parameter, config) {
+        if (!this.envelopes[parameter]) {
+            this.envelopes[parameter] = new ADSREnvelope({
+                attack: config.attack,
+                decay: config.decay,
+                sustain: config.sustain,
+                release: config.release
+            });
+        }
+        return this.envelopes[parameter];
+    }
+
+    static now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}


### PR DESCRIPTION
## Summary
- add an AudioAnalyzer utility that surfaces seven frequency bands, spectral descriptors, onsets, and BPM estimates
- introduce an ADSR envelope helper to smooth audio-driven parameter changes
- map analyzed audio data to visualization parameters with a configurable audio parameter mapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e8cb2e8c8329811e9f0b4c6836c9