### PR TITLE
Add audio-reactive color pipeline foundation

### DIFF
--- a/UNIFIED-REFACTOR-PLAN.md
+++ b/UNIFIED-REFACTOR-PLAN.md
@@ -1,0 +1,726 @@
+# 🎯 VIB34D MUSIC CHOREOGRAPHER - UNIFIED REFACTORING PLAN
+
+**Date**: October 5, 2025
+**Objective**: Refactor multiple systems together, make elegant, expand colors and audio reactivity
+
+---
+
+## 📊 REPOSITORY ANALYSIS COMPLETE
+
+### **Branch Structure:**
+```
+* html-versions-catalog (current)
+  - Contains comprehensive HTML versions catalog at versions-index.html
+  - Latest commit: "🌟 Add comprehensive HTML versions catalog"
+
+* main / origin/main
+  - Primary development branch
+  - Latest: "🎥 PROPER FIX: Composite canvas for export with smart system switching"
+
+* v3-professional
+  - Advanced audio-visual system experimentation
+  - NOT YET MERGED
+
+* music-video-choreographer-refactor (remote)
+  - Previous refactoring attempt
+  - Useful learnings in branch history
+```
+
+### **Key Files Count:**
+- **14 index-*.html variants** (514-3526 lines each)
+- **57 JavaScript modules** in src/
+- **3 visualization engines**: Faceted, Quantum, Holographic
+- **1 specialized system**: Polychora (4D mathematics)
+
+---
+
+## 🔍 CURRENT SYSTEM INVENTORY
+
+### **INDEX.HTML VARIANTS ANALYSIS:**
+
+| File | Lines | Purpose | Status |
+|------|-------|---------|--------|
+| **index-MASTER.html** | 678 | Beat-synced choreography + manual sequences + video export | ✅ WORKING |
+| **index-ULTIMATE-V2.html** | 645 | Musical timing with 4D rotation focus | ✅ WORKING |
+| **index-ULTIMATE.html** | 514 | Original AI choreography system | ✅ WORKING |
+| **index-WORKING-GOLD.html** | 3526 | Full features + reactivity (original backup) | ✅ ARCHIVE |
+| **index-enhanced.html** | 2225 | Enhanced UI + features | ⚠️ LEGACY |
+| **index-working-simple.html** | 1070 | Hybrid mode + timeline | ✅ USEFUL |
+| **index-FINAL.html** | 812 | Simplified choreographer | ✅ CLEAN |
+| **index-ULTRA.html** | 813 | Ultra version (experimental) | ⚠️ EXPERIMENTAL |
+
+**BEST VERSIONS IDENTIFIED:**
+1. **index-MASTER.html** - Most complete, working export, beat sync
+2. **index-ULTIMATE-V2.html** - Best 4D rotation usage, musical timing
+3. **index-working-simple.html** - Clean hybrid mode implementation
+
+---
+
+## 🎨 SOURCE ARCHITECTURE ANALYSIS
+
+### **Current Module Structure:**
+```
+src/
+├── core/ (14 files)
+│   ├── Engine.js                    // Faceted system
+│   ├── Visualizer.js                // Faceted visualizer (GLSL shaders)
+│   ├── ParameterMapper.js           // V3 advanced mapping (INCOMPLETE)
+│   ├── Parameters.js                // Parameter definitions + validation
+│   ├── CanvasManager.js             // Canvas lifecycle management
+│   ├── ReactivityManager.js         // Mouse/touch/scroll interactions
+│   └── UnifiedEngine.js             // Attempted unification (partial)
+│
+├── quantum/ (2 files)
+│   ├── QuantumEngine.js             // Complex 3D system
+│   └── QuantumVisualizer.js         // Advanced GLSL with volumetric lighting
+│
+├── holograms/ (6 files)
+│   ├── RealHolographicSystem.js     // Audio-reactive system
+│   ├── HolographicVisualizer.js     // Core holographic rendering
+│   ├── ActiveHolographicSystem.js   // Enhanced version
+│   └── HolographicSystem.js         // Legacy version
+│
+├── core/PolychoraSystem.js          // 4D polytope mathematics
+│
+├── export/ (15 files)
+│   └── Trading card + video export systems (per-engine variants)
+│
+├── audio/
+│   ├── AudioAnalyzer.js           // ✅ Implemented: 7-band + spectral analysis
+│   ├── ADSREnvelope.js            // ✅ Implemented: ADSR smoothing utilities
+│   └── ParameterMapper.js         // ✅ Implemented: audio-to-parameter routing
+│
+├── color/
+│   └── ColorSystem.js             // ✅ Implemented: palettes, gradients, reactive blending
+│
+└── geometry/
+    └── GeometryLibrary.js           // 8 geometry types shared
+```
+
+Supporting modules:
+- `js/audio/audio-engine.js` // ✅ AdvancedAudioEngine wiring analyzer → global state + color pipeline bridge
+- `window.colorState` // ✅ Shared color palette + gradient state exposed for visualizers/UI
+
+### **🚨 CRITICAL ARCHITECTURE PROBLEMS:**
+1. **INCONSISTENT INTERFACES**: Each system has different initialization patterns
+2. **NO UNIFIED PARAMETER SYSTEM**: 3 different parameter management approaches
+3. **DUPLICATE VISUALIZERS**: Multiple versions of Holographic system
+4. **LEGACY V3 GAPS**: Systems still need to adopt the new AudioAnalyzer + ParameterMapper pipeline
+5. **COLOR SYSTEM INTEGRATION**: New ColorSystem drives palettes + gradients, but shaders/UI still need full adoption
+6. **AUDIO INTEGRATION DRIFT**: Advanced analyzer now powers the global engine, but each visualization still needs bespoke mappings
+
+---
+
+## 🎯 UNIFIED REFACTORING GOALS
+
+### **1. ELEGANT SYSTEM ARCHITECTURE**
+
+Create **BaseSystem** interface that all engines implement:
+```javascript
+class BaseSystem {
+    constructor(config) {
+        this.name = config.name;
+        this.type = config.type; // 'faceted'|'quantum'|'holographic'|'polychora'
+        this.canvas = null;
+        this.visualizer = null;
+        this.parameters = new UnifiedParameters();
+        this.interactions = new UnifiedInteractions();
+    }
+
+    async initialize() {
+        // Standard init sequence
+        await this.createCanvas();
+        await this.createVisualizer();
+        await this.setupInteractions();
+        await this.setupAudio();
+    }
+
+    updateParameter(name, value) {
+        // Unified parameter update
+    }
+
+    render() {
+        // Unified render loop
+    }
+
+    destroy() {
+        // Proper cleanup
+    }
+}
+```
+
+**Benefits:**
+- ✅ Switch between systems with identical API
+- ✅ Predictable behavior across all engines
+- ✅ Easy to add new visualization systems
+- ✅ Clean separation of concerns
+
+---
+
+### **2. ADVANCED COLOR SYSTEM**
+
+**Current Limitation**: Single hue parameter (0-360)
+
+**New Color Architecture:**
+```javascript
+class ColorSystem {
+    constructor() {
+        // Multiple color modes
+        this.modes = {
+            single: this.singleHue,
+            dual: this.dualHue,
+            triad: this.triadHue,
+            complementary: this.complementaryHue,
+            analogous: this.analogousHue,
+            palette: this.paletteMode,
+            gradient: this.gradientMode,
+            reactive: this.audioReactiveMode
+        };
+
+        // Color palettes
+        this.palettes = {
+            vaporwave: ['#ff71ce', '#01cdfe', '#05ffa1', '#b967ff'],
+            cyberpunk: ['#ff006e', '#fb5607', '#ffbe0b', '#8338ec'],
+            synthwave: ['#f72585', '#7209b7', '#3a0ca3', '#4361ee'],
+            holographic: ['#ff00ff', '#00ffff', '#ff00aa', '#00aaff'],
+            neon: ['#fe00fe', '#00fefe', '#fefe00', '#00fe00'],
+            fire: ['#ff0000', '#ff4400', '#ff8800', '#ffcc00'],
+            ocean: ['#001eff', '#0088ff', '#00ccff', '#00ffee'],
+            forest: ['#004d00', '#008800', '#00cc00', '#88ff00']
+        };
+
+        // Gradient definitions
+        this.gradients = {
+            horizontal: (time, pos) => this.horizontalGradient(time, pos),
+            vertical: (time, pos) => this.verticalGradient(time, pos),
+            radial: (time, pos) => this.radialGradient(time, pos),
+            spiral: (time, pos) => this.spiralGradient(time, pos),
+            wave: (time, pos) => this.waveGradient(time, pos)
+        };
+    }
+
+    // Audio-reactive color
+    audioReactiveColor(audioData) {
+        const { bass, mid, high, spectralCentroid, spectralFlux } = audioData;
+
+        // Brightness from loudness
+        const brightness = audioData.rms;
+
+        // Hue from spectral centroid (brightness of sound)
+        const hue = spectralCentroid * 360;
+
+        // Saturation from spectral flux (energy change)
+        const saturation = 0.5 + (spectralFlux * 0.5);
+
+        return { h: hue, s: saturation, v: brightness };
+    }
+
+    // Multi-hue systems
+    triadHue(baseHue) {
+        return [
+            baseHue,
+            (baseHue + 120) % 360,
+            (baseHue + 240) % 360
+        ];
+    }
+
+    complementaryHue(baseHue) {
+        return [
+            baseHue,
+            (baseHue + 180) % 360
+        ];
+    }
+}
+```
+
+**New Parameters:**
+- `colorMode`: 'single'|'dual'|'triad'|'complementary'|'palette'|'gradient'|'reactive'
+- `colorPalette`: Selection from predefined palettes
+- `gradientType`: 'horizontal'|'vertical'|'radial'|'spiral'|'wave'
+- `gradientSpeed`: Animation speed of gradient
+- `colorReactivity`: How much audio influences color (0-1)
+- `colorSaturation`: Independent from hue (0-1) - ALREADY EXISTS
+- `colorIntensity`: Independent brightness (0-1) - ALREADY EXISTS
+
+**Implementation in Shaders:**
+```glsl
+uniform int u_colorMode;
+uniform vec3 u_palette[4];
+uniform int u_paletteSize;
+uniform float u_gradientPhase;
+
+vec3 getColor(vec2 uv, float audioData) {
+    if (u_colorMode == MODE_PALETTE) {
+        // Cycle through palette based on position + audio
+        int index = int(mod(uv.x * float(u_paletteSize) + audioData, float(u_paletteSize)));
+        return u_palette[index];
+    } else if (u_colorMode == MODE_GRADIENT) {
+        // Gradient between colors
+        return mix(u_palette[0], u_palette[1], uv.x + u_gradientPhase);
+    }
+    // ... other modes
+}
+```
+
+---
+
+### **3. PROFESSIONAL AUDIO REACTIVITY**
+
+**Current Limitation**: 3 frequency bands (bass, mid, high) with simple addition
+
+**New Audio Architecture** (from V3 plan):
+```javascript
+class AudioAnalyzer {
+    constructor(analyserNode) {
+        this.analyser = analyserNode;
+
+        // 7 frequency bands instead of 3
+        this.bands = {
+            subBass: { low: 20, high: 60, value: 0 },      // Kick drums, sub bass
+            bass: { low: 60, high: 250, value: 0 },        // Bass guitar, low toms
+            lowMid: { low: 250, high: 500, value: 0 },     // Guitars, keyboards
+            mid: { low: 500, high: 2000, value: 0 },       // Vocals, snares
+            highMid: { low: 2000, high: 4000, value: 0 },  // Cymbals, guitars
+            high: { low: 4000, high: 8000, value: 0 },     // Hi-hats, strings
+            air: { low: 8000, high: 20000, value: 0 }      // Airiness, sparkle
+        };
+
+        // Spectral features
+        this.spectralCentroid = 0;  // Brightness of sound (0-1)
+        this.spectralRolloff = 0;   // Frequency where 85% energy below (0-1)
+        this.spectralFlux = 0;      // Rate of spectral change (onset detection)
+        this.rms = 0;               // Overall loudness (0-1)
+
+        // Onset detection
+        this.onsetHistory = [];
+        this.lastOnsetTime = 0;
+        this.onsetThreshold = 0.15;
+
+        // BPM estimation
+        this.estimatedBPM = 120;
+
+        // Smoothing buffers
+        this.smoothingFactor = 0.8;
+        this.smoothedBands = { ...this.bands };
+    }
+
+    analyze() {
+        // Multi-band analysis
+        this.analyzeBands();
+
+        // Spectral features
+        this.calcSpectralCentroid();   // Brightness
+        this.calcSpectralRolloff();    // High frequency content
+        this.calcSpectralFlux();       // Change detection
+        this.calcRMS();                // Loudness
+
+        // Onset detection (kicks, snares, transients)
+        const onset = this.detectOnset();
+
+        // BPM estimation from onsets
+        if (this.onsetHistory.length > 8) {
+            this.estimateBPM();
+        }
+
+        return {
+            bands: this.smoothedBands,
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset: onset,
+            bpm: this.estimatedBPM
+        };
+    }
+}
+```
+
+**Parameter Mapping with ADSR Envelopes:**
+```javascript
+class ParameterMapper {
+    constructor() {
+        this.mappings = {
+            // 4D rotations react to different bands
+            rot4dXW: {
+                source: 'bass',
+                curve: 'exponential',  // Exponential response
+                range: [-2, 2],
+                envelope: new ADSREnvelope(200, 500, 0.6, 1000) // Attack, Decay, Sustain, Release
+            },
+            rot4dYW: {
+                source: 'mid',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(100, 300, 0.7, 800)
+            },
+            rot4dZW: {
+                source: 'high',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(50, 200, 0.8, 600)
+            },
+
+            // Grid density reacts to spectral flux (onsets)
+            gridDensity: {
+                source: 'spectralFlux',
+                curve: 'threshold',  // Only responds to strong onsets
+                range: [10, 100],
+                threshold: 0.15,
+                envelope: new ADSREnvelope(50, 1000, 0.3, 2000)
+            },
+
+            // Hue follows spectral centroid (brightness of sound)
+            hue: {
+                source: 'spectralCentroid',
+                curve: 'linear',
+                range: [0, 360],
+                envelope: null  // Instant response for color
+            },
+
+            // Intensity follows RMS (loudness)
+            intensity: {
+                source: 'rms',
+                curve: 'logarithmic',
+                range: [0.3, 1.0],
+                envelope: new ADSREnvelope(10, 50, 0.8, 200)
+            }
+        };
+    }
+
+    applyCurve(value, curve) {
+        switch(curve) {
+            case 'exponential':
+                return Math.pow(value, 2);
+            case 'logarithmic':
+                return Math.log10(1 + value * 9) / Math.log10(10);
+            case 's-curve':
+                return 1 / (1 + Math.exp(-10 * (value - 0.5)));
+            case 'threshold':
+                return value > this.threshold ? 1 : 0;
+            default:
+                return value; // linear
+        }
+    }
+}
+```
+
+**ADSR Envelope for Smooth Parameter Changes:**
+```javascript
+class ADSREnvelope {
+    constructor(attackMs, decayMs, sustain, releaseMs) {
+        this.attack = attackMs;
+        this.decay = decayMs;
+        this.sustain = sustain;  // 0-1
+        this.release = releaseMs;
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = 0;
+    }
+
+    trigger(value) {
+        this.targetValue = value;
+        this.phase = 'attack';
+        this.phaseStartTime = Date.now();
+    }
+
+    update() {
+        const now = Date.now();
+        const elapsed = now - this.phaseStartTime;
+
+        switch(this.phase) {
+            case 'attack':
+                this.value = (elapsed / this.attack) * this.targetValue;
+                if (elapsed >= this.attack) {
+                    this.phase = 'decay';
+                    this.phaseStartTime = now;
+                }
+                break;
+
+            case 'decay':
+                const decayProgress = elapsed / this.decay;
+                this.value = this.targetValue * (1 - decayProgress * (1 - this.sustain));
+                if (elapsed >= this.decay) {
+                    this.phase = 'sustain';
+                }
+                break;
+
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+
+            case 'release':
+                this.value *= 1 - (elapsed / this.release);
+                if (elapsed >= this.release) {
+                    this.phase = 'idle';
+                    this.value = 0;
+                }
+                break;
+        }
+
+        return this.value;
+    }
+}
+```
+
+---
+
+## 🏗️ REFACTORING IMPLEMENTATION PLAN
+
+### **PHASE 1: FOUNDATION (Week 1)**
+
+**1.1 Create BaseSystem Interface**
+- [ ] Write `src/systems/shared/BaseSystem.js`
+- [ ] Define standard lifecycle: init → render → update → destroy
+- [ ] Standard parameter interface
+- [ ] Standard canvas management
+
+**1.2 Extract Best Features from Each Index Variant**
+- [ ] From `index-MASTER.html`: Beat sync + video export
+- [ ] From `index-ULTIMATE-V2.html`: 4D rotation focus + musical timing
+- [ ] From `index-working-simple.html`: Clean hybrid mode
+- [ ] Document which features to preserve from each
+
+**1.3 Consolidate Parameter System**
+- [ ] Unify `Parameters.js` to work across all systems
+- [ ] Add new color parameters
+- [ ] Add audio reactivity parameters
+- [ ] Validation + ranges for all parameters
+
+---
+
+### **PHASE 2: COLOR SYSTEM (Week 1-2)**
+
+**2.1 Implement ColorSystem Class**
+- [x] Create `src/color/ColorSystem.js`
+- [x] Define 8+ color palettes
+- [x] Implement gradient functions
+- [x] Audio-reactive color mapping (palettes + gradients respond to analyzer state)
+
+**2.2 Update Shaders**
+- [ ] Modify `Visualizer.js` shader for multi-color support
+- [ ] Modify `QuantumVisualizer.js` shader
+- [ ] Modify `HolographicVisualizer.js` shader
+- [ ] Add palette uniforms to GLSL
+
+**2.3 UI for Color Control**
+- [ ] Color mode selector
+- [ ] Palette picker
+- [ ] Gradient controls
+- [ ] Preview system
+
+---
+
+### **PHASE 3: AUDIO SYSTEM (Week 2-3)**
+
+**3.1 Implement AudioAnalyzer**
+- [x] Create `src/audio/AudioAnalyzer.js` (complete V3 implementation)
+- [x] 7-band frequency analysis
+- [x] Spectral features (centroid, rolloff, flux)
+- [x] Onset detection
+- [x] BPM estimation
+
+**3.2 Implement ADSR Envelopes**
+- [x] Create `src/audio/ADSREnvelope.js`
+- [x] Attack/Decay/Sustain/Release phases
+- [x] Per-parameter envelope configuration
+- [x] Smooth parameter transitions
+
+**3.3 Implement ParameterMapper**
+- [x] Create `src/audio/ParameterMapper.js`
+- [x] Curve functions (exponential, logarithmic, s-curve, threshold)
+- [x] Band-to-parameter routing
+- [x] Envelope integration
+
+**3.4 Integration**
+- [x] Connect AudioAnalyzer to the global audio engine used by all systems (`js/audio/audio-engine.js`)
+- [x] Map audio features to parameters intelligently via default ParameterMapper presets
+- [ ] Test with various music genres
+- [ ] Optimize performance
+
+---
+
+### **PHASE 4: SYSTEM REFACTORING (Week 3-4)**
+
+**4.1 Refactor Faceted System**
+- [ ] Migrate `Engine.js` to extend `BaseSystem`
+- [ ] Integrate ColorSystem
+- [ ] Integrate AudioAnalyzer + ParameterMapper
+- [ ] Test all features
+
+**4.2 Refactor Quantum System**
+- [ ] Migrate `QuantumEngine.js` to extend `BaseSystem`
+- [ ] Integrate advanced color
+- [ ] Integrate advanced audio
+- [ ] Test volumetric lighting with new audio
+
+**4.3 Refactor Holographic System**
+- [ ] Consolidate 3 holographic variants into 1
+- [ ] Extend `BaseSystem`
+- [ ] Enhance audio reactivity with new system
+- [ ] Test multi-layer rendering
+
+**4.4 Refactor Polychora System**
+- [ ] Migrate `PolychoraSystem.js` to extend `BaseSystem`
+- [ ] 4D rotation optimization
+- [ ] Audio-reactive 4D transformations
+- [ ] Test polytope rendering
+
+---
+
+### **PHASE 5: UNIFIED INTERFACE (Week 4-5)**
+
+**5.1 Create Single Master Index**
+- [ ] New `index.html` using BaseSystem architecture
+- [ ] Dynamic system loading
+- [ ] Unified UI that adapts per system
+- [ ] System switcher with smooth transitions
+
+**5.2 Consolidate CSS**
+- [ ] Extract inline CSS to modules
+- [ ] Per-system themes
+- [ ] Responsive design
+- [ ] Animation system
+
+**5.3 Export System**
+- [ ] Unify trading card generation across all systems
+- [ ] Video export with proper canvas handling
+- [ ] JSON save/load for all systems
+- [ ] Gallery system integration
+
+---
+
+### **PHASE 6: OPTIMIZATION & POLISH (Week 5-6)**
+
+**6.1 Performance**
+- [ ] WebGL optimization
+- [ ] Mobile performance testing
+- [ ] Memory leak prevention
+- [ ] Frame rate monitoring
+
+**6.2 Testing**
+- [ ] Unit tests for audio analysis
+- [ ] Integration tests for system switching
+- [ ] Visual regression tests
+- [ ] Mobile device testing
+
+**6.3 Documentation**
+- [ ] API documentation
+- [ ] User guide
+- [ ] Developer guide
+- [ ] Example presets
+
+---
+
+## 📁 NEW FILE STRUCTURE
+```
+vib34d-music-video-choreographer-alternative/
+├── index.html                           // NEW: Unified master interface
+├── src/
+│   ├── systems/
+│   │   ├── shared/
+│   │   │   ├── BaseSystem.js           // NEW: Base class all systems extend
+│   │   │   ├── BaseVisualizer.js       // NEW: Base visualizer interface
+│   │   │   └── SystemRegistry.js       // NEW: System management
+│   │   ├── faceted/
+│   │   │   ├── FacetedSystem.js        // REFACTORED: from Engine.js
+│   │   │   └── FacetedVisualizer.js    // REFACTORED: from Visualizer.js
+│   │   ├── quantum/
+│   │   │   ├── QuantumSystem.js        // REFACTORED: from QuantumEngine.js
+│   │   │   └── QuantumVisualizer.js    // REFACTORED
+│   │   ├── holographic/
+│   │   │   ├── HolographicSystem.js    // CONSOLIDATED: from 3 variants
+│   │   │   └── HolographicVisualizer.js
+│   │   └── polychora/
+│   │       ├── PolychoraSystem.js      // REFACTORED
+│   │       └── PolychoraVisualizer.js  // EXTRACTED
+│   ├── core/
+│   │   ├── Parameters.js               // ENHANCED: unified parameters
+│   │   ├── CanvasManager.js            // KEEP: working well
+│   │   └── ReactivityManager.js        // KEEP: working well
+│   ├── audio/
+│   │   ├── AudioAnalyzer.js            // NEW: 7-band + spectral analysis
+│   │   ├── ADSREnvelope.js             // NEW: smooth parameter transitions
+│   │   └── ParameterMapper.js          // NEW: audio-to-parameter routing
+│   ├── color/
+│   │   └── ColorSystem.js              // NEW: palettes + gradients + reactive
+│   ├── geometry/
+│   │   └── GeometryLibrary.js          // KEEP: shared geometries
+│   └── export/
+│       ├── UnifiedExportManager.js     // NEW: single export system
+│       └── [consolidate card generators]
+├── styles/
+│   ├── base.css                        // NEW: extracted from inline
+│   ├── systems/
+│   │   ├── faceted.css                 // NEW: system-specific styling
+│   │   ├── quantum.css
+│   │   ├── holographic.css
+│   │   └── polychora.css
+│   └── ui/
+│       ├── controls.css                // NEW: unified controls
+│       └── mobile.css                  // NEW: responsive design
+└── archive/
+    └── [move all old index-*.html here]
+```
+
+---
+
+## 🎯 SUCCESS CRITERIA
+
+### **Elegance:**
+- ✅ Single `index.html` under 500 lines
+- ✅ All systems extend `BaseSystem` with identical API
+- ✅ No code duplication between systems
+- ✅ Clean separation: systems / audio / color / export
+
+### **Color Expansion:**
+- ✅ 8+ color modes (single, dual, triad, palette, gradient, reactive)
+- ✅ 8+ predefined palettes
+- ✅ 5+ gradient types
+- ✅ Audio-reactive color that responds to spectral features
+
+### **Audio Reactivity:**
+- ✅ 7 frequency bands (vs current 3)
+- ✅ 4 spectral features (centroid, rolloff, flux, rms)
+- ✅ Onset detection for transients
+- ✅ BPM estimation
+- ✅ ADSR envelopes for smooth parameter changes
+- ✅ Multiple mapping curves (exponential, logarithmic, s-curve, threshold)
+
+### **Performance:**
+- ✅ 60 FPS on desktop
+- ✅ 45+ FPS on mobile
+- ✅ Smooth system switching (< 500ms)
+- ✅ No memory leaks
+
+---
+
+## 🚀 IMMEDIATE NEXT STEPS
+
+1. **Advanced Audio Pipeline Integration** ✅
+   - Faceted, Quantum, and Holographic renderers now consume the analyzer's multi-band + spectral output with smoothing envelopes
+   - Audio-driven boosts power grid density, morphing, chaos, color, and 4D rotation without destabilizing base parameters
+   - Debug hooks remain for spot-checking live signals while preserving graceful fallbacks when audio is disabled
+
+2. **Color System Integration (in progress)**:
+   - ✅ Implemented `ColorSystem.js` with palettes, gradients, and audio-reactive blending
+   - ✅ Advanced audio engine now publishes `window.colorState` for every frame
+   - 🔄 Feed palette uniforms + gradient data into shaders and UI controls
+
+3. **Then Architecture**:
+   - Create `BaseSystem.js`
+   - Refactor Faceted system first (simplest)
+   - Use as template for others
+
+4. **Finally Consolidation**:
+   - New unified `index.html`
+   - Move old versions to archive
+   - Polish and optimize
+
+---
+
+**TIMELINE**: 6 weeks for complete refactoring
+**PRIORITY**: Audio system first (can integrate with current architecture immediately)
+
+**Next Command**: Prototype the ColorSystem class so the upgraded audio hues can blend with palette/gradient workflows?

--- a/js/audio/audio-engine.js
+++ b/js/audio/audio-engine.js
@@ -1,139 +1,429 @@
 /**
  * VIB34D Audio Engine Module
- * Mobile-safe audio reactivity system with global window integration
- * Extracted from monolithic index.html for clean architecture
+ * Advanced audio reactivity hub that feeds all visualization systems
+ * Built on the unified AudioAnalyzer / ParameterMapper toolkit
  */
+
+import { AudioAnalyzer } from '../../src/audio/AudioAnalyzer.js';
+import { ParameterMapper } from '../../src/audio/ParameterMapper.js';
+import { ADSREnvelope } from '../../src/audio/ADSREnvelope.js';
+import { ColorSystem } from '../../src/color/ColorSystem.js';
 
 // Global audio state flags - CRITICAL for system integration
 window.audioEnabled = false; // Global audio flag (will auto-enable on interaction)
 
-/**
- * Simple Audio Engine - Mobile-safe and actually works
- * Provides real-time audio analysis for all visualization systems
- */
-export class SimpleAudioEngine {
-    constructor() {
-        this.context = null;
-        this.analyser = null;
-        this.dataArray = null;
-        this.isActive = false;
-        
-        // Mobile-safe: Initialize with defaults
-        window.audioReactive = {
+const clamp01 = value => Math.min(Math.max(value, 0), 1);
+
+function createDefaultReactiveState(colorState = null) {
+    return {
+        bass: 0,
+        mid: 0,
+        high: 0,
+        sparkle: 0,
+        energy: 0,
+        motion: 0,
+        onset: 0,
+        hueShift: 0,
+        intensity: 0,
+        spectralCentroid: 0,
+        spectralRolloff: 0,
+        spectralFlux: 0,
+        rms: 0,
+        bpm: 0,
+        bands: {
+            subBass: 0,
             bass: 0,
-            mid: 0, 
+            lowMid: 0,
+            mid: 0,
+            highMid: 0,
             high: 0,
-            energy: 0
+            air: 0
+        },
+        color: colorState
+    };
+}
+
+/**
+ * Advanced Audio Engine - Unified analysis + parameter routing
+ */
+export class AdvancedAudioEngine {
+    constructor(options = {}) {
+        this.context = null;
+        this.mediaStream = null;
+        this.analyserNode = null;
+        this.audioAnalyzer = null;
+        this.parameterMapper = null;
+        this.colorSystem = new ColorSystem(options.colorSystem || {});
+        this.listeners = new Set();
+
+        this.isActive = false;
+        this.isEnabled = false;
+        this.processingHandle = null;
+        this.frameScheduler = 'raf';
+
+        this.options = {
+            fftSize: options.fftSize || 2048,
+            smoothingTimeConstant: options.smoothingTimeConstant ?? 0.7,
+            energySmoothing: options.energySmoothing ?? 0.75,
+            onsetThreshold: options.onsetThreshold ?? 0.18,
+            minimumOnsetInterval: options.minimumOnsetInterval ?? 110
         };
-        
-        console.log('🎵 Audio Engine: Initialized with default values');
+
+        this.sensitivity = {
+            bass: options.bassGain ?? 1,
+            mid: options.midGain ?? 1,
+            high: options.highGain ?? 1,
+            energy: options.energyGain ?? 1,
+            sparkle: options.sparkleGain ?? 1,
+            motion: options.motionGain ?? 1
+        };
+
+        const initialColorState = this.colorSystem.getState();
+        window.colorState = initialColorState;
+        window.audioReactive = createDefaultReactiveState(initialColorState);
+
+        console.log('🎵 Audio Engine: Advanced analyzer initialized with default values');
     }
-    
+
     async init() {
-        if (this.isActive) return true;
-        
+        if (this.isActive) {
+            if (this.context?.state === 'suspended') {
+                await this.context.resume();
+            }
+            this.setEnabled(true);
+            return true;
+        }
+
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            console.warn('⚠️ Audio Analyzer: getUserMedia not available.');
+            return false;
+        }
+
         try {
-            console.log('🎵 Simple Audio Engine: Starting...');
-            
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            console.log('🎵 Advanced Audio Engine: Requesting microphone access…');
+            this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
             this.context = new (window.AudioContext || window.webkitAudioContext)();
-            
+
             if (this.context.state === 'suspended') {
                 await this.context.resume();
             }
-            
-            this.analyser = this.context.createAnalyser();
-            this.analyser.fftSize = 256;
-            this.analyser.smoothingTimeConstant = 0.8;
-            
-            const source = this.context.createMediaStreamSource(stream);
-            source.connect(this.analyser);
-            
-            this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+
+            this.analyserNode = this.context.createAnalyser();
+            this.analyserNode.fftSize = this.options.fftSize;
+            this.analyserNode.smoothingTimeConstant = this.options.smoothingTimeConstant;
+
+            const source = this.context.createMediaStreamSource(this.mediaStream);
+            source.connect(this.analyserNode);
+
+            this.audioAnalyzer = new AudioAnalyzer(this.analyserNode, {
+                fftSize: this.options.fftSize,
+                frequencySmoothing: this.options.smoothingTimeConstant,
+                energySmoothing: this.options.energySmoothing,
+                onsetThreshold: this.options.onsetThreshold,
+                minimumOnsetInterval: this.options.minimumOnsetInterval
+            });
+
+            this.parameterMapper = this.#createDefaultMapper();
+
             this.isActive = true;
-            
-            // CRITICAL FIX: Enable global audio flag so visualizers will use the data
-            window.audioEnabled = true;
-            
-            this.startProcessing();
-            console.log('✅ Audio Engine: Active - window.audioEnabled = true');
+            this.setEnabled(true);
+            this.#startProcessing();
+
+            console.log('✅ Audio Engine: Advanced analyzer active');
             return true;
-            
         } catch (error) {
-            console.log('⚠️ Audio denied - silent mode');
-            window.audioEnabled = false; // Keep audio disabled if permission denied
+            console.warn('⚠️ Audio Analyzer: Permission denied or device unavailable', error);
+            this.isActive = false;
+            this.setEnabled(false);
             return false;
         }
     }
-    
-    startProcessing() {
-        const process = () => {
-            if (!this.isActive || !this.analyser) {
-                requestAnimationFrame(process);
-                return;
-            }
-            
-            this.analyser.getByteFrequencyData(this.dataArray);
-            
-            // Simple frequency analysis
-            const len = this.dataArray.length;
-            const bassRange = Math.floor(len * 0.1);
-            const midRange = Math.floor(len * 0.3);
-            
-            let bass = 0, mid = 0, high = 0;
-            
-            for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
-            for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
-            for (let i = midRange; i < len; i++) high += this.dataArray[i];
-            
-            bass = (bass / bassRange) / 255;
-            mid = (mid / (midRange - bassRange)) / 255;
-            high = (high / (len - midRange)) / 255;
-            
-            const smoothing = 0.7;
-            window.audioReactive.bass = bass * smoothing + window.audioReactive.bass * (1 - smoothing);
-            window.audioReactive.mid = mid * smoothing + window.audioReactive.mid * (1 - smoothing);
-            window.audioReactive.high = high * smoothing + window.audioReactive.high * (1 - smoothing);
-            window.audioReactive.energy = (window.audioReactive.bass + window.audioReactive.mid + window.audioReactive.high) / 3;
-            
-            // Debug logging every 5 seconds to verify audio processing
-            if (Date.now() % 5000 < 16) {
-                console.log(`🎵 Audio levels: Bass=${window.audioReactive.bass.toFixed(2)} Mid=${window.audioReactive.mid.toFixed(2)} High=${window.audioReactive.high.toFixed(2)} Energy=${window.audioReactive.energy.toFixed(2)}`);
-            }
-            
-            requestAnimationFrame(process);
-        };
-        
-        process();
-    }
-    
-    /**
-     * Check if audio is currently active and processing
-     */
+
     isAudioActive() {
-        return this.isActive && window.audioEnabled;
+        return this.isActive && this.isEnabled && window.audioEnabled;
     }
-    
-    /**
-     * Get current audio reactive values
-     */
+
+    setEnabled(enabled) {
+        this.isEnabled = Boolean(enabled);
+        window.audioEnabled = this.isEnabled;
+
+        if (!this.isEnabled) {
+            this.#resetReactiveState();
+            this.#stopProcessingLoop();
+        }
+
+        if (!this.processingHandle && this.isActive && this.isEnabled) {
+            this.#startProcessing();
+        }
+    }
+
+    updateSensitivity(settings = {}) {
+        if (typeof settings.bassGain === 'number') {
+            this.sensitivity.bass = Math.max(0, settings.bassGain);
+        }
+        if (typeof settings.midGain === 'number') {
+            this.sensitivity.mid = Math.max(0, settings.midGain);
+        }
+        if (typeof settings.highGain === 'number') {
+            this.sensitivity.high = Math.max(0, settings.highGain);
+        }
+        if (typeof settings.energyGain === 'number') {
+            this.sensitivity.energy = Math.max(0, settings.energyGain);
+        }
+        if (typeof settings.sparkleGain === 'number') {
+            this.sensitivity.sparkle = Math.max(0, settings.sparkleGain);
+        }
+        if (typeof settings.motionGain === 'number') {
+            this.sensitivity.motion = Math.max(0, settings.motionGain);
+        }
+    }
+
+    registerMappings(parameterMappings = {}) {
+        if (!this.parameterMapper) {
+            this.parameterMapper = new ParameterMapper(parameterMappings);
+            return;
+        }
+
+        Object.entries(parameterMappings).forEach(([parameter, config]) => {
+            this.parameterMapper.registerMapping(parameter, config);
+        });
+    }
+
+    subscribe(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
     getAudioLevels() {
         return window.audioReactive;
     }
-    
-    /**
-     * Stop audio processing and clean up resources
-     */
+
+    getColorState() {
+        return this.colorSystem?.getState() ?? window.colorState ?? null;
+    }
+
     stop() {
-        this.isActive = false;
+        this.isEnabled = false;
         window.audioEnabled = false;
-        
+
+        this.#stopProcessingLoop();
+
+        if (this.analyserNode) {
+            this.analyserNode.disconnect();
+            this.analyserNode = null;
+        }
+
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach(track => track.stop());
+            this.mediaStream = null;
+        }
+
         if (this.context) {
             this.context.close();
             this.context = null;
         }
-        
-        console.log('🎵 Audio Engine: Stopped');
+
+        this.isActive = false;
+        this.#resetReactiveState();
+
+        console.log('🎵 Audio Engine: Stopped and cleaned up');
+    }
+
+    #startProcessing() {
+        if (!this.isActive || !this.isEnabled || !this.audioAnalyzer || this.processingHandle != null) {
+            return;
+        }
+
+        const useRaf = typeof requestAnimationFrame === 'function';
+        this.frameScheduler = useRaf ? 'raf' : 'timeout';
+
+        const step = () => {
+            if (!this.isActive) {
+                this.#stopProcessingLoop();
+                return;
+            }
+
+            if (this.isEnabled) {
+                this.#processFrame();
+            }
+
+            if (this.frameScheduler === 'raf') {
+                this.processingHandle = requestAnimationFrame(step);
+            } else {
+                this.processingHandle = setTimeout(step, 16);
+            }
+        };
+
+        if (this.frameScheduler === 'raf') {
+            this.processingHandle = requestAnimationFrame(step);
+        } else {
+            this.processingHandle = setTimeout(step, 16);
+        }
+    }
+
+    #processFrame() {
+        if (!this.audioAnalyzer || !this.parameterMapper) {
+            return;
+        }
+
+        const audioData = this.audioAnalyzer.analyze();
+        const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const mapped = this.parameterMapper.map(audioData, now);
+
+        const combinedBands = {
+            subBass: clamp01(audioData.bands?.subBass ?? 0),
+            bass: clamp01(audioData.bands?.bass ?? 0),
+            lowMid: clamp01(audioData.bands?.lowMid ?? 0),
+            mid: clamp01(audioData.bands?.mid ?? 0),
+            highMid: clamp01(audioData.bands?.highMid ?? 0),
+            high: clamp01(audioData.bands?.high ?? 0),
+            air: clamp01(audioData.bands?.air ?? 0)
+        };
+
+        const reactive = {
+            bass: clamp01((mapped.bass ?? 0) * this.sensitivity.bass),
+            mid: clamp01((mapped.mid ?? 0) * this.sensitivity.mid),
+            high: clamp01((mapped.high ?? 0) * this.sensitivity.high),
+            sparkle: clamp01((mapped.sparkle ?? combinedBands.air) * this.sensitivity.sparkle),
+            energy: clamp01((mapped.energy ?? audioData.rms ?? 0) * this.sensitivity.energy),
+            motion: clamp01((mapped.motion ?? audioData.spectralFlux ?? 0) * this.sensitivity.motion),
+            onset: audioData.onset ? 1 : 0,
+            hueShift: clamp01(mapped.hueShift ?? audioData.spectralCentroid ?? 0),
+            intensity: clamp01(mapped.intensity ?? audioData.rms ?? 0),
+            spectralCentroid: clamp01(audioData.spectralCentroid ?? 0),
+            spectralRolloff: clamp01(audioData.spectralRolloff ?? 0),
+            spectralFlux: clamp01(audioData.spectralFlux ?? 0),
+            rms: clamp01(audioData.rms ?? 0),
+            bpm: audioData.bpm || 0,
+            bands: combinedBands
+        };
+
+        reactive.energy = Math.max(reactive.energy, (reactive.bass + reactive.mid + reactive.high) / 3);
+
+        if (this.colorSystem) {
+            const colorState = this.colorSystem.update(now, audioData, reactive);
+            reactive.color = colorState;
+            window.colorState = colorState;
+        }
+
+        window.audioReactive = reactive;
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(reactive, audioData);
+            } catch (error) {
+                console.warn('Audio Engine listener error', error);
+            }
+        });
+
+        if (Math.floor(now) % 5000 < 32) {
+            console.log(
+                `🎵 Audio levels: Bass=${reactive.bass.toFixed(2)} Mid=${reactive.mid.toFixed(2)} High=${reactive.high.toFixed(2)} Energy=${reactive.energy.toFixed(2)} BPM=${Math.round(reactive.bpm)}`
+            );
+        }
+    }
+
+    #stopProcessingLoop() {
+        if (this.processingHandle == null) {
+            return;
+        }
+
+        if (this.frameScheduler === 'raf') {
+            if (typeof cancelAnimationFrame === 'function') {
+                cancelAnimationFrame(this.processingHandle);
+            }
+        } else if (this.frameScheduler === 'timeout') {
+            clearTimeout(this.processingHandle);
+        }
+
+        this.processingHandle = null;
+    }
+
+    #createDefaultMapper() {
+        return new ParameterMapper({
+            bass: {
+                source: data => ((data.bands.subBass + data.bands.bass) / 2) || 0,
+                curve: 'exponential',
+                range: [0, 1],
+                envelope: new ADSREnvelope(60, 140, 0.65, 220),
+                envelopeTrigger: 0.05,
+                envelopeRelease: 0.03
+            },
+            mid: {
+                source: data => ((data.bands.lowMid + data.bands.mid) / 2) || 0,
+                curve: 's-curve',
+                intensity: 0.8,
+                range: [0, 1],
+                envelope: new ADSREnvelope(50, 100, 0.7, 200),
+                envelopeTrigger: 0.05,
+                envelopeRelease: 0.03
+            },
+            high: {
+                source: data => ((data.bands.highMid + data.bands.high) / 2) || 0,
+                curve: 'power',
+                power: 1.4,
+                range: [0, 1],
+                envelope: new ADSREnvelope(35, 90, 0.6, 160),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.025
+            },
+            sparkle: {
+                source: data => data.bands.air || 0,
+                curve: 'power',
+                power: 1.6,
+                range: [0, 1],
+                envelope: new ADSREnvelope(25, 80, 0.5, 140),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            },
+            energy: {
+                source: data => data.rms || 0,
+                curve: 'logarithmic',
+                range: [0.1, 1],
+                envelope: new ADSREnvelope(30, 120, 0.75, 260),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            },
+            motion: {
+                source: data => data.spectralFlux || 0,
+                curve: 'exponential',
+                range: [0, 1],
+                envelope: new ADSREnvelope(20, 80, 0.5, 180),
+                envelopeTrigger: 0.03,
+                envelopeRelease: 0.015
+            },
+            hueShift: {
+                source: data => data.spectralCentroid || 0,
+                curve: 'linear',
+                range: [0, 1]
+            },
+            intensity: {
+                source: data => data.rms || 0,
+                curve: 's-curve',
+                intensity: 0.6,
+                range: [0.2, 1],
+                envelope: new ADSREnvelope(25, 70, 0.8, 160),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            }
+        });
+    }
+
+    #resetReactiveState() {
+        const colorState = this.colorSystem ? this.colorSystem.reset() : null;
+        window.colorState = colorState;
+        window.audioReactive = createDefaultReactiveState(colorState);
+        this.listeners.forEach(listener => {
+            try {
+                listener(window.audioReactive, null);
+            } catch (error) {
+                console.warn('Audio Engine listener error during reset', error);
+            }
+        });
     }
 }
 
@@ -142,56 +432,45 @@ export class SimpleAudioEngine {
  * Toggles audio reactivity and updates UI state
  */
 export function setupAudioToggle() {
-    window.toggleAudio = function() {
+    window.toggleAudio = async function toggleAudio() {
         const audioBtn = document.getElementById('audioToggle') || document.querySelector('[onclick="toggleAudio()"]');
-        
-        if (!window.audioEngine.isActive) {
-            // Try to start audio
-            window.audioEngine.init().then(success => {
-                if (success) {
-                    if (audioBtn) {
-                        audioBtn.classList.add('active');
-                        audioBtn.title = 'Audio Reactivity: ON';
-                    }
-                    console.log('🎵 Audio Reactivity: ON');
-                } else {
-                    console.log('⚠️ Audio permission denied or not available');
-                }
-            });
-        } else {
-            // Toggle audio processing
-            let audioEnabled = !window.audioEnabled;
-            window.audioEnabled = audioEnabled; // Update global flag
-            
-            if (audioBtn) {
-                // Update button visual state
-                if (audioEnabled) {
-                    audioBtn.classList.add('active');
-                } else {
-                    audioBtn.classList.remove('active');
-                }
-                audioBtn.title = `Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`;
-            }
-            
-            // Audio permission check for mobile
-            if (audioEnabled) {
-                navigator.mediaDevices.getUserMedia({ audio: true }).catch(e => {
-                    audioEnabled = false;
-                    window.audioEnabled = false;
-                    console.log('⚠️ Audio permission denied:', e.message);
-                });
-            }
-            
-            console.log(`🎵 Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`);
+
+        if (!window.audioEngine) {
+            console.warn('⚠️ No audio engine instance available');
+            return;
         }
+
+        if (!window.audioEngine.isActive) {
+            const success = await window.audioEngine.init();
+            if (!success) {
+                console.warn('⚠️ Audio Reactivity: Permission denied or unavailable');
+                return;
+            }
+            if (audioBtn) {
+                audioBtn.classList.add('active');
+                audioBtn.title = 'Audio Reactivity: ON';
+            }
+            console.log('🎵 Audio Reactivity: ON');
+            return;
+        }
+
+        const nextEnabled = !window.audioEnabled;
+        window.audioEngine.setEnabled(nextEnabled);
+
+        if (audioBtn) {
+            audioBtn.classList.toggle('active', nextEnabled);
+            audioBtn.title = `Audio Reactivity: ${nextEnabled ? 'ON' : 'OFF'}`;
+        }
+
+        console.log(`🎵 Audio Reactivity: ${nextEnabled ? 'ON' : 'OFF'}`);
     };
 }
 
 // Create and initialize the global audio engine instance
-const audioEngine = new SimpleAudioEngine();
+const audioEngine = new AdvancedAudioEngine();
 window.audioEngine = audioEngine;
 
 // Set up global audio toggle function
 setupAudioToggle();
 
-console.log('🎵 Audio Engine Module: Loaded');
+console.log('🎵 Audio Engine Module: Advanced analyzer loaded');

--- a/src/audio/ADSREnvelope.js
+++ b/src/audio/ADSREnvelope.js
@@ -1,0 +1,121 @@
+export class ADSREnvelope {
+    constructor(attackMs = 100, decayMs = 200, sustainLevel = 0.7, releaseMs = 200) {
+        this.attack = Math.max(0, attackMs);
+        this.decay = Math.max(0, decayMs);
+        this.sustain = Math.min(Math.max(sustainLevel, 0), 1);
+        this.release = Math.max(0, releaseMs);
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = this.#now();
+        this.startValue = 0;
+    }
+
+    reset() {
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.startValue = 0;
+        this.phaseStartTime = this.#now();
+    }
+
+    trigger(level = 1, time = this.#now()) {
+        const clamped = Math.min(Math.max(level, 0), 1);
+        this.targetValue = clamped;
+        this.phaseStartTime = time;
+
+        if (this.attack <= 0) {
+            this.value = clamped;
+            this.startValue = this.value;
+
+            if (this.decay <= 0) {
+                this.phase = 'sustain';
+            } else {
+                this.phase = 'decay';
+            }
+        } else {
+            this.phase = 'attack';
+            this.startValue = this.value;
+        }
+    }
+
+    releasePhase(time = this.#now()) {
+        if (this.phase === 'idle' || this.release === 0) {
+            this.reset();
+            return;
+        }
+
+        if (this.phase === 'release') {
+            return;
+        }
+
+        this.phase = 'release';
+        this.phaseStartTime = time;
+        this.startValue = this.value;
+    }
+
+    update(time = this.#now()) {
+        const now = time;
+        switch (this.phase) {
+            case 'attack':
+                this.value = this.#interpolate(this.startValue, this.targetValue, this.attack, now);
+                if (now - this.phaseStartTime >= this.attack) {
+                    this.phase = this.decay === 0 ? 'sustain' : 'decay';
+                    this.phaseStartTime = now;
+                    this.startValue = this.value;
+                }
+                break;
+            case 'decay':
+                {
+                    const target = this.targetValue * this.sustain;
+                    this.value = this.#interpolate(this.startValue, target, this.decay, now);
+                    if (now - this.phaseStartTime >= this.decay) {
+                        this.phase = 'sustain';
+                        this.phaseStartTime = now;
+                        this.startValue = this.value;
+                    }
+                }
+                break;
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+            case 'release':
+                this.value = this.#interpolate(this.startValue, 0, this.release, now);
+                if (now - this.phaseStartTime >= this.release) {
+                    this.reset();
+                }
+                break;
+            default:
+                this.value = 0;
+                break;
+        }
+
+        return this.value;
+    }
+
+    isActive() {
+        return this.phase !== 'idle';
+    }
+
+    clone() {
+        return new ADSREnvelope(this.attack, this.decay, this.sustain, this.release);
+    }
+
+    #interpolate(start, end, duration, now) {
+        if (duration <= 0) {
+            return end;
+        }
+        const progress = Math.min((now - this.phaseStartTime) / duration, 1);
+        return start + (end - start) * progress;
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default ADSREnvelope;

--- a/src/audio/AudioAnalyzer.js
+++ b/src/audio/AudioAnalyzer.js
@@ -1,0 +1,261 @@
+const DEFAULT_BANDS = [
+    { key: 'subBass', low: 20, high: 60 },
+    { key: 'bass', low: 60, high: 250 },
+    { key: 'lowMid', low: 250, high: 500 },
+    { key: 'mid', low: 500, high: 2000 },
+    { key: 'highMid', low: 2000, high: 4000 },
+    { key: 'high', low: 4000, high: 8000 },
+    { key: 'air', low: 8000, high: 20000 }
+];
+
+const DB_FLOOR = -100;
+
+export class AudioAnalyzer {
+    constructor(analyserNode, options = {}) {
+        if (!analyserNode) {
+            throw new Error('AudioAnalyzer requires an AnalyserNode instance.');
+        }
+
+        this.analyser = analyserNode;
+        this.context = analyserNode.context || null;
+
+        this.fftSize = options.fftSize || 2048;
+        this.minDecibels = options.minDecibels ?? -100;
+        this.maxDecibels = options.maxDecibels ?? -20;
+        this.smoothingConstant = options.frequencySmoothing ?? 0.7;
+        this.energySmoothing = options.energySmoothing ?? 0.8;
+        this.onsetThreshold = options.onsetThreshold ?? 0.15;
+        this.minimumOnsetInterval = options.minimumOnsetInterval ?? 120;
+        this.bandDefinitions = options.bands || DEFAULT_BANDS;
+
+        this.analyser.fftSize = this.fftSize;
+        this.analyser.minDecibels = this.minDecibels;
+        this.analyser.maxDecibels = this.maxDecibels;
+        this.analyser.smoothingTimeConstant = this.smoothingConstant;
+
+        this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
+        this.timeDomainData = new Float32Array(this.analyser.fftSize);
+        this.previousSpectrum = new Float32Array(this.analyser.frequencyBinCount);
+
+        this.sampleRate = options.sampleRate || this.context?.sampleRate || 44100;
+
+        this.bandValues = this.bandDefinitions.reduce((acc, band) => {
+            acc[band.key] = 0;
+            return acc;
+        }, {});
+        this.smoothedBands = { ...this.bandValues };
+
+        this.spectralCentroid = 0;
+        this.spectralRolloff = 0;
+        this.spectralFlux = 0;
+        this.rms = 0;
+        this.estimatedBPM = options.initialBPM || 120;
+
+        this.onsetHistory = [];
+        this.lastOnsetTime = 0;
+    }
+
+    analyze() {
+        this.#captureFrequencyData();
+        this.#captureTimeDomainData();
+
+        this.#analyzeBands();
+        this.#calculateSpectralCentroid();
+        this.#calculateSpectralRolloff();
+        this.#calculateSpectralFlux();
+        this.#calculateRMS();
+
+        const now = this.#now();
+        const onset = this.#detectOnset(now);
+        if (onset) {
+            this.#recordOnset(now);
+            this.#estimateBPM();
+        }
+
+        return {
+            bands: { ...this.smoothedBands },
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset,
+            bpm: this.estimatedBPM
+        };
+    }
+
+    #captureFrequencyData() {
+        if (typeof this.analyser.getFloatFrequencyData === 'function') {
+            this.analyser.getFloatFrequencyData(this.frequencyData);
+        } else {
+            const byteData = new Uint8Array(this.analyser.frequencyBinCount);
+            this.analyser.getByteFrequencyData(byteData);
+            for (let i = 0; i < byteData.length; i += 1) {
+                this.frequencyData[i] = (byteData[i] / 255) * (this.maxDecibels - this.minDecibels) + this.minDecibels;
+            }
+        }
+    }
+
+    #captureTimeDomainData() {
+        if (typeof this.analyser.getFloatTimeDomainData === 'function') {
+            this.analyser.getFloatTimeDomainData(this.timeDomainData);
+        } else {
+            const byteData = new Uint8Array(this.analyser.fftSize);
+            this.analyser.getByteTimeDomainData(byteData);
+            for (let i = 0; i < byteData.length; i += 1) {
+                this.timeDomainData[i] = (byteData[i] - 128) / 128;
+            }
+        }
+    }
+
+    #analyzeBands() {
+        const binSize = this.sampleRate / this.analyser.fftSize;
+        const smoothing = this.energySmoothing;
+
+        this.bandDefinitions.forEach((band) => {
+            const startBin = Math.max(0, Math.floor(band.low / binSize));
+            const endBin = Math.min(this.frequencyData.length - 1, Math.ceil(band.high / binSize));
+
+            if (endBin <= startBin) {
+                this.smoothedBands[band.key] *= smoothing;
+                return;
+            }
+
+            let sum = 0;
+            let count = 0;
+            for (let i = startBin; i <= endBin; i += 1) {
+                const amplitude = this.#dbToNormalized(this.frequencyData[i]);
+                sum += amplitude;
+                count += 1;
+            }
+
+            const average = count > 0 ? sum / count : 0;
+            this.smoothedBands[band.key] = (smoothing * this.smoothedBands[band.key]) + ((1 - smoothing) * average);
+        });
+    }
+
+    #calculateSpectralCentroid() {
+        let weightedSum = 0;
+        let total = 0;
+        const binSize = this.sampleRate / this.analyser.fftSize;
+
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.#dbToNormalized(this.frequencyData[i]);
+            const frequency = i * binSize;
+            weightedSum += frequency * magnitude;
+            total += magnitude;
+        }
+
+        const centroid = total > 0 ? weightedSum / total : 0;
+        this.spectralCentroid = centroid / (this.sampleRate / 2);
+    }
+
+    #calculateSpectralRolloff() {
+        const threshold = 0.85;
+        const binSize = this.sampleRate / this.analyser.fftSize;
+        let totalEnergy = 0;
+        const magnitudes = new Array(this.frequencyData.length);
+
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.#dbToNormalized(this.frequencyData[i]);
+            magnitudes[i] = magnitude;
+            totalEnergy += magnitude;
+        }
+
+        const targetEnergy = totalEnergy * threshold;
+        let cumulative = 0;
+        let rolloffBin = 0;
+        for (let i = 0; i < magnitudes.length; i += 1) {
+            cumulative += magnitudes[i];
+            if (cumulative >= targetEnergy) {
+                rolloffBin = i;
+                break;
+            }
+        }
+
+        const rolloffFrequency = rolloffBin * binSize;
+        this.spectralRolloff = Math.min(rolloffFrequency / (this.sampleRate / 2), 1);
+    }
+
+    #calculateSpectralFlux() {
+        let flux = 0;
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const current = Math.max(0, this.#dbToNormalized(this.frequencyData[i]));
+            const previous = Math.max(0, this.previousSpectrum[i]);
+            const diff = current - previous;
+            if (diff > 0) {
+                flux += diff;
+            }
+            this.previousSpectrum[i] = current;
+        }
+
+        this.spectralFlux = flux / this.frequencyData.length;
+    }
+
+    #calculateRMS() {
+        let sumSquares = 0;
+        for (let i = 0; i < this.timeDomainData.length; i += 1) {
+            const sample = this.timeDomainData[i];
+            sumSquares += sample * sample;
+        }
+
+        const meanSquare = sumSquares / this.timeDomainData.length;
+        this.rms = Math.sqrt(meanSquare);
+    }
+
+    #detectOnset(now) {
+        const flux = this.spectralFlux;
+        const timeSinceLast = now - this.lastOnsetTime;
+
+        if (flux > this.onsetThreshold && timeSinceLast > this.minimumOnsetInterval) {
+            this.lastOnsetTime = now;
+            return true;
+        }
+
+        return false;
+    }
+
+    #recordOnset(timestamp) {
+        this.onsetHistory.push(timestamp);
+        const windowMs = 6000;
+        const cutoff = timestamp - windowMs;
+        this.onsetHistory = this.onsetHistory.filter((time) => time >= cutoff);
+    }
+
+    #estimateBPM() {
+        if (this.onsetHistory.length < 2) {
+            return;
+        }
+
+        const intervals = [];
+        for (let i = 1; i < this.onsetHistory.length; i += 1) {
+            intervals.push(this.onsetHistory[i] - this.onsetHistory[i - 1]);
+        }
+
+        if (intervals.length === 0) {
+            return;
+        }
+
+        const avgInterval = intervals.reduce((sum, value) => sum + value, 0) / intervals.length;
+        if (avgInterval === 0) {
+            return;
+        }
+
+        const bpm = 60000 / avgInterval;
+        const clampedBpm = Math.min(Math.max(bpm, 60), 200);
+        this.estimatedBPM = (this.estimatedBPM * 0.8) + (clampedBpm * 0.2);
+    }
+
+    #dbToNormalized(db) {
+        const normalized = (db - (this.minDecibels ?? DB_FLOOR)) / ((this.maxDecibels ?? -30) - (this.minDecibels ?? DB_FLOOR));
+        return Math.min(Math.max(normalized, 0), 1);
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default AudioAnalyzer;

--- a/src/audio/ParameterMapper.js
+++ b/src/audio/ParameterMapper.js
@@ -1,0 +1,141 @@
+import { ADSREnvelope } from './ADSREnvelope.js';
+
+const clamp01 = (value) => Math.min(Math.max(value, 0), 1);
+
+export class ParameterMapper {
+    constructor(mappings = {}) {
+        this.mappings = {};
+        this.envelopes = new Map();
+        this.lastValues = new Map();
+
+        Object.entries(mappings).forEach(([parameter, config]) => {
+            this.registerMapping(parameter, config);
+        });
+    }
+
+    registerMapping(parameter, config) {
+        if (!config) {
+            return;
+        }
+
+        const mapping = {
+            source: config.source,
+            curve: config.curve || 'linear',
+            range: config.range || [0, 1],
+            scale: config.scale || 1,
+            offset: config.offset || 0,
+            threshold: config.threshold ?? 0,
+            envelopeTrigger: config.envelopeTrigger ?? config.threshold ?? 0,
+            envelopeRelease: config.envelopeRelease ?? config.threshold ?? 0,
+            envelope: null
+        };
+
+        if (config.envelope instanceof ADSREnvelope) {
+            mapping.envelope = config.envelope.clone();
+            this.envelopes.set(parameter, mapping.envelope);
+        }
+
+        this.mappings[parameter] = mapping;
+        this.lastValues.set(parameter, 0);
+    }
+
+    removeMapping(parameter) {
+        delete this.mappings[parameter];
+        this.envelopes.delete(parameter);
+        this.lastValues.delete(parameter);
+    }
+
+    map(audioData, time = this.#now()) {
+        const result = {};
+        Object.entries(this.mappings).forEach(([parameter, config]) => {
+            const rawValue = clamp01(this.#resolveSource(config.source, audioData));
+            const curvedValue = clamp01(this.#applyCurve(rawValue, config));
+            let value = this.#applyRange(curvedValue, config);
+
+            const envelope = this.envelopes.get(parameter);
+            if (envelope) {
+                if (curvedValue >= config.envelopeTrigger) {
+                    envelope.trigger(curvedValue, time);
+                } else if (curvedValue <= config.envelopeRelease) {
+                    envelope.releasePhase(time);
+                }
+                const envelopeValue = envelope.update(time);
+                value = this.#applyRange(envelopeValue, config);
+            }
+
+            value = (value * config.scale) + config.offset;
+            result[parameter] = value;
+            this.lastValues.set(parameter, value);
+        });
+
+        return result;
+    }
+
+    #resolveSource(source, audioData) {
+        if (typeof source === 'function') {
+            try {
+                const resolved = source(audioData);
+                return typeof resolved === 'number' ? resolved : 0;
+            } catch (error) {
+                console.warn('ParameterMapper source function failed:', error);
+                return 0;
+            }
+        }
+
+        if (typeof source === 'string') {
+            const path = source.split('.');
+            let value = audioData;
+            for (let i = 0; i < path.length; i += 1) {
+                if (value == null) {
+                    return 0;
+                }
+                value = value[path[i]];
+            }
+
+            if (typeof value === 'number') {
+                return value;
+            }
+
+            if (value && typeof value.value === 'number') {
+                return value.value;
+            }
+        }
+
+        return 0;
+    }
+
+    #applyCurve(value, config) {
+        const curve = config.curve;
+        switch (curve) {
+            case 'exponential':
+                return Math.pow(value, config.exponent ?? 2);
+            case 'logarithmic':
+                return Math.log10(1 + value * 9) / Math.log10(10);
+            case 's-curve': {
+                const intensity = config.intensity ?? 1;
+                const x = (value - 0.5) * (1 + intensity * 4);
+                return 1 / (1 + Math.exp(-x * 5));
+            }
+            case 'threshold':
+                return value >= (config.threshold ?? 0.5) ? 1 : 0;
+            case 'power':
+                return Math.pow(value, config.power ?? 1.5);
+            default:
+                return value;
+        }
+    }
+
+    #applyRange(value, config) {
+        const [min, max] = config.range;
+        return min + (clamp01(value) * (max - min));
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default ParameterMapper;

--- a/src/color/ColorSystem.js
+++ b/src/color/ColorSystem.js
@@ -1,0 +1,442 @@
+/**
+ * VIB34D Advanced Color System
+ * Provides palette, gradient, and audio-reactive color generation utilities.
+ */
+
+const clamp01 = value => Math.min(Math.max(value, 0), 1);
+const mod360 = value => {
+    const wrapped = value % 360;
+    return wrapped < 0 ? wrapped + 360 : wrapped;
+};
+
+const DEFAULT_CONFIG = {
+    colorMode: 'single',
+    baseHue: 210,
+    baseSaturation: 0.75,
+    baseIntensity: 0.65,
+    colorPalette: 'synthwave',
+    gradientType: 'horizontal',
+    gradientSpeed: 0.25,
+    colorReactivity: 0.65,
+    dualOffset: 180,
+    triadSpacing: 120,
+    analogousSpread: 30
+};
+
+const PALETTES = {
+    vaporwave: ['#ff71ce', '#01cdfe', '#05ffa1', '#b967ff'],
+    cyberpunk: ['#ff006e', '#fb5607', '#ffbe0b', '#8338ec'],
+    synthwave: ['#f72585', '#7209b7', '#3a0ca3', '#4361ee'],
+    holographic: ['#ff00ff', '#00ffff', '#ff00aa', '#00aaff'],
+    neon: ['#fe00fe', '#00fefe', '#fefe00', '#00fe00'],
+    fire: ['#ff0000', '#ff4400', '#ff8800', '#ffcc00'],
+    ocean: ['#001eff', '#0088ff', '#00ccff', '#00ffee'],
+    forest: ['#004d00', '#008800', '#00cc00', '#88ff00']
+};
+
+function hexToRgb(hex) {
+    const clean = hex.replace('#', '');
+    const value = parseInt(clean, 16);
+    return {
+        r: ((value >> 16) & 255) / 255,
+        g: ((value >> 8) & 255) / 255,
+        b: (value & 255) / 255
+    };
+}
+
+function rgbToHex({ r, g, b }) {
+    const toHex = component => {
+        const clamped = Math.round(clamp01(component) * 255);
+        return clamped.toString(16).padStart(2, '0');
+    };
+
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hsvToRgb(h, s, v) {
+    const hue = (mod360(h) / 60);
+    const c = v * s;
+    const x = c * (1 - Math.abs((hue % 2) - 1));
+    const m = v - c;
+    const sector = Math.floor(hue);
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    switch (sector) {
+        case 0:
+            r = c; g = x; b = 0;
+            break;
+        case 1:
+            r = x; g = c; b = 0;
+            break;
+        case 2:
+            r = 0; g = c; b = x;
+            break;
+        case 3:
+            r = 0; g = x; b = c;
+            break;
+        case 4:
+            r = x; g = 0; b = c;
+            break;
+        default:
+            r = c; g = 0; b = x;
+    }
+
+    return {
+        r: r + m,
+        g: g + m,
+        b: b + m
+    };
+}
+
+function rgbToHsl({ r, g, b }) {
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    let s = 0;
+    const l = (max + min) / 2;
+
+    if (delta !== 0) {
+        if (max === r) {
+            h = ((g - b) / delta) % 6;
+        } else if (max === g) {
+            h = (b - r) / delta + 2;
+        } else {
+            h = (r - g) / delta + 4;
+        }
+
+        s = delta / (1 - Math.abs(2 * l - 1));
+    }
+
+    h = (h * 60 + 360) % 360;
+
+    return { h, s, l };
+}
+
+function makeColorObject(h, s, v) {
+    const rgb = hsvToRgb(h, s, v);
+    const hsl = rgbToHsl(rgb);
+
+    return {
+        h: mod360(h),
+        s: clamp01(s),
+        v: clamp01(v),
+        rgb,
+        hex: rgbToHex(rgb),
+        hsl,
+        css: `hsl(${Math.round(hsl.h)}, ${Math.round(hsl.s * 100)}%, ${Math.round(hsl.l * 100)}%)`
+    };
+}
+
+function clonePalette(palette) {
+    return palette.map(color => ({ ...color, rgb: { ...color.rgb }, hsl: { ...color.hsl } }));
+}
+
+export class ColorSystem {
+    constructor(config = {}) {
+        this.config = { ...DEFAULT_CONFIG, ...config };
+        this.gradientPhase = 0;
+        this.lastUpdateTime = null;
+
+        this.#paletteCache = new Map();
+
+        // Prime initial state so consumers have data immediately
+        const initialState = this.#computeColorState({});
+        this.lastState = { ...initialState, gradient: this.#buildGradient(initialState.palette) };
+    }
+
+    updateConfig(partial = {}) {
+        if (!partial || typeof partial !== 'object') {
+            return this.getState();
+        }
+
+        this.config = { ...this.config, ...partial };
+
+        if (partial.colorMode) {
+            this.config.colorMode = partial.colorMode;
+        }
+
+        if (partial.colorPalette) {
+            this.config.colorPalette = partial.colorPalette;
+        }
+
+        return this.getState();
+    }
+
+    setMode(mode) {
+        if (typeof mode === 'string') {
+            this.config.colorMode = mode;
+        }
+    }
+
+    setPalette(name) {
+        if (typeof name === 'string' && PALETTES[name]) {
+            this.config.colorPalette = name;
+        }
+    }
+
+    getAvailablePalettes() {
+        return Object.keys(PALETTES);
+    }
+
+    /**
+     * Update the color system using the latest audio frame.
+     * @param {number} now - timestamp in milliseconds
+     * @param {object} audioData - analyzer output
+     * @param {object} reactive - mapped audio data
+     */
+    update(now = Date.now(), audioData = {}, reactive = {}) {
+        if (typeof now !== 'number') {
+            now = Date.now();
+        }
+
+        if (this.lastUpdateTime == null) {
+            this.lastUpdateTime = now;
+        }
+
+        const delta = Math.max(0, (now - this.lastUpdateTime) / 1000);
+        this.lastUpdateTime = now;
+
+        const modulation = (audioData?.spectralFlux ?? reactive.motion ?? 0) * this.config.colorReactivity;
+        const speed = this.config.gradientSpeed * (1 + modulation * 1.5);
+        this.gradientPhase = (this.gradientPhase + delta * speed) % 1;
+
+        const paletteInfo = this.#computeColorState(audioData, reactive);
+        const gradient = this.#buildGradient(paletteInfo.palette);
+
+        this.lastState = {
+            ...paletteInfo,
+            gradient: {
+                ...gradient,
+                phase: this.gradientPhase
+            }
+        };
+
+        return this.lastState;
+    }
+
+    reset() {
+        this.lastUpdateTime = null;
+        this.gradientPhase = 0;
+        return this.update(Date.now(), {});
+    }
+
+    getState() {
+        return this.lastState;
+    }
+
+    /**
+     * Build a normalized palette given the current configuration.
+     */
+    #computeColorState(audioData = {}, reactive = {}) {
+        const mode = this.config.colorMode;
+        const baseHue = this.#computeBaseHue(audioData, reactive);
+        const baseSaturation = this.#computeBaseSaturation(audioData, reactive);
+        const baseIntensity = this.#computeBaseIntensity(audioData, reactive);
+
+        const palette = this.#generatePalette(mode, baseHue, baseSaturation, baseIntensity, audioData, reactive);
+        const primary = palette[0];
+        const accent = palette[Math.min(1, palette.length - 1)];
+
+        const uniforms = {
+            palette: palette.slice(0, 4).map(color => [color.rgb.r, color.rgb.g, color.rgb.b]),
+            size: Math.min(palette.length, 4)
+        };
+
+        return {
+            mode,
+            baseHue,
+            palette,
+            primary,
+            accent,
+            uniforms,
+            saturation: baseSaturation,
+            intensity: baseIntensity,
+            paletteName: this.config.colorPalette
+        };
+    }
+
+    #computeBaseHue(audioData = {}, reactive = {}) {
+        const centroid = audioData?.spectralCentroid ?? 0;
+        const motion = reactive.motion ?? audioData?.spectralFlux ?? 0;
+        const onsetBoost = audioData?.onset ? 25 : 0;
+
+        const reactiveShift = (centroid * 220 + motion * 110 + onsetBoost) * this.config.colorReactivity;
+        return mod360(this.config.baseHue + reactiveShift);
+    }
+
+    #computeBaseSaturation(audioData = {}, reactive = {}) {
+        const sparkle = reactive.sparkle ?? audioData?.bands?.air ?? 0;
+        const flux = audioData?.spectralFlux ?? 0;
+        const adjustment = (sparkle * 0.35 + flux * 0.4) * this.config.colorReactivity;
+        return clamp01(this.config.baseSaturation + adjustment);
+    }
+
+    #computeBaseIntensity(audioData = {}, reactive = {}) {
+        const rms = audioData?.rms ?? 0;
+        const energy = reactive.energy ?? rms;
+        const adjustment = (energy * 0.55) * this.config.colorReactivity;
+        return clamp01(this.config.baseIntensity + adjustment);
+    }
+
+    #generatePalette(mode, baseHue, saturation, intensity, audioData = {}, reactive = {}) {
+        switch (mode) {
+            case 'dual':
+                return this.#buildHueSet([baseHue, baseHue + this.config.dualOffset], saturation, intensity, audioData, reactive);
+            case 'triad':
+                return this.#buildHueSet([
+                    baseHue,
+                    baseHue + this.config.triadSpacing,
+                    baseHue + this.config.triadSpacing * 2
+                ], saturation, intensity, audioData, reactive);
+            case 'complementary':
+                return this.#buildHueSet([baseHue, baseHue + 180], saturation, intensity, audioData, reactive);
+            case 'analogous':
+                return this.#buildHueSet([
+                    baseHue - this.config.analogousSpread,
+                    baseHue,
+                    baseHue + this.config.analogousSpread
+                ], saturation, intensity, audioData, reactive);
+            case 'palette':
+                return this.#buildPaletteMode(saturation, intensity, audioData, reactive);
+            case 'gradient':
+                return this.#buildGradientMode(baseHue, saturation, intensity, audioData, reactive);
+            case 'reactive':
+                return this.#buildReactivePalette(saturation, intensity, audioData, reactive);
+            case 'single':
+            default:
+                return this.#buildHueSet([baseHue], saturation, intensity, audioData, reactive);
+        }
+    }
+
+    #buildHueSet(hues, saturation, intensity, audioData, reactive) {
+        return hues.map(hue => this.#applyAudioModulation(hue, saturation, intensity, audioData, reactive));
+    }
+
+    #applyAudioModulation(h, s, v, audioData = {}, reactive = {}) {
+        const centroid = audioData?.spectralCentroid ?? 0;
+        const sparkle = reactive.sparkle ?? audioData?.bands?.air ?? 0;
+        const energy = reactive.energy ?? audioData?.rms ?? 0;
+
+        const hueShift = centroid * 45 * this.config.colorReactivity;
+        const saturationBoost = sparkle * 0.45 * this.config.colorReactivity;
+        const intensityBoost = energy * 0.55 * this.config.colorReactivity;
+
+        const hue = mod360(h + hueShift);
+        const saturation = clamp01(s + saturationBoost);
+        const intensityValue = clamp01(v + intensityBoost);
+
+        return makeColorObject(hue, saturation, intensityValue);
+    }
+
+    #buildPaletteMode(saturation, intensity, audioData, reactive) {
+        const paletteName = this.config.colorPalette;
+        const key = `${paletteName}|${Math.round(saturation * 100)}|${Math.round(intensity * 100)}`;
+
+        if (this.#paletteCache.has(key)) {
+            const cached = this.#paletteCache.get(key);
+            return clonePalette(cached);
+        }
+
+        const source = PALETTES[paletteName] || PALETTES.synthwave;
+        const palette = source.map(hex => {
+            const { r, g, b } = hexToRgb(hex);
+            const max = Math.max(r, g, b);
+            const min = Math.min(r, g, b);
+            const delta = max - min;
+
+            let hue = 0;
+            if (delta > 0) {
+                if (max === r) {
+                    hue = ((g - b) / delta) % 6;
+                } else if (max === g) {
+                    hue = (b - r) / delta + 2;
+                } else {
+                    hue = (r - g) / delta + 4;
+                }
+            }
+
+            hue = (hue * 60 + 360) % 360;
+            return makeColorObject(hue, saturation, intensity);
+        });
+
+        this.#paletteCache.set(key, palette);
+        return clonePalette(palette).map(color => this.#applyAudioModulation(color.h, color.s, color.v, audioData, reactive));
+    }
+
+    #buildGradientMode(baseHue, saturation, intensity, audioData, reactive) {
+        const hues = [baseHue, baseHue + 60, baseHue + 180];
+        return this.#buildHueSet(hues, saturation, intensity, audioData, reactive);
+    }
+
+    #buildReactivePalette(saturation, intensity, audioData = {}, reactive = {}) {
+        const bass = reactive.bass ?? audioData?.bands?.bass ?? 0;
+        const mid = reactive.mid ?? audioData?.bands?.mid ?? 0;
+        const high = reactive.high ?? audioData?.bands?.high ?? 0;
+
+        const bassHue = 20 + bass * 60;
+        const midHue = 160 + mid * 80;
+        const highHue = 260 + high * 80;
+
+        return this.#buildHueSet([bassHue, midHue, highHue], saturation, intensity, audioData, reactive);
+    }
+
+    #buildGradient(palette) {
+        if (!palette || palette.length === 0) {
+            return {
+                type: this.config.gradientType,
+                css: 'linear-gradient(90deg, #ffffff, #000000)',
+                stops: []
+            };
+        }
+
+        const stops = palette.map((color, index) => ({
+            offset: palette.length === 1 ? 0 : index / (palette.length - 1),
+            color
+        }));
+
+        const stopString = stops
+            .map(({ offset, color }) => `${color.css} ${(offset * 100).toFixed(1)}%`)
+            .join(', ');
+
+        const angle = Math.round(this.gradientPhase * 360);
+
+        switch (this.config.gradientType) {
+            case 'vertical':
+                return {
+                    type: 'vertical',
+                    css: `linear-gradient(180deg, ${stopString})`,
+                    stops
+                };
+            case 'radial':
+                return {
+                    type: 'radial',
+                    css: `radial-gradient(circle, ${stopString})`,
+                    stops
+                };
+            case 'spiral':
+                return {
+                    type: 'spiral',
+                    css: `conic-gradient(from ${angle}deg, ${stopString})`,
+                    stops
+                };
+            case 'wave':
+                return {
+                    type: 'wave',
+                    css: `linear-gradient(${angle}deg, ${stopString})`,
+                    stops
+                };
+            case 'horizontal':
+            default:
+                return {
+                    type: 'horizontal',
+                    css: `linear-gradient(90deg, ${stopString})`,
+                    stops
+                };
+        }
+    }
+}

--- a/src/core/Visualizer.js
+++ b/src/core/Visualizer.js
@@ -5,6 +5,9 @@
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
 
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const lerp = (current, target, factor) => current + (target - current) * factor;
+
 export class IntegratedHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
         this.canvas = document.getElementById(canvasId);
@@ -55,6 +58,21 @@ export class IntegratedHolographicVisualizer {
             rot4dYW: 0.0,
             rot4dZW: 0.0
         };
+
+        this.audioResponse = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hueShift: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+        this.onsetPulse = 0;
         
         // Initialization now happens in ensureCanvasSizedThenInitWebGL after sizing
         // this.init(); // MOVED
@@ -537,12 +555,101 @@ void main() {
             this.mouseIntensity = 0.0;
             return;
         }
-        
+
         this.mouseX = x;
         this.mouseY = y;
         this.mouseIntensity = intensity;
     }
-    
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined' || !window.audioEnabled) {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels() || null;
+        }
+
+        return window.audioReactive || null;
+    }
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    updateAudioResponse(audioState) {
+        const smoothing = 0.18;
+        const target = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hueShift: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.onsetPulse = (this.onsetPulse || 0) * 0.82;
+
+        if (audioState) {
+            const bass = clamp(audioState.bass ?? 0, 0, 1);
+            const mid = clamp(audioState.mid ?? 0, 0, 1);
+            const high = clamp(audioState.high ?? 0, 0, 1);
+            const sparkle = clamp(audioState.sparkle ?? audioState.bands?.air ?? 0, 0, 1);
+            const energy = clamp(audioState.energy ?? audioState.rms ?? 0, 0, 1);
+            const motion = clamp(audioState.motion ?? audioState.spectralFlux ?? 0, 0, 1);
+            const hueShiftNorm = clamp(audioState.hueShift ?? audioState.spectralCentroid ?? 0, 0, 1);
+            const intensityBoost = clamp(audioState.intensity ?? audioState.rms ?? 0, 0, 1);
+
+            if (audioState.onset) {
+                this.onsetPulse = 1;
+            }
+
+            target.gridDensity = (bass * 32) + (motion * 14);
+            target.morph = (motion * 0.9) + (energy * 0.4);
+            target.chaos = (motion * 0.6) + (energy * 0.45);
+            target.speed = (energy * 0.45) + (motion * 0.3);
+            target.hueShift = (hueShiftNorm * 240) + (sparkle * 60);
+            target.intensity = (intensityBoost * 0.6) + (sparkle * 0.4);
+            target.saturation = sparkle * 0.35;
+            target.dimension = (energy * 0.35) + (bass * 0.25);
+            target.rot4dXW = bass * 0.4;
+            target.rot4dYW = mid * 0.3;
+            target.rot4dZW = high * 0.25;
+        }
+
+        target.speed += this.onsetPulse * 0.45;
+
+        this.audioResponse.gridDensity = lerp(this.audioResponse.gridDensity, target.gridDensity, smoothing);
+        this.audioResponse.morph = lerp(this.audioResponse.morph, target.morph, smoothing);
+        this.audioResponse.chaos = lerp(this.audioResponse.chaos, target.chaos, smoothing);
+        this.audioResponse.speed = lerp(this.audioResponse.speed, target.speed, smoothing);
+        this.audioResponse.hueShift = lerp(this.audioResponse.hueShift, target.hueShift, smoothing);
+        this.audioResponse.intensity = lerp(this.audioResponse.intensity, target.intensity, smoothing);
+        this.audioResponse.saturation = lerp(this.audioResponse.saturation, target.saturation, smoothing);
+        this.audioResponse.dimension = lerp(this.audioResponse.dimension, target.dimension, smoothing);
+        this.audioResponse.rot4dXW = lerp(this.audioResponse.rot4dXW, target.rot4dXW, smoothing);
+        this.audioResponse.rot4dYW = lerp(this.audioResponse.rot4dYW, target.rot4dYW, smoothing);
+        this.audioResponse.rot4dZW = lerp(this.audioResponse.rot4dZW, target.rot4dZW, smoothing);
+
+        return this.audioResponse;
+    }
+
     /**
      * Render frame
      */
@@ -591,29 +698,54 @@ void main() {
         this.gl.uniform1f(this.uniforms.time, time);
         this.gl.uniform2f(this.uniforms.mouse, this.mouseX, this.mouseY);
         this.gl.uniform1f(this.uniforms.geometry, this.params.geometry);
-        // 🎵 DIRECT AUDIO REACTIVITY - Simple and works
-        let gridDensity = this.params.gridDensity;
-        let hue = this.params.hue;
-        let intensity = this.params.intensity;
-        
-        if (window.audioEnabled && window.audioReactive) {
-            // Faceted audio mapping: Bass affects grid density, Mid affects hue, High affects intensity
-            gridDensity += window.audioReactive.bass * 30;  // Bass makes patterns denser
-            hue += window.audioReactive.mid * 60;           // Mid frequencies shift colors
-            intensity += window.audioReactive.high * 0.4;   // High frequencies brighten
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+
+        let gridDensity = this.params.gridDensity + audioResponse.gridDensity;
+        let morphFactor = this.params.morphFactor + audioResponse.morph;
+        let chaos = this.params.chaos + audioResponse.chaos;
+        let speed = this.params.speed + audioResponse.speed;
+        let hue = (this.params.hue + audioResponse.hueShift) % 360;
+        let intensity = this.params.intensity + audioResponse.intensity;
+        let saturation = this.params.saturation + audioResponse.saturation;
+        let dimension = this.params.dimension + audioResponse.dimension;
+        let rot4dXW = this.params.rot4dXW + audioResponse.rot4dXW;
+        let rot4dYW = this.params.rot4dYW + audioResponse.rot4dYW;
+        let rot4dZW = this.params.rot4dZW + audioResponse.rot4dZW;
+
+        if (colorState?.primary) {
+            hue = colorState.primary.h;
+            saturation = clamp(Math.max(saturation, colorState.primary.s), 0, 1);
+            intensity = clamp(intensity + (colorState.primary.v - 0.5) * 0.8, 0, 2);
         }
-        
-        this.gl.uniform1f(this.uniforms.gridDensity, Math.min(100, gridDensity));
-        this.gl.uniform1f(this.uniforms.morphFactor, this.params.morphFactor);
-        this.gl.uniform1f(this.uniforms.chaos, this.params.chaos);
-        this.gl.uniform1f(this.uniforms.speed, this.params.speed);
-        this.gl.uniform1f(this.uniforms.hue, hue % 360);
+
+        if (colorState?.accent && colorState.accent !== colorState.primary) {
+            saturation = clamp(Math.max(saturation, colorState.accent.s * 0.9), 0, 1);
+        }
+
+        gridDensity = clamp(gridDensity, 0, 120);
+        morphFactor = clamp(morphFactor, 0, 2.5);
+        chaos = clamp(chaos, 0, 1.4);
+        speed = clamp(speed, 0, 3.5);
+        intensity = clamp(intensity, 0, 1.4);
+        saturation = clamp(saturation, 0, 1);
+        dimension = clamp(dimension, 0, 6);
+        rot4dXW = clamp(rot4dXW, -4, 4);
+        rot4dYW = clamp(rot4dYW, -4, 4);
+        rot4dZW = clamp(rot4dZW, -4, 4);
+
+        this.gl.uniform1f(this.uniforms.gridDensity, gridDensity);
+        this.gl.uniform1f(this.uniforms.morphFactor, morphFactor);
+        this.gl.uniform1f(this.uniforms.chaos, chaos);
+        this.gl.uniform1f(this.uniforms.speed, speed);
+        this.gl.uniform1f(this.uniforms.hue, hue);
         this.gl.uniform1f(this.uniforms.intensity, Math.min(1, intensity));
-        this.gl.uniform1f(this.uniforms.saturation, this.params.saturation);
-        this.gl.uniform1f(this.uniforms.dimension, this.params.dimension);
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.params.rot4dXW);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.params.rot4dYW);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.params.rot4dZW);
+        this.gl.uniform1f(this.uniforms.saturation, saturation);
+        this.gl.uniform1f(this.uniforms.dimension, dimension);
+        this.gl.uniform1f(this.uniforms.rot4dXW, rot4dXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, rot4dYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, rot4dZW);
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.roleIntensity, roleIntensities[this.role] || 1.0);

--- a/src/quantum/QuantumVisualizer.js
+++ b/src/quantum/QuantumVisualizer.js
@@ -6,6 +6,9 @@
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
 
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const lerp = (current, target, factor) => current + (target - current) * factor;
+
 export class QuantumHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
         this.canvas = document.getElementById(canvasId);
@@ -73,6 +76,21 @@ export class QuantumHolographicVisualizer {
         this.setGeometryCatalog(initialCatalog);
 
         this.init();
+
+        this.audioResponse = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hue: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+        this.onsetPulse = 0;
     }
 
     normalizeGeometryIndex(index) {
@@ -968,7 +986,97 @@ void main() {
         this.mouseY = y;
         this.mouseIntensity = intensity;
     }
-    
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined' || !window.audioEnabled) {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels() || null;
+        }
+
+        return window.audioReactive || null;
+    }
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    updateAudioResponse(audioState) {
+        const smoothing = 0.16;
+        const target = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hue: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.onsetPulse = (this.onsetPulse || 0) * 0.85;
+
+        if (audioState) {
+            const bass = clamp(audioState.bass ?? 0, 0, 1);
+            const mid = clamp(audioState.mid ?? 0, 0, 1);
+            const high = clamp(audioState.high ?? 0, 0, 1);
+            const sparkle = clamp(audioState.sparkle ?? audioState.bands?.air ?? 0, 0, 1);
+            const energy = clamp(audioState.energy ?? audioState.rms ?? 0, 0, 1);
+            const motion = clamp(audioState.motion ?? audioState.spectralFlux ?? 0, 0, 1);
+            const centroid = clamp(audioState.hueShift ?? audioState.spectralCentroid ?? 0, 0, 1);
+            const rolloff = clamp(audioState.spectralRolloff ?? 0, 0, 1);
+            const intensityBoost = clamp(audioState.intensity ?? audioState.rms ?? 0, 0, 1);
+
+            if (audioState.onset) {
+                this.onsetPulse = 1;
+            }
+
+            target.gridDensity = clamp((bass * 45) + (motion * 18), 0, 75);
+            target.morph = clamp((mid * 1.3) + (sparkle * 0.6) + (motion * 0.5), 0, 2.5);
+            target.chaos = clamp((energy * 0.7) + (motion * 0.4) + (high * 0.25), 0, 1.4);
+            target.speed = clamp((energy * 0.65) + (motion * 0.45), 0, 3.2);
+            target.hue = clamp((centroid * 0.6) + (sparkle * 0.3), 0, 1);
+            target.intensity = clamp((intensityBoost * 0.6) + (energy * 0.3), 0, 1.4);
+            target.saturation = clamp(sparkle * 0.4, 0, 0.6);
+            target.dimension = clamp((rolloff * 2.0) + (bass * 0.35), 0, 3.2);
+            target.rot4dXW = clamp(bass * 0.35, 0, 1.5);
+            target.rot4dYW = clamp(mid * 0.25, 0, 1.2);
+            target.rot4dZW = clamp(high * 0.2, 0, 1.0);
+        }
+
+        target.speed += this.onsetPulse * 0.55;
+
+        this.audioResponse.gridDensity = lerp(this.audioResponse.gridDensity, target.gridDensity, smoothing);
+        this.audioResponse.morph = lerp(this.audioResponse.morph, target.morph, smoothing);
+        this.audioResponse.chaos = lerp(this.audioResponse.chaos, target.chaos, smoothing);
+        this.audioResponse.speed = lerp(this.audioResponse.speed, target.speed, smoothing);
+        this.audioResponse.hue = lerp(this.audioResponse.hue, target.hue, smoothing);
+        this.audioResponse.intensity = lerp(this.audioResponse.intensity, target.intensity, smoothing);
+        this.audioResponse.saturation = lerp(this.audioResponse.saturation, target.saturation, smoothing);
+        this.audioResponse.dimension = lerp(this.audioResponse.dimension, target.dimension, smoothing);
+        this.audioResponse.rot4dXW = lerp(this.audioResponse.rot4dXW, target.rot4dXW, smoothing);
+        this.audioResponse.rot4dYW = lerp(this.audioResponse.rot4dYW, target.rot4dYW, smoothing);
+        this.audioResponse.rot4dZW = lerp(this.audioResponse.rot4dZW, target.rot4dZW, smoothing);
+
+        return this.audioResponse;
+    }
+
     /**
      * Render frame
      */
@@ -1012,37 +1120,51 @@ void main() {
         this.gl.uniform1f(this.uniforms.time, time);
         this.gl.uniform2f(this.uniforms.mouse, this.mouseX, this.mouseY);
         this.gl.uniform1f(this.uniforms.geometry, this.params.geometry);
-        // 🎵 QUANTUM AUDIO REACTIVITY - Direct and effective
-        let gridDensity = this.params.gridDensity;
-        let morphFactor = this.params.morphFactor;
-        let hue = this.params.hue;
-        let chaos = this.params.chaos;
-        
-        if (window.audioEnabled && window.audioReactive) {
-            // Quantum audio mapping: Enhanced complex lattice response
-            gridDensity += window.audioReactive.bass * 40;      // Bass creates dense lattice structures
-            morphFactor += window.audioReactive.mid * 1.2;      // Mid frequencies morph the geometry
-            hue += window.audioReactive.high * 120;             // High frequencies shift colors dramatically
-            chaos += window.audioReactive.energy * 0.6;         // Overall energy adds chaos/complexity
-            
-            // Debug logging every 10 seconds to verify audio reactivity is working
-            if (Date.now() % 10000 < 16) {
-                console.log(`🌌 Quantum audio reactivity: Density+${(window.audioReactive.bass * 40).toFixed(1)} Morph+${(window.audioReactive.mid * 1.2).toFixed(2)} Hue+${(window.audioReactive.high * 120).toFixed(1)} Chaos+${(window.audioReactive.energy * 0.6).toFixed(2)}`);
-            }
+
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+
+        let gridDensity = this.params.gridDensity + audioResponse.gridDensity;
+        let morphFactor = this.params.morphFactor + audioResponse.morph;
+        let chaos = this.params.chaos + audioResponse.chaos;
+        let speed = this.params.speed + audioResponse.speed;
+
+        gridDensity = clamp(gridDensity, 0, 120);
+        morphFactor = clamp(morphFactor, 0, 3);
+        chaos = clamp(chaos, 0, 1.5);
+        speed = clamp(speed, 0, 4);
+
+        const hueBase = (this.params.hue % 360) / 360.0;
+        let hue = (hueBase + audioResponse.hue) % 1;
+        let intensity = clamp(this.params.intensity + audioResponse.intensity, 0, 2);
+        let saturation = clamp(this.params.saturation + audioResponse.saturation, 0, 1);
+        const dimension = clamp(this.params.dimension + audioResponse.dimension, 0, 6);
+        const rot4dXW = clamp(this.params.rot4dXW + audioResponse.rot4dXW, -4, 4);
+        const rot4dYW = clamp(this.params.rot4dYW + audioResponse.rot4dYW, -4, 4);
+        const rot4dZW = clamp(this.params.rot4dZW + audioResponse.rot4dZW, -4, 4);
+
+        if (colorState?.primary) {
+            hue = clamp((hue * 0.4) + (colorState.primary.v * 0.6), 0, 1);
+            saturation = clamp(Math.max(saturation, colorState.primary.s), 0, 1);
+            intensity = clamp(Math.max(intensity, colorState.primary.v * 1.4), 0, 2);
         }
-        
-        this.gl.uniform1f(this.uniforms.gridDensity, Math.min(100, gridDensity));
-        this.gl.uniform1f(this.uniforms.morphFactor, Math.min(2, morphFactor));
-        this.gl.uniform1f(this.uniforms.chaos, Math.min(1, chaos));
-        this.gl.uniform1f(this.uniforms.speed, this.params.speed);
-        // Hue now used as global intensity modifier for extreme layer system
-        this.gl.uniform1f(this.uniforms.hue, (hue % 360) / 360.0); // Normalize to 0-1
-        this.gl.uniform1f(this.uniforms.intensity, this.params.intensity);
-        this.gl.uniform1f(this.uniforms.saturation, this.params.saturation);
-        this.gl.uniform1f(this.uniforms.dimension, this.params.dimension);
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.params.rot4dXW);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.params.rot4dYW);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.params.rot4dZW);
+
+        if (colorState?.accent && colorState.accent !== colorState.primary) {
+            saturation = clamp(Math.max(saturation, colorState.accent.s * 0.85), 0, 1);
+        }
+
+        this.gl.uniform1f(this.uniforms.gridDensity, gridDensity);
+        this.gl.uniform1f(this.uniforms.morphFactor, morphFactor);
+        this.gl.uniform1f(this.uniforms.chaos, chaos);
+        this.gl.uniform1f(this.uniforms.speed, speed);
+        this.gl.uniform1f(this.uniforms.hue, hue);
+        this.gl.uniform1f(this.uniforms.intensity, Math.min(2, intensity));
+        this.gl.uniform1f(this.uniforms.saturation, saturation);
+        this.gl.uniform1f(this.uniforms.dimension, dimension);
+        this.gl.uniform1f(this.uniforms.rot4dXW, rot4dXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, rot4dYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, rot4dZW);
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.roleIntensity, roleIntensities[this.role] || 1.0);


### PR DESCRIPTION
## Summary
- add a ColorSystem module that generates palettes, gradients, and audio-driven hue/intensity data
- wire the advanced audio engine to publish `window.colorState` and pass color context into subscribed listeners
- let the faceted, quantum, and holographic visualizers blend the shared color state into their hue, saturation, and intensity math
- update the unified refactor plan to record the color system milestone and outline remaining shader/UI work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e8cb2e8c8329811e9f0b4c6836c9