### PR TITLE
Add continuity analytics to reactive inspector

### DIFF
--- a/4D-ROTATION-GUIDE.md
+++ b/4D-ROTATION-GUIDE.md
@@ -1,0 +1,397 @@
+# 4D Rotation Choreography Guide
+
+## 🌀 Understanding 4D Rotations
+
+The VIB34D system uses **true 4D mathematics** to create impossible geometry. This isn't fake - it's actual 4D rotation projected to 3D space.
+
+---
+
+## 📐 The Three Rotation Planes
+
+In 4D space, there are **6 possible rotation planes**, but we expose the 3 most visually interesting:
+
+### **rot4dXW** - X-W Plane Rotation
+- Rotates the **horizontal axis** through the **4th dimension**
+- Visual effect: Shapes spin left/right while morphing through impossible forms
+- Range: `-2` to `2` (radians)
+- Musical use: **Verse foundations**, steady left-right morphing
+
+### **rot4dYW** - Y-W Plane Rotation
+- Rotates the **vertical axis** through the **4th dimension**
+- Visual effect: Shapes spin up/down while transforming
+- Range: `-2` to `2` (radians)
+- Musical use: **Builds**, adding vertical energy
+
+### **rot4dZW** - Z-W Plane Rotation
+- Rotates the **depth axis** through the **4th dimension**
+- Visual effect: Shapes spin forward/backward through hyperdimensional space
+- Range: `-2` to `2` (radians)
+- Musical use: **Drops**, adding the third dimension of rotation
+
+---
+
+## 🎵 Musical Choreography with 4D Rotations
+
+### **Intro/Breakdown (Minimal)**
+```json
+{
+  "rot4dXW": 0.2,
+  "rot4dYW": 0,
+  "rot4dZW": 0,
+  "gridDensity": 10,
+  "speed": 0.4
+}
+```
+**Effect**: Slow, single-plane rotation. Clean and minimal.
+
+---
+
+### **Verse (Steady Foundation)**
+```json
+{
+  "rot4dXW": 0.4,
+  "rot4dYW": 0.2,
+  "rot4dZW": 0,
+  "gridDensity": 25,
+  "speed": 0.5
+}
+```
+**Effect**: Two-plane rotation creates steady morphing. Foundation for the song.
+
+---
+
+### **Build (Progressive Energy)**
+```json
+{
+  "sweeps": {
+    "rot4dXW": [0.4, 1.0],
+    "rot4dYW": [0.2, 0.7],
+    "rot4dZW": [0, 0.4],
+    "gridDensity": [25, 60],
+    "chaos": [0.2, 0.6]
+  },
+  "speed": 0.6
+}
+```
+**Effect**: All three rotation planes engage progressively. Tension builds.
+
+---
+
+### **Drop (Full 4D Showcase)**
+```json
+{
+  "rot4dXW": 1.2,
+  "rot4dYW": 0.9,
+  "rot4dZW": 0.7,
+  "gridDensity": 95,
+  "morphFactor": 1.8,
+  "chaos": 0.8,
+  "speed": 0.4,
+  "geometry": 5  // Fractal
+}
+```
+**Effect**: **ALL THREE PLANES** rotating at high speeds creates impossible 4D morphing. High density creates fractal detail. SLOW speed lets you SEE the complexity.
+
+---
+
+### **Counter-Rotation (Breakdown)**
+```json
+{
+  "rot4dXW": -0.2,
+  "rot4dYW": 0.3,
+  "rot4dZW": -0.1,
+  "gridDensity": 12,
+  "speed": 0.25
+}
+```
+**Effect**: Negative rotations = reverse spin. Creates otherworldly counter-motion.
+
+---
+
+## 🔁 Rotation Dynamics - Polyrhythmic Motion
+
+Instead of **static rotation**, use **oscillating rotation**:
+
+```json
+{
+  "rotDynamics": {
+    "xw": {
+      "base": 0.5,    // Center value
+      "freq": 0.5,    // Oscillation frequency (Hz)
+      "amp": 0.8      // Oscillation amplitude
+    },
+    "yw": {
+      "base": 0.3,
+      "freq": 0.33,   // 3:2 polyrhythm with xw
+      "amp": 0.5
+    },
+    "zw": {
+      "base": -0.2,
+      "freq": 0.25,   // 2:1 polyrhythm
+      "amp": 0.6
+    }
+  }
+}
+```
+
+**What happens**:
+- `xw` oscillates: `0.5 + sin(t * 0.5 * 2π) * 0.8`
+- Range: `-0.3` to `1.3` (0.5 ± 0.8)
+- Each plane oscillates at different rates = **polyrhythmic 4D motion**
+- Visual effect: Complex, never-repeating 4D choreography
+
+**Frequency guide**:
+- `0.5 Hz` = 2 seconds per cycle = 120 BPM half-notes
+- `0.33 Hz` = 3 seconds per cycle = 120 BPM dotted half-notes (3:2 polyrhythm)
+- `0.25 Hz` = 4 seconds per cycle = 120 BPM whole notes
+- `0.66 Hz` = 1.5 seconds per cycle = 120 BPM quarter-notes (double-time)
+
+---
+
+## 📊 Grid Density - Fractal Detail Control
+
+The shader does this:
+```glsl
+vec4 pos = fract(p * u_gridDensity * 0.08);
+```
+
+**Higher density = more repetitions = fractal detail!**
+
+### **Density Guide**
+
+| Density | Visual Effect | Musical Use |
+|---------|---------------|-------------|
+| 4-8 | Minimal, wide spacing | Silent intros |
+| 10-15 | Clean patterns | Breakdowns, ambient |
+| 20-30 | Moderate detail | Verses, foundations |
+| 40-60 | Dense fractals | Choruses, pre-drops |
+| 70-85 | Intense detail | Build climaxes |
+| 90-100 | **FRACTAL EXPLOSION** | **DROPS** |
+
+---
+
+## 🎨 Geometry Types & 4D Rotation
+
+Different geometries react to 4D rotation differently:
+
+| Geometry | ID | Best For | 4D Rotation Visibility |
+|----------|-----|----------|------------------------|
+| Tetrahedron | 0 | Intros, minimal | Low (simple) |
+| **Hypercube** | **1** | **Drops** | **⭐ BEST** (cubic lattice shows 4D clearly) |
+| Sphere | 2 | Breakdowns | Medium (concentric) |
+| Torus | 3 | Builds | High (donut warping) |
+| Klein Bottle | 4 | Experimental | Very High (impossible topology) |
+| **Fractal** | **5** | **Drops** | **⭐ MAXIMUM** (recursive patterns) |
+| Wave | 6 | Rhythmic sections | Medium (interference) |
+| Crystal | 7 | Sharp drops | High (prismatic) |
+
+**For drops**: Use **Fractal (5)** or **Hypercube (1)** with high rotation values.
+
+---
+
+## 💡 Example: Complete Drop Sequence
+
+```json
+{
+  "name": "DROP 1 - 4D Fractal Explosion",
+  "time": 60,
+  "dur": 16,
+  "sys": "faceted",
+  "par": {
+    "geometry": 5,           // FRACTAL
+    "rot4dXW": 1.2,          // High X-W rotation
+    "rot4dYW": 0.9,          // High Y-W rotation
+    "rot4dZW": 0.7,          // High Z-W rotation
+    "gridDensity": 95,       // MAXIMUM fractal detail
+    "morphFactor": 1.8,      // Heavy shape morphing
+    "chaos": 0.8,            // Controlled chaos
+    "speed": 0.4,            // SLOW to see rotation
+    "hue": 280,              // Purple
+    "intensity": 0.7,
+    "saturation": 0.9
+  },
+  "densityReact": 5,         // Small (already at 95)
+  "morphReact": 0.2,
+  "chaosReact": 0.15,
+  "intensityReact": 0.25,
+  "rotDynamics": {
+    "xw": {"base": 1.2, "freq": 0.5, "amp": 0.4},
+    "yw": {"base": 0.9, "freq": 0.33, "amp": 0.5},
+    "zw": {"base": 0.7, "freq": 0.4, "amp": 0.3}
+  },
+  "sweeps": {
+    "hue": [280, 320],       // Purple → Pink
+    "chaos": [0.7, 0.9]      // Chaos builds
+  }
+}
+```
+
+**What you'll see**:
+1. **Fractal geometry** with 95 density = intricate recursive patterns
+2. **Three-plane 4D rotation** at 1.2/0.9/0.7 = impossible morphing
+3. **Polyrhythmic oscillation** = rotation speeds pulse at different rates
+4. **Color sweep** = purple gradually shifts to pink
+5. **Chaos builds** = 0.7 → 0.9 over 16 seconds
+6. **Slow speed** (0.4) = you can SEE all the complexity
+
+---
+
+## 🎼 Complete Song Structure Example
+
+```json
+[
+  {
+    "name": "Intro",
+    "time": 0,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 0,
+      "rot4dXW": 0.2, "rot4dYW": 0, "rot4dZW": 0,
+      "gridDensity": 10,
+      "speed": 0.4,
+      "hue": 200
+    }
+  },
+  {
+    "name": "Verse 1",
+    "time": 16,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 1,
+      "rot4dXW": 0.4, "rot4dYW": 0.2, "rot4dZW": 0,
+      "gridDensity": 25,
+      "speed": 0.5,
+      "hue": 210
+    }
+  },
+  {
+    "name": "Build 1",
+    "time": 48,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 1,
+      "rot4dXW": 0.6, "rot4dYW": 0.4, "rot4dZW": 0.2,
+      "gridDensity": 40,
+      "speed": 0.7,
+      "hue": 240
+    },
+    "sweeps": {
+      "rot4dXW": [0.6, 1.0],
+      "rot4dYW": [0.4, 0.7],
+      "rot4dZW": [0.2, 0.5],
+      "gridDensity": [40, 70],
+      "chaos": [0.2, 0.6]
+    }
+  },
+  {
+    "name": "DROP 1 - 4D Fractal Explosion",
+    "time": 64,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 5,
+      "rot4dXW": 1.2, "rot4dYW": 0.9, "rot4dZW": 0.7,
+      "gridDensity": 95,
+      "morphFactor": 1.8,
+      "chaos": 0.8,
+      "speed": 0.4,
+      "hue": 280,
+      "intensity": 0.7
+    },
+    "rotDynamics": {
+      "xw": {"base": 1.2, "freq": 0.5, "amp": 0.4},
+      "yw": {"base": 0.9, "freq": 0.33, "amp": 0.5},
+      "zw": {"base": 0.7, "freq": 0.4, "amp": 0.3}
+    }
+  },
+  {
+    "name": "Breakdown",
+    "time": 96,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 2,
+      "rot4dXW": -0.1, "rot4dYW": 0.2, "rot4dZW": -0.05,
+      "gridDensity": 12,
+      "speed": 0.25,
+      "hue": 200
+    }
+  },
+  {
+    "name": "Verse 2",
+    "time": 112,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 1,
+      "rot4dXW": 0.45, "rot4dYW": 0.25, "rot4dZW": 0,
+      "gridDensity": 28,
+      "speed": 0.55,
+      "hue": 215
+    }
+  },
+  {
+    "name": "Build 2",
+    "time": 144,
+    "dur": 16,
+    "sys": "faceted",
+    "par": {
+      "geometry": 5,
+      "rot4dXW": 0.7, "rot4dYW": 0.5, "rot4dZW": 0.3,
+      "gridDensity": 50,
+      "speed": 0.8,
+      "hue": 260
+    },
+    "sweeps": {
+      "rot4dXW": [0.7, 1.5],
+      "rot4dYW": [0.5, 1.2],
+      "rot4dZW": [0.3, 1.0],
+      "gridDensity": [50, 100],
+      "chaos": [0.3, 0.9]
+    }
+  },
+  {
+    "name": "FINAL DROP - Maximum 4D",
+    "time": 160,
+    "dur": 32,
+    "sys": "faceted",
+    "par": {
+      "geometry": 5,
+      "rot4dXW": 1.5, "rot4dYW": 1.2, "rot4dZW": 1.0,
+      "gridDensity": 100,
+      "morphFactor": 2.0,
+      "chaos": 0.9,
+      "speed": 0.35,
+      "hue": 300,
+      "intensity": 0.8
+    },
+    "rotDynamics": {
+      "xw": {"base": 1.5, "freq": 0.66, "amp": 0.5},
+      "yw": {"base": 1.2, "freq": 0.5, "amp": 0.6},
+      "zw": {"base": 1.0, "freq": 0.4, "amp": 0.4}
+    }
+  }
+]
+```
+
+---
+
+## 🔑 Key Takeaways
+
+1. **4D rotations are the star** - Use all three planes (XW, YW, ZW) for drops
+2. **Slow speed during complex rotation** - speed: 0.3-0.5 lets you SEE the 4D math
+3. **High grid density = fractal detail** - 90-100 for drops
+4. **Polyrhythmic motion** - rotDynamics with different frequencies per plane
+5. **Geometry matters** - Fractal (5) or Hypercube (1) show 4D rotation best
+6. **Progressive builds** - Use sweeps to gradually increase rotation
+7. **Counter-rotations** - Negative values create otherworldly breakdown effects
+8. **Musical repetition** - Verse 1 ≈ Verse 2, but each drop is MORE extreme
+
+---
+
+**The AI now understands all of this and will generate sequences that SHOWCASE the 4D mathematics instead of random parameter chaos!**
+
+Test it with: https://domusgpt.github.io/vib34d-music-video-choreographer-alternative/index-ULTIMATE-V2.html

--- a/V3-PLAN.md
+++ b/V3-PLAN.md
@@ -1,0 +1,428 @@
+# V3 System - Complete Rebuild Plan
+
+## 🔍 What I Found (Deep Analysis)
+
+### **Rotation Parameters - ALL WORKING**
+Checked all 3 systems:
+- ✅ **Faceted**: rot4dXW/YW/ZW with correct 4D rotation matrices
+- ✅ **Quantum**: rot4dXW/YW/ZW with correct 4D rotation matrices
+- ⚠️ **Holographic**: rot4dXW/YW/ZW BUT adds `+ time * 0.2` automatically
+
+**Issue**: Holographic system auto-rotates, making manual control harder to perceive
+
+### **What's Actually Broken**
+1. **Audio reactivity is TOO SIMPLE** - just 3 frequency bands (bass/mid/high)
+2. **No temporal smoothing** - values jump instantly, can't see rhythm
+3. **No ADSR envelopes** - parameters don't have attack/decay/release
+4. **No onset detection** - can't detect kicks/snares/transients
+5. **No spectral features** - missing brightness, flux, rolloff
+6. **Limited parameter mapping** - only additive, no curves/thresholds
+
+---
+
+## 🎯 V3 System Architecture
+
+### **1. Advanced Audio Analysis Engine**
+
+```javascript
+class AudioAnalyzer {
+    constructor(audioContext) {
+        this.ctx = audioContext;
+        this.analyser = this.ctx.createAnalyser();
+        this.analyser.fftSize = 4096; // Higher resolution
+
+        // Multi-band analysis
+        this.bands = {
+            subBass: { low: 20, high: 60 },
+            bass: { low: 60, high: 250 },
+            lowMid: { low: 250, high: 500 },
+            mid: { low: 500, high: 2000 },
+            highMid: { low: 2000, high: 4000 },
+            high: { low: 4000, high: 8000 },
+            air: { low: 8000, high: 20000 }
+        };
+
+        // Feature extraction
+        this.features = {
+            spectralCentroid: 0,
+            spectralRolloff: 0,
+            spectralFlux: 0,
+            rms: 0,
+            zcr: 0
+        };
+
+        // Onset detection
+        this.onsetThreshold = 1.5;
+        this.lastOnsetTime = 0;
+        this.onsetHistory = [];
+
+        // Beat tracking
+        this.bpm = 120;
+        this.beatPhase = 0;
+        this.beatConfidence = 0;
+    }
+
+    analyze() {
+        const freqData = new Uint8Array(this.analyser.frequencyBinCount);
+        const timeData = new Uint8Array(this.analyser.fftSize);
+
+        this.analyser.getByteFrequencyData(freqData);
+        this.analyser.getByteTimeDomainData(timeData);
+
+        return {
+            bands: this.analyzeBands(freqData),
+            spectralCentroid: this.calcSpectralCentroid(freqData),
+            spectralFlux: this.calcSpectralFlux(freqData),
+            onset: this.detectOnset(freqData),
+            beat: this.detectBeat(),
+            rms: this.calcRMS(timeData)
+        };
+    }
+
+    calcSpectralCentroid(freqData) {
+        let weightedSum = 0;
+        let sum = 0;
+
+        for (let i = 0; i < freqData.length; i++) {
+            weightedSum += i * freqData[i];
+            sum += freqData[i];
+        }
+
+        return sum > 0 ? weightedSum / sum : 0;
+    }
+
+    detectOnset(freqData) {
+        const flux = this.calcSpectralFlux(freqData);
+        const now = Date.now();
+
+        if (flux > this.onsetThreshold && now - this.lastOnsetTime > 100) {
+            this.lastOnsetTime = now;
+            this.onsetHistory.push(now);
+            return { detected: true, strength: flux };
+        }
+
+        return { detected: false, strength: flux };
+    }
+}
+```
+
+### **2. ADSR Envelope System**
+
+```javascript
+class ADSREnvelope {
+    constructor(attackMs, decayMs, sustain, releaseMs) {
+        this.attack = attackMs;
+        this.decay = decayMs;
+        this.sustain = sustain;
+        this.release = releaseMs;
+
+        this.state = 'idle'; // idle, attack, decay, sustain, release
+        this.currentValue = 0;
+        this.targetValue = 0;
+        this.startTime = 0;
+        this.startValue = 0;
+    }
+
+    trigger(value) {
+        this.targetValue = value;
+        this.startValue = this.currentValue;
+        this.startTime = Date.now();
+        this.state = 'attack';
+    }
+
+    release() {
+        this.startValue = this.currentValue;
+        this.startTime = Date.now();
+        this.state = 'release';
+    }
+
+    update() {
+        const now = Date.now();
+        const elapsed = now - this.startTime;
+
+        switch (this.state) {
+            case 'attack':
+                if (elapsed < this.attack) {
+                    const progress = elapsed / this.attack;
+                    this.currentValue = this.startValue + (this.targetValue - this.startValue) * progress;
+                } else {
+                    this.currentValue = this.targetValue;
+                    this.state = 'decay';
+                    this.startTime = now;
+                    this.startValue = this.targetValue;
+                }
+                break;
+
+            case 'decay':
+                if (elapsed < this.decay) {
+                    const progress = elapsed / this.decay;
+                    this.currentValue = this.targetValue + (this.targetValue * this.sustain - this.targetValue) * progress;
+                } else {
+                    this.currentValue = this.targetValue * this.sustain;
+                    this.state = 'sustain';
+                }
+                break;
+
+            case 'sustain':
+                // Hold at sustain level
+                break;
+
+            case 'release':
+                if (elapsed < this.release) {
+                    const progress = elapsed / this.release;
+                    this.currentValue = this.startValue * (1 - progress);
+                } else {
+                    this.currentValue = 0;
+                    this.state = 'idle';
+                }
+                break;
+        }
+
+        return this.currentValue;
+    }
+}
+```
+
+### **3. Parameter Mapping Engine**
+
+```javascript
+class ParameterMapper {
+    constructor() {
+        this.mappings = {
+            // Rotation mappings
+            rot4dXW: {
+                source: 'bass',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(200, 500, 0.6, 1000),
+                smoothing: 0.8
+            },
+            rot4dYW: {
+                source: 'mid',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(150, 400, 0.7, 800),
+                smoothing: 0.7
+            },
+            rot4dZW: {
+                source: 'high',
+                curve: 'logarithmic',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(100, 300, 0.8, 600),
+                smoothing: 0.6
+            },
+
+            // Density mapping
+            gridDensity: {
+                source: 'spectralCentroid',
+                curve: 's-curve',
+                range: [10, 100],
+                envelope: new ADSREnvelope(300, 600, 0.5, 1200),
+                threshold: 0.2
+            },
+
+            // Hue mapping
+            hue: {
+                source: 'spectralRolloff',
+                curve: 'linear',
+                range: [0, 360],
+                smoothing: 0.9 // Very smooth color changes
+            },
+
+            // Chaos mapping (onsets)
+            chaos: {
+                source: 'onset',
+                curve: 'threshold',
+                range: [0.2, 0.9],
+                envelope: new ADSREnvelope(50, 200, 0.3, 500),
+                threshold: 0.5
+            }
+        };
+
+        this.smoothedValues = {};
+    }
+
+    map(paramName, audioFeatures) {
+        const mapping = this.mappings[paramName];
+        if (!mapping) return null;
+
+        // Get source value
+        let value = audioFeatures[mapping.source] || 0;
+
+        // Apply threshold
+        if (mapping.threshold && value < mapping.threshold) {
+            value = 0;
+        }
+
+        // Apply curve
+        value = this.applyCurve(value, mapping.curve);
+
+        // Apply envelope
+        if (mapping.envelope) {
+            if (value > (this.smoothedValues[paramName] || 0)) {
+                mapping.envelope.trigger(value);
+            } else if (value < 0.1) {
+                mapping.envelope.release();
+            }
+            value = mapping.envelope.update();
+        }
+
+        // Apply smoothing
+        if (mapping.smoothing) {
+            const prev = this.smoothedValues[paramName] || value;
+            value = prev * mapping.smoothing + value * (1 - mapping.smoothing);
+            this.smoothedValues[paramName] = value;
+        }
+
+        // Map to range
+        const [min, max] = mapping.range;
+        value = min + value * (max - min);
+
+        return value;
+    }
+
+    applyCurve(value, curve) {
+        switch (curve) {
+            case 'linear':
+                return value;
+            case 'exponential':
+                return Math.pow(value, 2);
+            case 'logarithmic':
+                return Math.log(1 + value * 9) / Math.log(10);
+            case 's-curve':
+                return 1 / (1 + Math.exp(-10 * (value - 0.5)));
+            case 'threshold':
+                return value > 0.5 ? 1 : 0;
+            default:
+                return value;
+        }
+    }
+}
+```
+
+### **4. Sequence System with Advanced Mapping**
+
+```json
+{
+  "name": "DROP 1 - Spectral Explosion",
+  "time": 60,
+  "dur": 32,
+  "sys": "faceted",
+
+  "baseParams": {
+    "geometry": 5,
+    "speed": 0.4,
+    "morphFactor": 1.5
+  },
+
+  "audioMappings": {
+    "rot4dXW": {
+      "source": "bass",
+      "curve": "exponential",
+      "range": [0.5, 1.8],
+      "attack": 100,
+      "decay": 300,
+      "sustain": 0.7,
+      "release": 800
+    },
+    "rot4dYW": {
+      "source": "spectralCentroid",
+      "curve": "s-curve",
+      "range": [0.3, 1.5],
+      "attack": 150,
+      "release": 600
+    },
+    "gridDensity": {
+      "source": "spectralFlux",
+      "curve": "exponential",
+      "range": [60, 100],
+      "threshold": 0.3,
+      "attack": 200,
+      "release": 1000
+    },
+    "hue": {
+      "source": "beat",
+      "curve": "step",
+      "values": [280, 300, 320, 340],
+      "smoothing": 0.9
+    },
+    "chaos": {
+      "source": "onset",
+      "curve": "threshold",
+      "range": [0.5, 0.9],
+      "attack": 50,
+      "release": 400
+    }
+  },
+
+  "sweeps": {
+    "morphFactor": [1.5, 2.0],
+    "intensity": [0.6, 0.9]
+  }
+}
+```
+
+---
+
+## 🎵 Expected Results
+
+### **Drops**:
+- **Bass hits trigger rot4dXW** with 100ms attack, 300ms decay
+- **Spectral brightness controls density** (bright = high density)
+- **Onsets trigger chaos spikes** that decay over 400ms
+- **Beat-synced hue changes** with smooth transitions
+- **Everything feels MUSICAL** not random
+
+### **Builds**:
+- **Progressive parameter sweeps** over duration
+- **Spectral centroid increases** = brighter colors, more density
+- **Attack times shorten** = more responsive
+- **Multiple layers reacting differently** to different features
+
+### **Breakdowns**:
+- **Long release times** (2000ms+) = smooth fadeouts
+- **Low spectral centroid** = darker colors, less density
+- **Minimal onset detection** = calm, flowing
+
+---
+
+## 📊 Parameter Mappings Table
+
+| Parameter | Audio Source | Curve | Attack | Release | Musical Effect |
+|-----------|-------------|-------|--------|---------|----------------|
+| rot4dXW | Bass | Exponential | 100ms | 800ms | Punchy rotation on kicks |
+| rot4dYW | Spectral Centroid | S-curve | 150ms | 600ms | Brightness = rotation |
+| rot4dZW | High | Logarithmic | 100ms | 600ms | Hi-hats add Z rotation |
+| gridDensity | Spectral Flux | Exponential | 200ms | 1000ms | Change = more detail |
+| hue | Beat Phase | Step | - | - | Color cycles with beat |
+| chaos | Onset | Threshold | 50ms | 400ms | Hits = chaos spikes |
+| morphFactor | Mid | Linear | 300ms | 1200ms | Smooth shape changes |
+| intensity | RMS | Exponential | 100ms | 500ms | Loudness = brightness |
+
+---
+
+## 🚀 Implementation Priority
+
+1. ✅ **Research complete** - Found all issues
+2. ✅ **Test page created** - test-parameters.html
+3. 🔄 **Build AudioAnalyzer** - Multi-band + spectral features
+4. 🔄 **Build ADSREnvelope** - Temporal smoothing
+5. 🔄 **Build ParameterMapper** - Advanced mapping engine
+6. ⏳ **Create V3 HTML** - Full integration
+7. ⏳ **Test with real music** - Verify improvements
+8. ⏳ **Update AI prompts** - Generate sequences with new mapping format
+
+---
+
+## 📁 Files
+
+- ✅ `test-parameters.html` - Manual testing
+- ✅ `V3-PLAN.md` - This document
+- ⏳ `index-V3-ULTIMATE.html` - Complete V3 system
+- ⏳ `src/audio/AudioAnalyzer.js` - Advanced analysis
+- ⏳ `src/audio/ADSREnvelope.js` - Envelope system
+- ⏳ `src/audio/ParameterMapper.js` - Mapping engine
+
+---
+
+**V3 will have PROFESSIONAL audio-visual dynamics instead of simple additive reactivity!**

--- a/index-FINAL.html
+++ b/index-FINAL.html
@@ -160,6 +160,22 @@
             cursor: pointer;
         }
 
+        .geometry-legend {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            font-size: 10px;
+            line-height: 1.4;
+            opacity: 0.8;
+        }
+
+        .geometry-legend span {
+            background: rgba(0, 255, 255, 0.12);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+
         .system-pills {
             display: flex;
             gap: 6px;
@@ -419,6 +435,7 @@
             <div class="param-row">
                 <label>Type <span class="param-value" id="v-geometry">0</span></label>
                 <input type="range" id="geometry" min="0" max="7" value="0" oninput="window.updateParam('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend"></div>
             </div>
         </div>
 
@@ -528,6 +545,7 @@
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
         // System state
         let canvasManager = new CanvasManager();
@@ -552,12 +570,15 @@
 
         let reactivity = { bassDensity: 50, midMorph: 50, highChaos: 60 };
         let sequences = [];
+        let geometryNames = GeometryLibrary.getGeometryNames();
+        let geometrySubscriptionCleanup = null;
 
         const engineClasses = { VIB34DIntegratedEngine, QuantumEngine, RealHolographicSystem };
 
         // Initialize
         (async function() {
             currentEngine = await canvasManager.switchToSystem('faceted', engineClasses);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAudio);
             audio.addEventListener('timeupdate', updatePlayhead);
             audio.addEventListener('ended', () => window.stop());
@@ -569,18 +590,91 @@
             document.getElementById('status-bar').textContent = '🎵 ' + msg;
         }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const numeric = Number(index);
+            if (!Number.isFinite(numeric)) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(numeric)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span>${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                if (Number(slider.max) !== maxIndex) {
+                    slider.max = maxIndex;
+                }
+                const normalized = clampGeometry(params.geometry ?? 0);
+                params.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        geometrySubscriptionCleanup = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
         window.switchSystem = async function(sys) {
             currentEngine = await canvasManager.switchToSystem(sys, engineClasses);
             currentSystem = sys;
             document.querySelectorAll('.system-pill').forEach(p => p.classList.toggle('active', p.dataset.system === sys));
             applyAllParams();
+            refreshGeometryControls();
             setStatus(`Switched to ${sys.toUpperCase()}`);
         };
 
         window.updateParam = function(param, val) {
             params[param] = parseFloat(val);
-            document.getElementById('v-' + param).textContent = param === 'hue' ? val + '°' :
-                param === 'geometry' || param === 'gridDensity' ? parseInt(val) : parseFloat(val).toFixed(2);
+            if (param === 'geometry') {
+                params[param] = clampGeometry(params[param]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = params[param];
+                updateGeometryReadout(params[param]);
+            } else {
+                document.getElementById('v-' + param).textContent = param === 'hue' ? val + '°' :
+                    (param === 'gridDensity' ? parseInt(val) : parseFloat(val).toFixed(2));
+            }
             applyParam(param, params[param]);
         };
 
@@ -603,7 +697,10 @@
         window.randomize = function() {
             Object.keys(params).forEach(p => {
                 let val;
-                if (p === 'geometry') val = Math.floor(Math.random() * 8);
+                if (p === 'geometry') {
+                    const count = geometryCount();
+                    val = count > 0 ? Math.floor(Math.random() * count) : 0;
+                }
                 else if (p.startsWith('rot4d')) val = Math.random() * 12.56 - 6.28;
                 else if (p === 'gridDensity') val = 5 + Math.random() * 95;
                 else if (p === 'morphFactor') val = Math.random() * 2;
@@ -774,6 +871,14 @@
                 console.error(err);
             }
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof geometrySubscriptionCleanup === 'function') {
+                try { geometrySubscriptionCleanup(); }
+                catch (err) { console.warn('Geometry unsubscribe failed', err); }
+                geometrySubscriptionCleanup = null;
+            }
+        });
 
         window.exportVideo = async function() {
             if (!audio.src) return alert('Load audio first');

--- a/index-MASTER.html
+++ b/index-MASTER.html
@@ -121,7 +121,8 @@
             <h3>🔷 Geometry</h3>
             <div class="param">
                 <label>Type <span class="param-val" id="v-geometry">0</span></label>
-                <input type="range" id="geometry" min="0" max="7" value="0" oninput="P('geometry', this.value)">
+                <input type="range" id="geometry" min="0" max="0" value="0" oninput="P('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend" style="margin-top:6px;font-size:10px;line-height:1.4;display:flex;flex-wrap:wrap;gap:4px;opacity:0.8;"></div>
             </div>
         </div>
 
@@ -214,6 +215,7 @@
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
 
         let mgr = new CanvasManager();
@@ -228,6 +230,7 @@
         let play = false;
         let par = { geometry: 0, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0, gridDensity: 15, morphFactor: 1.0, chaos: 0.2, speed: 1.0, hue: 200, intensity: 0.5, saturation: 0.8 };
         let seqs = [];
+        let geometryNames = GeometryLibrary.getGeometryNames();
 
         // Beat detection
         let lastBeatTime = 0;
@@ -238,6 +241,7 @@
 
         (async function() {
             eng = await mgr.switchToSystem('faceted', cls);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAud);
             aud.addEventListener('timeupdate', upd);
             aud.addEventListener('ended', () => window.stop());
@@ -247,18 +251,100 @@
 
         function stat(m) { document.getElementById('status').textContent = '🎵 ' + m; }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const clamped = Math.max(0, Math.min(count - 1, Math.round(index)));
+            return clamped;
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span style="background:rgba(0,255,255,0.08);padding:2px 4px;border-radius:3px;">${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                slider.max = maxIndex;
+                const normalized = clampGeometry(par.geometry ?? 0);
+                par.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        let unsubscribeGeometry = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof unsubscribeGeometry === 'function') {
+                try { unsubscribeGeometry(); } catch (err) {
+                    console.warn('Geometry unsubscribe failed', err);
+                }
+                unsubscribeGeometry = null;
+            }
+        });
+
+        window.refreshGeometryControls = refreshGeometryControls;
+
         window.switchSys = async function(s) {
             eng = await mgr.switchToSystem(s, cls);
             sys = s;
             document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.dataset.sys === s));
+            refreshGeometryControls();
             applyAll();
             stat(`Switched to ${s.toUpperCase()}`);
         };
 
         window.P = function(p, v) {
             par[p] = parseFloat(v);
-            const val = p === 'hue' ? v + '°' : (p === 'geometry' || p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
-            document.getElementById('v-' + p).textContent = val;
+            if (p === 'geometry') {
+                par[p] = clampGeometry(par[p]);
+                if (document.getElementById('geometry')) {
+                    document.getElementById('geometry').value = par[p];
+                }
+                updateGeometryReadout(par[p]);
+            } else {
+                const val = p === 'hue' ? v + '°' : (p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+                document.getElementById('v-' + p).textContent = val;
+            }
             apply(p, par[p]);
         };
 
@@ -276,7 +362,9 @@
         }
 
         window.randomize = function() {
-            par.geometry = Math.floor(Math.random() * 8);
+            geometryCount();
+            const count = Math.max(geometryNames.length, 1);
+            par.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             par.rot4dXW = Math.random() * 12.56 - 6.28;
             par.rot4dYW = Math.random() * 12.56 - 6.28;
             par.rot4dZW = Math.random() * 12.56 - 6.28;
@@ -456,14 +544,23 @@
 
         window.genAI = async function() {
             const prompt = document.getElementById('ai-prompt').value;
-            if (!prompt) return alert('Enter description');
+            if (!prompt) {
+                alert('Enter description');
+                return;
+            }
 
-            const key = document.getElementById('api-key').value || 'AIzaSyD1dHwFcwVxg6r-Lt8I7U6CgznDfwn4GeI';
+            const key = document.getElementById('api-key').value.trim();
+            if (!key) {
+                alert('Enter a Gemini API key');
+                stat('AI failed: API key required');
+                return;
+            }
+
             const dur = aud.duration || 180;
             stat('AI generating with beat sync...');
 
             try {
-                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${key}`;
+                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${encodeURIComponent(key)}`;
                 const resp = await fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -475,7 +572,7 @@
 🔥 YOUR CREATIVE FREEDOM - GO WILD:
 
 PARAMETERS (use FULL ranges - don't be shy!):
-- geometry: 0-7 (0=tetrahedron, 1=hypercube, 2=sphere, 3=torus, 4=klein, 5=fractal, 6=wave, 7=crystal)
+- geometry: use the legend above (indices expand automatically as new shapes register)
 - rot4dXW/YW/ZW: -6.28 to 6.28 (FULL rotations - use extremes!)
 - gridDensity: 5-100 (5=minimal, 100=INSANE detail)
 - morphFactor: 0-2 (2=MAXIMUM morphing)
@@ -532,98 +629,126 @@ Return ONLY the JSON array. Make it INSANE. Be a VISUAL GENIUS.`
                     })
                 });
 
+                if (!resp.ok) {
+                    throw new Error(`HTTP ${resp.status}`);
+                }
+
                 const data = await resp.json();
-                const txt = data.candidates[0].content.parts[0].text;
-                const json = txt.match(/\[[\s\S]*\]/)[0];
-                seqs = JSON.parse(json);
+                const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (!text) {
+                    throw new Error('No choreography returned');
+                }
+
+                const match = text.match(/\[[\s\S]*\]/);
+                if (!match) {
+                    throw new Error('Response missing choreography array');
+                }
+
+                seqs = JSON.parse(match[0]);
                 rend();
                 beatCount = 0;
                 stat(`AI: ${seqs.length} seqs with beat sync!`);
                 window.closeAI();
             } catch (err) {
+                console.error('AI generation failed', err);
                 stat('AI failed: ' + err.message);
-                console.error(err);
             }
         };
 
-        window.exportVid = function() {
-            if (!aud.src) return alert('Load audio first');
+        window.exportVid = async function() {
+            if (!aud.src) {
+                alert('Load audio first');
+                return;
+            }
+
+            if (typeof MediaRecorder === 'undefined') {
+                stat('Export failed: MediaRecorder not supported in this browser');
+                return;
+            }
 
             stat('Preparing export...');
 
-            // Get the first visible canvas
             const canvas = document.querySelector('canvas');
-            if (!canvas) return alert('No canvas found');
-
-            // Try different MediaRecorder mimeTypes for compatibility
-            let mimeType = 'video/webm;codecs=vp9';
-            if (!MediaRecorder.isTypeSupported(mimeType)) {
-                mimeType = 'video/webm;codecs=vp8';
-                if (!MediaRecorder.isTypeSupported(mimeType)) {
-                    mimeType = 'video/webm';
-                }
+            if (!canvas || !canvas.captureStream) {
+                stat('Export failed: Unable to capture canvas stream');
+                return;
             }
 
+            const mimeCandidates = [
+                'video/webm;codecs=vp9',
+                'video/webm;codecs=vp8',
+                'video/webm'
+            ];
+            const mimeType = mimeCandidates.find(type => {
+                try {
+                    return MediaRecorder.isTypeSupported(type);
+                } catch (err) {
+                    return false;
+                }
+            }) || '';
+
             try {
-                // Create video stream from canvas
                 const videoStream = canvas.captureStream(60);
+                const exportDest = ctx.createMediaStreamDestination();
+                let fallbackAudioStream = null;
 
-                // Create a second AudioContext for export to avoid conflicts
-                const exportCtx = new AudioContext();
-                const exportDest = exportCtx.createMediaStreamDestination();
+                try {
+                    anl.connect(exportDest);
+                } catch (err) {
+                    console.warn('Export: analyser connect failed', err);
+                }
 
-                // Create a gain node to tap the audio without disrupting playback
-                const gainNode = ctx.createGain();
-                gainNode.gain.value = 1.0;
+                const combinedStream = new MediaStream();
+                videoStream.getVideoTracks().forEach(track => combinedStream.addTrack(track));
 
-                // Insert gain node into audio chain: source -> analyser -> gain -> destination
-                // We'll connect gain to export destination
-                const srcNode = ctx.createMediaStreamSource(exportDest.stream);
+                const audioTracks = exportDest.stream.getAudioTracks();
+                if (audioTracks.length) {
+                    audioTracks.forEach(track => combinedStream.addTrack(track));
+                } else if (aud.captureStream) {
+                    fallbackAudioStream = aud.captureStream();
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getAudioTracks().forEach(track => combinedStream.addTrack(track));
+                    }
+                }
 
-                // Alternative: Use MediaElementAudioSourceNode if audio isn't playing
-                // Create audio element clone for export
-                const exportAudio = new Audio(aud.src);
-                exportAudio.currentTime = 0;
+                if (combinedStream.getAudioTracks().length === 0) {
+                    stat('Export failed: No audio track available for recording');
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    videoStream.getTracks().forEach(track => track.stop());
+                    return;
+                }
 
-                const exportAudioSource = exportCtx.createMediaElementSource(exportAudio);
-                exportAudioSource.connect(exportDest);
-                exportAudioSource.connect(exportCtx.destination);
-
-                // Combine video + audio streams
-                const combinedStream = new MediaStream([
-                    ...videoStream.getVideoTracks(),
-                    ...exportDest.stream.getAudioTracks()
-                ]);
-
-                // Create MediaRecorder
                 const recorder = new MediaRecorder(combinedStream, {
                     mimeType: mimeType,
                     videoBitsPerSecond: 8000000
                 });
 
                 const chunks = [];
+                const cleanup = () => {
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    exportDest.stream.getTracks().forEach(track => track.stop());
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getTracks().forEach(track => track.stop());
+                    }
+                    videoStream.getTracks().forEach(track => track.stop());
+                };
 
-                recorder.ondataavailable = e => {
-                    if (e.data && e.data.size > 0) {
-                        chunks.push(e.data);
+                recorder.ondataavailable = (event) => {
+                    if (event.data && event.data.size > 0) {
+                        chunks.push(event.data);
                         stat(`Recording... ${chunks.length} chunks`);
                     }
                 };
 
                 recorder.onstop = () => {
-                    console.log('Recorder stopped, chunks:', chunks.length);
+                    cleanup();
 
-                    exportCtx.close();
-                    exportAudio.pause();
-
-                    if (chunks.length === 0) {
+                    if (!chunks.length) {
                         stat('Export failed: No data recorded');
                         return;
                     }
 
-                    const blob = new Blob(chunks, { type: 'video/webm' });
-                    console.log('Blob size:', blob.size);
-
+                    const blob = new Blob(chunks, { type: mimeType || 'video/webm' });
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement('a');
                     a.href = url;
@@ -631,43 +756,41 @@ Return ONLY the JSON array. Make it INSANE. Be a VISUAL GENIUS.`
                     document.body.appendChild(a);
                     a.click();
                     document.body.removeChild(a);
-
                     setTimeout(() => URL.revokeObjectURL(url), 1000);
                     stat('Export complete! Downloaded');
                 };
 
-                recorder.onerror = e => {
-                    console.error('Recorder error:', e);
-                    stat('Export failed: ' + e.error);
-                    exportCtx.close();
-                    exportAudio.pause();
+                recorder.onerror = (event) => {
+                    console.error('Recorder error:', event);
+                    cleanup();
+                    stat('Export failed: ' + (event.error?.message || event.name || 'Unknown error'));
                 };
 
-                // Start recording
-                console.log('Starting recorder with mimeType:', mimeType);
-                recorder.start(100); // Collect data every 100ms
+                if (ctx.state === 'suspended') {
+                    await ctx.resume();
+                }
 
-                // Play both audios in sync
                 aud.currentTime = 0;
-                exportAudio.currentTime = 0;
                 beatCount = 0;
 
-                Promise.all([aud.play(), exportAudio.play()]).then(() => {
-                    stat('Recording... 0 chunks');
-                }).catch(err => {
-                    console.error('Play error:', err);
-                    stat('Playback failed: ' + err.message);
-                    recorder.stop();
-                });
+                recorder.start(100);
 
-                // Stop recording when audio ends
-                exportAudio.onended = () => {
-                    console.log('Audio ended, stopping recorder');
+                try {
+                    await aud.play();
+                    stat('Recording... 0 chunks');
+                } catch (err) {
+                    console.error('Playback failed', err);
+                    recorder.stop();
+                    return;
+                }
+
+                const stopRecording = () => {
                     if (recorder.state === 'recording') {
                         recorder.stop();
                     }
                 };
 
+                aud.addEventListener('ended', stopRecording, { once: true });
             } catch (err) {
                 console.error('Export setup error:', err);
                 stat('Export failed: ' + err.message);

--- a/index-ULTIMATE-V2.html
+++ b/index-ULTIMATE-V2.html
@@ -36,6 +36,22 @@
         input[type="range"]::-webkit-slider-thumb { appearance: none; width: 14px; height: 14px;
             background: linear-gradient(135deg, #0ff, #f0f); border-radius: 50%; cursor: pointer; }
 
+        .geometry-legend {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            font-size: 10px;
+            line-height: 1.4;
+            opacity: 0.8;
+        }
+
+        .geometry-legend span {
+            background: rgba(0, 255, 255, 0.12);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+
         .pills { display: flex; gap: 6px; margin-bottom: 10px; }
         .pill { flex: 1; padding: 8px; background: rgba(0,255,255,0.1); border: 2px solid #0ff; border-radius: 6px;
             text-align: center; font-size: 9px; cursor: pointer; transition: all 0.2s; }
@@ -112,6 +128,7 @@
             <div class="param">
                 <label>Type <span class="param-val" id="v-geometry">0</span></label>
                 <input type="range" id="geometry" min="0" max="7" value="0" oninput="P('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend"></div>
             </div>
         </div>
 
@@ -205,6 +222,7 @@
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
         let mgr = new CanvasManager();
         let eng = null;
@@ -232,11 +250,14 @@
 
         let seqs = [];
         let currentSeq = null;
+        let geometryNames = GeometryLibrary.getGeometryNames();
+        let geometrySubscriptionCleanup = null;
 
         const cls = { VIB34DIntegratedEngine, QuantumEngine, RealHolographicSystem };
 
         (async function() {
             eng = await mgr.switchToSystem('faceted', cls);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAud);
             aud.addEventListener('timeupdate', upd);
             aud.addEventListener('ended', () => window.stop());
@@ -246,18 +267,91 @@
 
         function stat(m) { document.getElementById('status').textContent = '🎵 ' + m; }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const numeric = Number(index);
+            if (!Number.isFinite(numeric)) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(numeric)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span>${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                if (Number(slider.max) !== maxIndex) {
+                    slider.max = maxIndex;
+                }
+                const normalized = clampGeometry(par.geometry ?? 0);
+                par.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        geometrySubscriptionCleanup = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
         window.switchSys = async function(s) {
             eng = await mgr.switchToSystem(s, cls);
             sys = s;
             document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.dataset.sys === s));
+            refreshGeometryControls();
             applyAll();
             stat(`Switched to ${s.toUpperCase()}`);
         };
 
         window.P = function(p, v) {
             par[p] = parseFloat(v);
-            const val = p === 'hue' ? v + '°' : (p === 'geometry' || p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
-            document.getElementById('v-' + p).textContent = val;
+            if (p === 'geometry') {
+                par[p] = clampGeometry(par[p]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = par[p];
+                updateGeometryReadout(par[p]);
+            } else {
+                const val = p === 'hue' ? v + '°' : (p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+                document.getElementById('v-' + p).textContent = val;
+            }
             apply(p, par[p]);
         };
 
@@ -273,7 +367,8 @@
         }
 
         window.randomize = function() {
-            par.geometry = Math.floor(Math.random() * 8);
+            const count = geometryCount();
+            par.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             par.rot4dXW = Math.random() * 4 - 2;
             par.rot4dYW = Math.random() * 4 - 2;
             par.rot4dZW = Math.random() * 4 - 2;
@@ -611,6 +706,14 @@ Return ONLY JSON array.`
                 console.error(err);
             }
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof geometrySubscriptionCleanup === 'function') {
+                try { geometrySubscriptionCleanup(); }
+                catch (err) { console.warn('Geometry unsubscribe failed', err); }
+                geometrySubscriptionCleanup = null;
+            }
+        });
 
         window.exportVid = function() {
             stat('Video export not yet implemented in V2');

--- a/index-ULTIMATE.html
+++ b/index-ULTIMATE.html
@@ -110,7 +110,8 @@
             <h3>🔷 Geometry</h3>
             <div class="param">
                 <label>Type <span class="param-val" id="v-geometry">0</span></label>
-                <input type="range" id="geometry" min="0" max="7" value="0" oninput="P('geometry', this.value)">
+                <input type="range" id="geometry" min="0" max="0" value="0" oninput="P('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend" style="margin-top:6px;font-size:10px;line-height:1.4;display:flex;flex-wrap:wrap;gap:4px;opacity:0.8;"></div>
             </div>
         </div>
 
@@ -203,6 +204,7 @@
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
 
         let mgr = new CanvasManager();
@@ -217,6 +219,7 @@
         let play = false;
         let par = { geometry: 0, rot4dXW: 0, rot4dYW: 0, rot4dZW: 0, gridDensity: 15, morphFactor: 1.0, chaos: 0.2, speed: 1.0, hue: 200, intensity: 0.5, saturation: 0.8 };
         let seqs = [];
+        let geometryNames = GeometryLibrary.getGeometryNames();
         let recChunks = [];
         let rec = null;
 
@@ -224,6 +227,7 @@
 
         (async function() {
             eng = await mgr.switchToSystem('faceted', cls);
+            refreshGeometryControls();
             document.getElementById('audio-file').addEventListener('change', loadAud);
             aud.addEventListener('timeupdate', upd);
             aud.addEventListener('ended', () => window.stop());
@@ -233,17 +237,98 @@
 
         function stat(m) { document.getElementById('status').textContent = '🎵 ' + m; }
 
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(index)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span style="background:rgba(0,255,255,0.08);padding:2px 4px;border-radius:3px;">${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('v-geometry');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                slider.max = maxIndex;
+                const normalized = clampGeometry(par.geometry ?? 0);
+                par.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        let unsubscribeGeometry = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof unsubscribeGeometry === 'function') {
+                try { unsubscribeGeometry(); } catch (err) {
+                    console.warn('Geometry unsubscribe failed', err);
+                }
+                unsubscribeGeometry = null;
+            }
+        });
+
+        window.refreshGeometryControls = refreshGeometryControls;
+
         window.switchSys = async function(s) {
             eng = await mgr.switchToSystem(s, cls);
             sys = s;
             document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.dataset.sys === s));
+            refreshGeometryControls();
             applyAll();
             stat(`Switched to ${s.toUpperCase()}`);
         };
 
         window.P = function(p, v) {
             par[p] = parseFloat(v);
-            document.getElementById('v-' + p).textContent = p === 'hue' ? v + '°' : (p === 'geometry' || p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+            if (p === 'geometry') {
+                par[p] = clampGeometry(par[p]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = par[p];
+                updateGeometryReadout(par[p]);
+            } else {
+                const val = p === 'hue' ? v + '°' : (p === 'gridDensity' ? parseInt(v) : parseFloat(v).toFixed(2));
+                document.getElementById('v-' + p).textContent = val;
+            }
             apply(p, par[p]);
         };
 
@@ -259,7 +344,9 @@
         }
 
         window.randomize = function() {
-            par.geometry = Math.floor(Math.random() * 8);
+            geometryCount();
+            const count = Math.max(geometryNames.length, 1);
+            par.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             par.rot4dXW = Math.random() * 12.56 - 6.28;
             par.rot4dYW = Math.random() * 12.56 - 6.28;
             par.rot4dZW = Math.random() * 12.56 - 6.28;
@@ -396,14 +483,23 @@
 
         window.genAI = async function() {
             const prompt = document.getElementById('ai-prompt').value;
-            if (!prompt) return alert('Enter description');
+            if (!prompt) {
+                alert('Enter description');
+                return;
+            }
 
-            const key = document.getElementById('api-key').value || 'AIzaSyD1dHwFcwVxg6r-Lt8I7U6CgznDfwn4GeI';
+            const key = document.getElementById('api-key').value.trim();
+            if (!key) {
+                alert('Enter a Gemini API key');
+                stat('AI failed: API key required');
+                return;
+            }
+
             const dur = aud.duration || 180; // Use actual duration or default 3min
             stat('AI analyzing full song structure...');
 
             try {
-                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${key}`;
+                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${encodeURIComponent(key)}`;
                 const resp = await fetch(url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -429,7 +525,7 @@ For each sequence, create:
 - time: start time in seconds
 - dur: duration in seconds
 - sys: system type (faceted, quantum, or holographic)
-- geometry: 0-7 (switch at transitions for impact)
+- geometry: consult the live legend (indices expand automatically as new shapes load)
 - rot4dXW, rot4dYW, rot4dZW: -6.28 to 6.28 (use extreme values for drops)
 - gridDensity: 5-100 (pulse between low/high for oomf)
 - morphFactor: 0-2 (high for chaotic, low for clean)
@@ -454,60 +550,167 @@ Return ONLY valid JSON array with 10-15 sequences covering the full ${dur.toFixe
                     })
                 });
 
+                if (!resp.ok) {
+                    throw new Error(`HTTP ${resp.status}`);
+                }
+
                 const data = await resp.json();
-                const txt = data.candidates[0].content.parts[0].text;
-                const json = txt.match(/\[[\s\S]*\]/)[0];
-                seqs = JSON.parse(json);
+                const text = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (!text) {
+                    throw new Error('No choreography returned');
+                }
+
+                const match = text.match(/\[[\s\S]*\]/);
+                if (!match) {
+                    throw new Error('Response missing choreography array');
+                }
+
+                seqs = JSON.parse(match[0]);
                 rend();
                 stat(`AI choreographed ${seqs.length} sequences - ${dur.toFixed(0)}s full song!`);
                 window.closeAI();
             } catch (err) {
+                console.error('AI generation failed', err);
                 stat('AI failed: ' + err.message);
-                console.error(err);
             }
         };
 
         window.exportVid = async function() {
-            if (!aud.src) return alert('Load audio first');
+            if (!aud.src) {
+                alert('Load audio first');
+                return;
+            }
+
+            if (typeof MediaRecorder === 'undefined') {
+                stat('Export failed: MediaRecorder not supported in this browser');
+                return;
+            }
 
             stat('Preparing export...');
-            const canv = document.querySelector('canvas');
-            const stream = canv.captureStream(60);
 
-            // Create new audio context for export to avoid "already connected" error
-            const expCtx = new AudioContext();
-            const expSrc = expCtx.createMediaElementSource(aud);
-            const expDest = expCtx.createMediaStreamDestination();
-            expSrc.connect(expDest);
-            expSrc.connect(expCtx.destination);
+            const canvas = document.querySelector('canvas');
+            if (!canvas || !canvas.captureStream) {
+                stat('Export failed: Unable to capture canvas stream');
+                return;
+            }
 
-            stream.addTrack(expDest.stream.getAudioTracks()[0]);
-
-            rec = new MediaRecorder(stream, { mimeType: 'video/webm;codecs=vp9', videoBitsPerSecond: 8000000 });
-            recChunks = [];
-
-            rec.ondataavailable = e => recChunks.push(e.data);
-            rec.onstop = () => {
-                const blob = new Blob(recChunks, { type: 'video/webm' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = `vib34d-ultimate-${Date.now()}.webm`;
-                a.click();
-                expCtx.close();
-                stat('Export complete!');
-            };
-
-            rec.start();
-            aud.currentTime = 0;
-            await aud.play();
-            stat('Recording... (will auto-stop at end)');
-
-            aud.onended = () => {
-                if (rec && rec.state === 'recording') {
-                    rec.stop();
+            const mimeCandidates = [
+                'video/webm;codecs=vp9',
+                'video/webm;codecs=vp8',
+                'video/webm'
+            ];
+            const mimeType = mimeCandidates.find(type => {
+                try {
+                    return MediaRecorder.isTypeSupported(type);
+                } catch (err) {
+                    return false;
                 }
-            };
+            }) || '';
+
+            try {
+                const stream = canvas.captureStream(60);
+                const exportDest = ctx.createMediaStreamDestination();
+                let fallbackAudioStream = null;
+
+                try {
+                    anl.connect(exportDest);
+                } catch (err) {
+                    console.warn('Export: analyser connect failed', err);
+                }
+
+                const combinedStream = new MediaStream();
+                stream.getVideoTracks().forEach(track => combinedStream.addTrack(track));
+
+                let audioTracks = exportDest.stream.getAudioTracks();
+                if (!audioTracks.length && aud.captureStream) {
+                    fallbackAudioStream = aud.captureStream();
+                    if (fallbackAudioStream) {
+                        audioTracks = fallbackAudioStream.getAudioTracks();
+                    }
+                }
+
+                audioTracks.forEach(track => combinedStream.addTrack(track));
+
+                if (combinedStream.getAudioTracks().length === 0) {
+                    stat('Export failed: No audio track available for recording');
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    stream.getTracks().forEach(track => track.stop());
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getTracks().forEach(track => track.stop());
+                    }
+                    return;
+                }
+
+                rec = new MediaRecorder(combinedStream, { mimeType, videoBitsPerSecond: 8000000 });
+                recChunks = [];
+
+                const cleanup = () => {
+                    try { anl.disconnect(exportDest); } catch (err) {}
+                    exportDest.stream.getTracks().forEach(track => track.stop());
+                    stream.getTracks().forEach(track => track.stop());
+                    if (fallbackAudioStream) {
+                        fallbackAudioStream.getTracks().forEach(track => track.stop());
+                    }
+                };
+
+                rec.ondataavailable = (event) => {
+                    if (event.data && event.data.size > 0) {
+                        recChunks.push(event.data);
+                        stat(`Recording... ${recChunks.length} chunks`);
+                    }
+                };
+
+                rec.onstop = () => {
+                    cleanup();
+
+                    if (!recChunks.length) {
+                        stat('Export failed: No data recorded');
+                        return;
+                    }
+
+                    const blob = new Blob(recChunks, { type: mimeType || 'video/webm' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `vib34d-ultimate-${Date.now()}.webm`;
+                    a.click();
+                    stat('Export complete!');
+                    setTimeout(() => URL.revokeObjectURL(url), 1000);
+                };
+
+                rec.onerror = (event) => {
+                    console.error('Recorder error:', event);
+                    cleanup();
+                    stat('Export failed: ' + (event.error?.message || event.name || 'Unknown error'));
+                };
+
+                if (ctx.state === 'suspended') {
+                    await ctx.resume();
+                }
+
+                aud.currentTime = 0;
+                rec.start(100);
+
+                try {
+                    await aud.play();
+                    stat('Recording... (will auto-stop at end)');
+                } catch (err) {
+                    console.error('Playback failed', err);
+                    rec.stop();
+                    return;
+                }
+
+                const stopRecording = () => {
+                    if (rec && rec.state === 'recording') {
+                        rec.stop();
+                    }
+                };
+
+                aud.addEventListener('ended', stopRecording, { once: true });
+            } catch (err) {
+                console.error('Export setup error:', err);
+                stat('Export failed: ' + err.message);
+            }
         };
     </script>
 </body>

--- a/index-ULTRA.html
+++ b/index-ULTRA.html
@@ -112,6 +112,22 @@
             cursor: pointer;
         }
 
+        .geometry-legend {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            font-size: 10px;
+            line-height: 1.4;
+            opacity: 0.8;
+        }
+
+        .geometry-legend span {
+            background: rgba(0, 255, 255, 0.12);
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+
         .param-value {
             float: right;
             color: #f0f;
@@ -390,6 +406,7 @@
             <div class="param-group">
                 <label>Geometry <span class="param-value" id="geometry-value">0</span></label>
                 <input type="range" id="geometry" min="0" max="7" step="1" value="0" oninput="updateParam('geometry', this.value)">
+                <div class="geometry-legend" id="geometry-legend"></div>
             </div>
         </div>
 
@@ -499,6 +516,7 @@
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
         import { CanvasManager } from './src/core/CanvasManager.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
         let canvasManager = null;
         let currentEngine = null;
@@ -528,6 +546,8 @@
         // Sequences
         let sequences = [];
         let currentTime = 0;
+        let geometryNames = GeometryLibrary.getGeometryNames();
+        let geometrySubscriptionCleanup = null;
 
         const engineClasses = {
             VIB34DIntegratedEngine,
@@ -539,6 +559,7 @@
         (async function init() {
             canvasManager = new CanvasManager();
             currentEngine = await canvasManager.switchToSystem('faceted', engineClasses);
+            refreshGeometryControls();
 
             document.getElementById('audio-file').addEventListener('change', loadAudio);
             audioElement.addEventListener('timeupdate', updatePlayhead);
@@ -547,6 +568,71 @@
             startVisualization();
             console.log('✅ ULTRA System initialized');
         })();
+
+        function geometryCount() {
+            geometryNames = GeometryLibrary.getGeometryNames();
+            return geometryNames.length;
+        }
+
+        function clampGeometry(index) {
+            const count = geometryCount();
+            if (count === 0) return 0;
+            const numeric = Number(index);
+            if (!Number.isFinite(numeric)) return 0;
+            return Math.max(0, Math.min(count - 1, Math.round(numeric)));
+        }
+
+        function geometryLabel(index) {
+            if (!geometryNames.length) {
+                return `${index}`;
+            }
+            const normalized = clampGeometry(index);
+            const name = geometryNames[normalized];
+            return name ? `${normalized} · ${name}` : `${normalized}`;
+        }
+
+        function updateGeometryLegend() {
+            const legend = document.getElementById('geometry-legend');
+            if (!legend) return;
+            if (!geometryNames.length) {
+                legend.innerHTML = '<span style="opacity:0.6;">No geometries available</span>';
+                return;
+            }
+            legend.innerHTML = geometryNames
+                .map((name, idx) => `<span>${idx}: ${name}</span>`)
+                .join('');
+        }
+
+        function updateGeometryReadout(index) {
+            const readout = document.getElementById('geometry-value');
+            if (!readout) return;
+            if (index === undefined || index === null || Number.isNaN(index)) {
+                readout.textContent = '--';
+                return;
+            }
+            readout.textContent = geometryLabel(index);
+        }
+
+        function refreshGeometryControls() {
+            geometryCount();
+            const slider = document.getElementById('geometry');
+            if (slider) {
+                const maxIndex = Math.max(geometryNames.length - 1, 0);
+                if (Number(slider.max) !== maxIndex) {
+                    slider.max = maxIndex;
+                }
+                const normalized = clampGeometry(params.geometry ?? 0);
+                params.geometry = normalized;
+                slider.value = normalized;
+                updateGeometryReadout(normalized);
+            }
+            updateGeometryLegend();
+        }
+
+        geometrySubscriptionCleanup = GeometryLibrary.subscribe(({ names }) => {
+            geometryNames = Array.isArray(names) ? names : GeometryLibrary.getGeometryNames();
+            refreshGeometryControls();
+        });
 
         window.switchSystem = async function(system) {
             currentEngine = await canvasManager.switchToSystem(system, engineClasses);
@@ -557,12 +643,20 @@
             });
 
             applyAllParams();
+            refreshGeometryControls();
         };
 
         window.updateParam = function(param, value) {
             params[param] = parseFloat(value);
-            document.getElementById(param + '-value').textContent =
-                param === 'hue' ? value + '°' : parseFloat(value).toFixed(param === 'gridDensity' || param === 'geometry' ? 0 : 2);
+            if (param === 'geometry') {
+                params[param] = clampGeometry(params[param]);
+                const slider = document.getElementById('geometry');
+                if (slider) slider.value = params[param];
+                updateGeometryReadout(params[param]);
+            } else {
+                document.getElementById(param + '-value').textContent =
+                    param === 'hue' ? value + '°' : parseFloat(value).toFixed(param === 'gridDensity' ? 0 : 2);
+            }
 
             applyParam(param, params[param]);
         };
@@ -609,7 +703,8 @@
         };
 
         window.randomizeAll = function() {
-            params.geometry = Math.floor(Math.random() * 8);
+            const count = geometryCount();
+            params.geometry = count > 0 ? Math.floor(Math.random() * count) : 0;
             params.rot4dXW = Math.random() * 12.56 - 6.28;
             params.rot4dYW = Math.random() * 12.56 - 6.28;
             params.rot4dZW = Math.random() * 12.56 - 6.28;
@@ -720,6 +815,14 @@
             sequences.sort((a, b) => a.time - b.time);
             renderSequences();
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (typeof geometrySubscriptionCleanup === 'function') {
+                try { geometrySubscriptionCleanup(); }
+                catch (err) { console.warn('Geometry unsubscribe failed', err); }
+                geometrySubscriptionCleanup = null;
+            }
+        });
 
         function renderSequences() {
             const track = document.getElementById('sequence-track');

--- a/index.html
+++ b/index.html
@@ -472,6 +472,10 @@
         };
 
         async function initChoreographer(mode) {
+            if (choreographer && typeof choreographer.destroy === 'function') {
+                choreographer.destroy();
+            }
+
             const { MusicVideoChoreographer } = await import('./music-choreographer-engine.js');
             choreographer = new MusicVideoChoreographer(mode);
             window.choreographer = choreographer;
@@ -502,6 +506,46 @@
             if (!choreographer) return;
             choreographer.importChoreography();
         };
+
+        window.addEventListener('beforeunload', () => {
+            if (choreographer && typeof choreographer.destroy === 'function') {
+                choreographer.destroy();
+            }
+        });
+
+        async function configureReactiveInspectorDebug() {
+            const params = new URLSearchParams(window.location.search);
+            const debugState = window.VIB34D_DEBUG = window.VIB34D_DEBUG || {};
+            debugState.reactiveInspector = debugState.reactiveInspector || {};
+
+            if (params.get('inspectorLog') === '1') {
+                debugState.reactiveInspector.log = true;
+            }
+
+            const shouldAutoPanel = params.get('inspectorPanel') === '1'
+                || debugState.reactiveInspector.autoPanel === true;
+
+            if (!shouldAutoPanel) {
+                return;
+            }
+
+            const anchor = params.get('inspectorAnchor') || debugState.reactiveInspector.anchor || 'bottom-right';
+            const widthParam = params.get('inspectorWidth') || debugState.reactiveInspector.width;
+            const parsedWidth = widthParam ? parseInt(widthParam, 10) : 320;
+
+            try {
+                const { installReactiveInspectorPanel } = await import('./src/ui/ReactiveInspectorPanel.js');
+                installReactiveInspectorPanel({
+                    anchor,
+                    width: Number.isFinite(parsedWidth) ? parsedWidth : 320,
+                    log: params.get('inspectorLog') === '1' || debugState.reactiveInspector.log === true
+                });
+            } catch (error) {
+                console.error('Failed to install reactive inspector panel:', error);
+            }
+        }
+
+        configureReactiveInspectorDebug();
     </script>
 </body>
 </html>

--- a/music-choreographer-engine.js
+++ b/music-choreographer-engine.js
@@ -6,6 +6,8 @@
 import { VIB34DIntegratedEngine } from './src/core/Engine.js';
 import { QuantumEngine } from './src/quantum/QuantumEngine.js';
 import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+import { DynamicParameterBridge } from './src/choreography/DynamicParameterBridge.js';
+import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
 
 export class MusicVideoChoreographer {
     constructor(mode = 'reactive') {
@@ -18,6 +20,7 @@ export class MusicVideoChoreographer {
         this.currentEngine = null;
         this.isPlaying = false;
         this.animationId = null;
+        this.canvasManager = null;
 
         // Beat detection
         this.beatThreshold = 0.7;
@@ -28,6 +31,16 @@ export class MusicVideoChoreographer {
         // Choreography sequences (for choreographed mode)
         this.sequences = [];
         this.currentSequence = null;
+        this.dynamicBridge = new DynamicParameterBridge(this);
+
+        // Geometry controls
+        this.geometryModes = new Set(['hold', 'cycle', 'morph', 'random', 'explosive']);
+        this.lastGeometryIndex = 0;
+        this.refreshGeometryMetadata();
+        this.resetGeometryState(false);
+        this.geometrySubscription = GeometryLibrary.subscribe(() => {
+            this.refreshGeometryMetadata();
+        });
 
         // Audio reactivity multipliers (for reactive mode)
         this.reactivitySettings = {
@@ -41,6 +54,119 @@ export class MusicVideoChoreographer {
         this.init();
     }
 
+    refreshGeometryMetadata() {
+        this.geometryNames = GeometryLibrary.getGeometryNames();
+        this.geometryCount = this.geometryNames.length;
+        this.geometryNameLookup = new Map(
+            this.geometryNames.map((name, index) => [name.toLowerCase(), index])
+        );
+        this.geometryIndexList = Array.from({ length: this.geometryCount }, (_, index) => index);
+
+        if (this.geometryCount > 0) {
+            this.lastGeometryIndex = this.normalizeGeometryIndex(this.lastGeometryIndex);
+        } else {
+            this.lastGeometryIndex = 0;
+        }
+
+        if (this.currentEngine && this.currentEngine.parameterManager && this.currentEngine.parameterManager.updateGeometryRange) {
+            this.currentEngine.parameterManager.updateGeometryRange(this.geometryCount);
+        }
+
+        this.applyGeometryMetadataToUI();
+    }
+
+    applyGeometryMetadataToUI() {
+        if (typeof document === 'undefined') return;
+
+        const slider = document.getElementById('geometry');
+        if (slider) {
+            const maxIndex = Math.max(this.geometryCount - 1, 0);
+            if (slider.max !== String(maxIndex)) {
+                slider.max = String(maxIndex);
+            }
+            if (Number(slider.value) > maxIndex) {
+                slider.value = String(maxIndex);
+            }
+        }
+
+        const sliderWrapper = slider?.parentElement;
+        if (sliderWrapper) {
+            let legend = sliderWrapper.querySelector('.geometry-legend');
+            if (!legend) {
+                legend = document.createElement('div');
+                legend.className = 'geometry-legend';
+                legend.style.marginTop = '6px';
+                legend.style.display = 'flex';
+                legend.style.flexWrap = 'wrap';
+                legend.style.gap = '4px';
+                legend.style.fontSize = '9px';
+                legend.style.lineHeight = '1.4';
+                legend.style.opacity = '0.8';
+                sliderWrapper.appendChild(legend);
+            }
+
+            legend.innerHTML = this.geometryNames.map((name, index) => {
+                return `<span style="background:rgba(0,255,255,0.08);padding:2px 4px;border-radius:3px;">${index}: ${name}</span>`;
+            }).join('');
+        }
+
+        this.updateGeometryReadout(this.lastGeometryIndex);
+    }
+
+    destroy() {
+        if (typeof this.geometrySubscription === 'function') {
+            try {
+                this.geometrySubscription();
+            } catch (err) {
+                console.warn('[MusicVideoChoreographer] geometry unsubscribe failed', err);
+            }
+            this.geometrySubscription = null;
+        }
+    }
+
+    getGeometryName(index) {
+        if (!Number.isFinite(index)) {
+            return 'UNKNOWN';
+        }
+        if (!this.geometryNames || !this.geometryNames.length) {
+            return `#${index}`;
+        }
+        const normalized = this.normalizeGeometryIndex(index);
+        return this.geometryNames[normalized] || `#${index}`;
+    }
+
+    updateGeometryReadout(index) {
+        if (typeof document === 'undefined') return;
+        const readout = document.getElementById('v-geometry');
+        if (!readout) return;
+
+        if (index === null || index === undefined) {
+            readout.textContent = '--';
+            return;
+        }
+
+        const geometryName = this.getGeometryName(index);
+        readout.textContent = `${index} · ${geometryName}`;
+    }
+
+    registerGeometryIfNeeded(name) {
+        if (!name) return null;
+        const normalized = GeometryLibrary.normalizeName(name);
+        if (!normalized) return null;
+
+        const key = normalized.toLowerCase();
+        if (this.geometryNameLookup && this.geometryNameLookup.has(key)) {
+            return this.geometryNameLookup.get(key);
+        }
+
+        const added = GeometryLibrary.registerGeometry(normalized);
+        if (added) {
+            this.refreshGeometryMetadata();
+        }
+
+        return this.geometryNameLookup?.get(key) ?? null;
+    }
+
     async init() {
         console.log(`🎵 Initializing Music Video Choreographer in ${this.mode.toUpperCase()} mode`);
 
@@ -52,9 +178,13 @@ export class MusicVideoChoreographer {
 
         // Initialize default engine
         await this.switchSystem('faceted');
+        this.dynamicBridge.bindToEngine(this.currentEngine);
 
         // Setup event listeners
         this.setupEventListeners();
+
+        // Expose AI choreography ingestion for external tooling / UI overlays
+        window.loadAIChoreography = (data) => this.ingestAIChoreography(data);
 
         // Initialize mode-specific features
         if (this.mode === 'choreographed') {
@@ -121,86 +251,218 @@ export class MusicVideoChoreographer {
         this.sequences = [
             {
                 time: 0,
-                duration: 15,
+                duration: 14,
                 effects: {
                     system: 'faceted', // Start with Faceted
                     geometry: 'cycle',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'smooth',
                     chaos: 0.1,
-                    speed: 0.5,
+                    speed: 0.6,
                     colorShift: 'slow',
-                    densityBoost: 0
+                    densityBoost: 0,
+                    parameters: {
+                        gridDensity: {
+                            value: 20,
+                            audioAxis: 'bass',
+                            scale: 55,
+                            allowOverflow: true,
+                            range: [12, 160]
+                        },
+                        morphFactor: {
+                            value: 0.9,
+                            audioAxis: 'mid',
+                            scale: 1.3,
+                            allowOverflow: true,
+                            range: [0, 3]
+                        },
+                        hue: {
+                            value: 210,
+                            audioAxis: 'energy',
+                            scale: 60,
+                            mode: 'mix'
+                        }
+                    }
                 }
             },
             {
-                time: 15,
-                duration: 15,
+                time: 14,
+                duration: 14,
                 effects: {
-                    system: 'faceted', // Stay on Faceted
+                    system: 'faceted', // stay on Faceted but build energy
                     geometry: 'morph',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'accelerate',
-                    chaos: 0.3,
-                    speed: 1.0,
+                    chaos: 0.28,
+                    speed: 1.1,
                     colorShift: 'medium',
-                    densityBoost: 10
+                    densityBoost: 16,
+                    parameters: {
+                        chaos: {
+                            value: 0.35,
+                            audioAxis: 'high',
+                            scale: 0.6,
+                            mode: 'add',
+                            range: [0, 1]
+                        },
+                        speed: {
+                            value: 1.2,
+                            audioAxis: 'energy',
+                            scale: 0.9,
+                            allowOverflow: true,
+                            range: [0.8, 3.5]
+                        }
+                    }
                 }
             },
             {
-                time: 30,
-                duration: 20,
+                time: 28,
+                duration: 18,
                 effects: {
-                    system: 'quantum', // SWITCH to Quantum for drop
+                    system: 'quantum', // SWITCH to Quantum for the first drop
                     geometry: 'random',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'chaos',
-                    chaos: 0.8,
-                    speed: 2.0,
+                    chaos: 0.75,
+                    speed: 2.1,
                     colorShift: 'fast',
-                    densityBoost: 20
+                    densityBoost: 28,
+                    parameters: {
+                        gridDensity: {
+                            value: 48,
+                            audioAxis: ['bass', 'energy'],
+                            scale: 65,
+                            randomize: 8,
+                            allowOverflow: true,
+                            range: [25, 180]
+                        },
+                        intensity: {
+                            value: 0.9,
+                            audioAxis: 'energy',
+                            scale: 0.8,
+                            mode: 'max',
+                            range: [0, 2],
+                            allowOverflow: true
+                        },
+                        saturation: {
+                            value: 1.1,
+                            audioAxis: 'bass',
+                            scale: 0.6,
+                            allowOverflow: true,
+                            range: [0, 2]
+                        }
+                    },
+                    actions: ['triggerClick']
                 }
             },
             {
-                time: 50,
-                duration: 10,
+                time: 46,
+                duration: 12,
                 effects: {
-                    system: 'holographic', // SWITCH to Holographic
+                    system: 'holographic', // ethereal breakdown
                     geometry: 'explosive',
-                    rotation: 'extreme',
-                    chaos: 0.9,
-                    speed: 2.5,
-                    colorShift: 'rainbow',
-                    densityBoost: 30
-                }
-            },
-            {
-                time: 60,
-                duration: 15,
-                effects: {
-                    system: 'faceted', // BACK to Faceted for breakdown
-                    geometry: 'hold',
+                    geometryList: this.geometryNames.slice(),
                     rotation: 'minimal',
-                    chaos: 0.05,
-                    speed: 0.3,
+                    chaos: 0.22,
+                    speed: 0.7,
                     colorShift: 'freeze',
-                    baseHue: 240,
-                    densityBoost: -5
+                    baseHue: 260,
+                    densityBoost: -8,
+                    parameters: {
+                        hue: {
+                            value: 240,
+                            wave: { speed: 0.35, amplitude: 45 },
+                            allowOverflow: true,
+                            range: [120, 420]
+                        },
+                        saturation: {
+                            value: 0.35,
+                            audioAxis: 'mid',
+                            scale: -0.4,
+                            mode: 'mix',
+                            range: [0, 1]
+                        },
+                        intensity: {
+                            value: 0.45,
+                            audioAxis: 'energy',
+                            scale: 0.35,
+                            range: [0, 2]
+                        }
+                    }
                 }
             },
             {
-                time: 75,
+                time: 58,
+                duration: 16,
+                effects: {
+                    system: 'faceted', // rebuild
+                    geometry: 'cycle',
+                    rotation: 'smooth',
+                    chaos: 0.18,
+                    speed: 1.3,
+                    colorShift: 'medium',
+                    densityBoost: 12,
+                    parameters: {
+                        morphFactor: {
+                            value: 1.1,
+                            audioAxis: 'mid',
+                            scale: 1.4,
+                            allowOverflow: true,
+                            range: [0.2, 2.8]
+                        },
+                        gridDensity: {
+                            value: 26,
+                            audioAxis: 'bass',
+                            scale: 40,
+                            mode: 'mix',
+                            allowOverflow: true,
+                            range: [12, 140]
+                        }
+                    }
+                }
+            },
+            {
+                time: 74,
                 duration: 999,
                 effects: {
                     system: 'quantum', // Final drop on Quantum
                     geometry: 'explosive',
                     rotation: 'extreme',
                     chaos: 1.0,
-                    speed: 3.0,
+                    speed: 3.2,
                     colorShift: 'rainbow',
-                    densityBoost: 40
+                    densityBoost: 42,
+                    parameters: {
+                        gridDensity: {
+                            value: 60,
+                            audioAxis: 'bass',
+                            scale: 75,
+                            allowOverflow: true,
+                            range: [30, 220]
+                        },
+                        chaos: {
+                            value: 0.8,
+                            audioAxis: 'energy',
+                            scale: 0.3,
+                            mode: 'max',
+                            range: [0, 1]
+                        },
+                        speed: {
+                            value: 2.4,
+                            audioAxis: 'energy',
+                            scale: 1.2,
+                            allowOverflow: true,
+                            range: [1.2, 4]
+                        }
+                    },
+                    actions: ['triggerClick']
                 }
             }
         ];
 
+        this.resetGeometryState(false);
         this.renderSequenceList();
+        this.scanGeometryDescriptors(this.sequences);
         console.log('🎬 Generated default choreography with system switching');
     }
 
@@ -208,7 +470,26 @@ export class MusicVideoChoreographer {
         const list = document.getElementById('sequence-list');
         if (!list) return;
 
-        list.innerHTML = this.sequences.map((seq, index) => `
+        const legendMarkup = `
+            <div class="geometry-legend-panel" style="margin-bottom:10px;padding:8px;border-radius:6px;background:rgba(0,255,255,0.06);border:1px solid rgba(0,255,255,0.2);font-size:10px;line-height:1.5;">
+                <strong>Available Geometries (${this.geometryNames.length})</strong><br>
+                ${this.geometryNames.map((name, idx) => `<span style="display:inline-block;margin:2px 4px;padding:2px 6px;border-radius:4px;background:rgba(0,255,255,0.08);">${idx}: ${name}</span>`).join(' ')}
+            </div>
+        `;
+
+        const sequenceMarkup = this.sequences.length ? this.sequences.map((seq, index) => {
+            const dynamicSummary = this.renderDynamicSummary(seq.effects);
+            const startIndex = this.resolveGeometryDescriptor(seq.effects.geometryStart);
+            const geometryListValue = this.describeGeometryListInput(seq.effects.geometryList);
+            const intervalValue = seq.effects.geometryInterval ?? '';
+            const cyclesValue = seq.effects.geometryCycles ?? '';
+            const thresholdValue = seq.effects.geometryEnergyThreshold ?? '';
+            const axisValue = seq.effects.geometryAudioAxis ?? '';
+            const geometryValue = seq.effects.geometry;
+            const numericGeometryTarget = (typeof geometryValue === 'number' && Number.isFinite(geometryValue))
+                ? this.normalizeGeometryIndex(geometryValue)
+                : null;
+            return `
             <div class="sequence-item">
                 <h4>Sequence ${index + 1} (${seq.time}s - ${seq.time + seq.duration}s)</h4>
                 <div class="sequence-controls">
@@ -232,7 +513,36 @@ export class MusicVideoChoreographer {
                         <option value="morph" ${seq.effects.geometry === 'morph' ? 'selected' : ''}>Morph</option>
                         <option value="random" ${seq.effects.geometry === 'random' ? 'selected' : ''}>Random</option>
                         <option value="explosive" ${seq.effects.geometry === 'explosive' ? 'selected' : ''}>Explosive</option>
+                        ${this.geometryNames.map((name, idx) => {
+                            const normalized = name.toLowerCase();
+                            const isSelected = (typeof geometryValue === 'string' && geometryValue.toLowerCase() === normalized)
+                                || (numericGeometryTarget !== null && numericGeometryTarget === idx);
+                            return `<option value="${name}" ${isSelected ? 'selected' : ''}>${name}</option>`;
+                        }).join('')}
                     </select>
+
+                    <label>Start Geometry</label>
+                    <select onchange="choreographer.updateSequence(${index}, 'geometryStart', this.value)">
+                        <option value="" ${startIndex === null || startIndex === undefined ? 'selected' : ''}>Auto (carry over)</option>
+                        ${this.geometryNames.map((name, idx) => `<option value="${idx}" ${startIndex === idx ? 'selected' : ''}>${idx}: ${name}</option>`).join('')}
+                    </select>
+
+                    <label>Geometry List</label>
+                    <input type="text" value="${geometryListValue}" placeholder="e.g. Tetrahedron, Wave, 3" onchange="choreographer.updateSequence(${index}, 'geometryList', this.value)">
+
+                    <label>Geometry Interval (s)</label>
+                    <input type="number" step="0.1" min="0.1" value="${intervalValue}" placeholder="2" onchange="choreographer.updateSequence(${index}, 'geometryInterval', this.value)">
+
+                    <label>Geometry Cycles</label>
+                    <input type="number" step="1" min="1" value="${cyclesValue}" placeholder="1" onchange="choreographer.updateSequence(${index}, 'geometryCycles', this.value)">
+
+                    <label>Geometry Audio Axis</label>
+                    <select onchange="choreographer.updateSequence(${index}, 'geometryAudioAxis', this.value)">
+                        ${this.renderGeometryAxisOptions(axisValue)}
+                    </select>
+
+                    <label>Random Threshold</label>
+                    <input type="number" step="0.05" min="0" max="1" value="${thresholdValue}" placeholder="${seq.effects.geometry === 'explosive' ? 0.4 : 0.6}" onchange="choreographer.updateSequence(${index}, 'geometryEnergyThreshold', this.value)">
 
                     <label>Rotation</label>
                     <select onchange="choreographer.updateSequence(${index}, 'rotation', this.value)">
@@ -261,9 +571,138 @@ export class MusicVideoChoreographer {
                 <div style="font-size: 9px; color: #666; margin-top: 5px; padding: 5px; background: rgba(0,255,255,0.05); border-radius: 3px;">
                     ℹ️ Audio reactivity is ALWAYS active - these are base values that audio modulates
                 </div>
+                ${dynamicSummary}
                 <button onclick="choreographer.deleteSequence(${index})" style="margin-top: 10px; background: #f44; font-size: 10px; padding: 5px;">Delete</button>
             </div>
-        `).join('');
+        `;
+        }).join('') : `<div class="sequence-empty" style="padding:12px;border:1px dashed rgba(0,255,255,0.3);border-radius:6px;font-size:11px;color:#7ff;">No sequences defined yet.</div>`;
+
+        list.innerHTML = legendMarkup + sequenceMarkup;
+    }
+
+    describeGeometryStrategy(effects = {}) {
+        if (!effects) return '';
+
+        const summaryParts = [];
+        const geometry = effects.geometry;
+
+        if (geometry !== undefined && geometry !== null) {
+            if (typeof geometry === 'string') {
+                const trimmed = geometry.trim();
+                if (this.geometryModes.has(trimmed.toLowerCase())) {
+                    summaryParts.push(`Mode: ${trimmed}`);
+                } else {
+                    const index = this.resolveGeometryDescriptor(trimmed);
+                    if (index !== null && index !== undefined) {
+                        summaryParts.push(`Target: ${this.getGeometryName(index)} (#${index})`);
+                    } else {
+                        summaryParts.push(`Target: ${GeometryLibrary.normalizeName(trimmed)}`);
+                    }
+                }
+            } else if (typeof geometry === 'number' && Number.isFinite(geometry)) {
+                const normalized = this.normalizeGeometryIndex(geometry);
+                summaryParts.push(`Target #: ${this.getGeometryName(normalized)} (#${normalized})`);
+            } else if (typeof geometry === 'object') {
+                const mode = geometry.mode || geometry.behavior || geometry.type;
+                if (mode) {
+                    summaryParts.push(`Mode: ${mode}`);
+                }
+                if (geometry.name) {
+                    const index = this.resolveGeometryDescriptor(geometry.name);
+                    if (index !== null && index !== undefined) {
+                        summaryParts.push(`Target: ${this.getGeometryName(index)} (#${index})`);
+                    } else {
+                        summaryParts.push(`Target: ${GeometryLibrary.normalizeName(geometry.name)}`);
+                    }
+                }
+                if (geometry.list) {
+                    const listSummary = this.describeGeometryListInput(geometry.list);
+                    if (listSummary) {
+                        summaryParts.push(`List: ${listSummary}`);
+                    }
+                }
+            }
+        }
+
+        const startIndex = this.resolveGeometryDescriptor(effects.geometryStart);
+        if (startIndex !== null && startIndex !== undefined) {
+            summaryParts.push(`Start ➜ ${this.getGeometryName(startIndex)} (#${startIndex})`);
+        }
+
+        const listValue = this.describeGeometryListInput(effects.geometryList);
+        if (listValue) {
+            summaryParts.push(`List ➜ ${listValue}`);
+        }
+
+        if (effects.geometryInterval !== undefined && effects.geometryInterval !== null) {
+            summaryParts.push(`Interval ${Number(effects.geometryInterval).toFixed(2)}s`);
+        }
+
+        if (effects.geometryCycles !== undefined && effects.geometryCycles !== null) {
+            summaryParts.push(`Cycles ×${Math.round(effects.geometryCycles)}`);
+        }
+
+        if (effects.geometryAudioAxis) {
+            summaryParts.push(`Axis ${effects.geometryAudioAxis}`);
+        }
+
+        if (effects.geometryEnergyThreshold !== undefined) {
+            summaryParts.push(`Threshold ${Number(effects.geometryEnergyThreshold).toFixed(2)}`);
+        }
+
+        if (!summaryParts.length) {
+            return '';
+        }
+
+        return summaryParts.join(' | ');
+    }
+
+    renderDynamicSummary(effects = {}) {
+        const parts = [];
+        const geometrySummary = this.describeGeometryStrategy(effects);
+        if (geometrySummary) {
+            parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(0,170,255,0.08);font-size:10px;line-height:1.4;"><strong>Geometry</strong><br>${geometrySummary}</div>`);
+        }
+        if (effects.parameters && Object.keys(effects.parameters).length) {
+            const entries = Object.entries(effects.parameters).map(([name, descriptor]) => {
+                if (typeof descriptor === 'number') {
+                    return `${name}: ${descriptor}`;
+                }
+                if (typeof descriptor === 'object') {
+                    const details = [];
+                    if (descriptor.audioAxis || descriptor.audio) {
+                        details.push(`↔ audio:${descriptor.audioAxis || descriptor.audio}`);
+                    }
+                    if (descriptor.range) {
+                        details.push(`range:${JSON.stringify(descriptor.range)}`);
+                    }
+                    if (descriptor.mode) {
+                        details.push(`mode:${descriptor.mode}`);
+                    }
+                    return `${name}: ${descriptor.value ?? descriptor.base ?? 'auto'}${details.length ? ' (' + details.join(', ') + ')' : ''}`;
+                }
+                return `${name}: ${descriptor}`;
+            }).join('<br>');
+            parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(0,255,255,0.05);font-size:10px;line-height:1.4;"><strong>Dynamic Parameters</strong><br>${entries}</div>`);
+        }
+
+        if (effects.actions && effects.actions.length) {
+            const entries = effects.actions.map(action => {
+                if (typeof action === 'string') return action;
+                if (action.type) {
+                    const suffix = action.args ? ` → ${JSON.stringify(action.args)}` : '';
+                    return `${action.type}${suffix}`;
+                }
+                return JSON.stringify(action);
+            }).join('<br>');
+            parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(255,0,255,0.05);font-size:10px;line-height:1.4;"><strong>Actions</strong><br>${entries}</div>`);
+        }
+
+        if (!parts.length) {
+            return '';
+        }
+
+        return `<div class="dynamic-insight">${parts.join('')}</div>`;
     }
 
     updateSequence(index, property, value) {
@@ -274,21 +713,89 @@ export class MusicVideoChoreographer {
             seq[property] = parseFloat(value);
         } else if (property === 'chaos' || property === 'speed') {
             seq.effects[property] = parseFloat(value);
+        } else if (property === 'geometry') {
+            const resolved = this.normalizeGeometryBehaviorValue(value);
+            if (resolved === null) {
+                delete seq.effects.geometry;
+            } else {
+                seq.effects.geometry = resolved;
+            }
+        } else if (property === 'geometryStart') {
+            const resolved = this.coerceGeometryIndexDescriptor(value);
+            if (resolved === null || resolved === undefined) {
+                delete seq.effects.geometryStart;
+            } else {
+                seq.effects.geometryStart = resolved;
+            }
+        } else if (property === 'geometryList') {
+            const list = this.coerceGeometryList(value);
+            if (list && list.length) {
+                seq.effects.geometryList = list;
+            } else {
+                delete seq.effects.geometryList;
+            }
+        } else if (property === 'geometryInterval') {
+            const numeric = parseFloat(value);
+            if (Number.isFinite(numeric)) {
+                seq.effects.geometryInterval = Math.max(0.05, numeric);
+            } else {
+                delete seq.effects.geometryInterval;
+            }
+        } else if (property === 'geometryCycles') {
+            const numeric = parseInt(value, 10);
+            if (Number.isFinite(numeric)) {
+                seq.effects.geometryCycles = Math.max(1, numeric);
+            } else {
+                delete seq.effects.geometryCycles;
+            }
+        } else if (property === 'geometryAudioAxis') {
+            const axis = value ? value.toString().toLowerCase() : '';
+            if (!axis) {
+                delete seq.effects.geometryAudioAxis;
+            } else {
+                seq.effects.geometryAudioAxis = axis;
+            }
+        } else if (property === 'geometryEnergyThreshold') {
+            const numeric = parseFloat(value);
+            if (Number.isFinite(numeric)) {
+                seq.effects.geometryEnergyThreshold = Math.min(1, Math.max(0, numeric));
+            } else {
+                delete seq.effects.geometryEnergyThreshold;
+            }
         } else {
             seq.effects[property] = value;
         }
 
+        if ([
+            'time',
+            'duration',
+            'geometry',
+            'geometryList',
+            'geometryInterval',
+            'geometryStart',
+            'geometryCycles',
+            'geometryAudioAxis',
+            'geometryEnergyThreshold'
+        ].includes(property)) {
+            this.resetGeometryState(true);
+        }
+
+        this.scanGeometryDescriptors(this.sequences);
+        this.renderSequenceList();
         console.log(`Updated sequence ${index}:`, seq);
     }
 
     deleteSequence(index) {
         this.sequences.splice(index, 1);
+        this.resetGeometryState(true);
         this.renderSequenceList();
     }
 
     addSequenceToTimeline(newSeq) {
         this.sequences.push(newSeq);
         this.sequences.sort((a, b) => a.time - b.time);
+        this.scanGeometryDescriptors(this.sequences);
+        this.resetGeometryState(true);
         this.renderSequenceList();
     }
 
@@ -342,6 +849,8 @@ export class MusicVideoChoreographer {
             }
 
             this.currentSystem = systemName;
+            this.canvasManager = this.currentEngine?.canvasManager || null;
+            this.dynamicBridge.bindToEngine(this.currentEngine);
 
             // Update UI
             document.querySelectorAll('.system-btn').forEach(btn => {
@@ -349,6 +858,7 @@ export class MusicVideoChoreographer {
             });
 
             console.log('✅ Switched to', systemName, 'system');
+            this.refreshGeometryMetadata();
         } catch (error) {
             console.error('Failed to switch system:', error);
         }
@@ -519,16 +1029,26 @@ export class MusicVideoChoreographer {
             this.switchSystem(effects.system);
         }
 
-        // Geometry choreography
-        if (effects.geometry === 'cycle') {
-            const geomIndex = Math.floor((currentTime - activeSequence.time) / 2) % 9;
-            setParam('geometry', geomIndex);
-        } else if (effects.geometry === 'random' && audioData.energy > 0.6) {
-            const geomIndex = Math.floor(Math.random() * 9);
-            setParam('geometry', geomIndex);
-        } else if (effects.geometry === 'explosive' && Math.random() < 0.1) {
-            const geomIndex = Math.floor(Math.random() * 9);
-            setParam('geometry', geomIndex);
+        const sequenceId = this.sequences.indexOf(activeSequence);
+        if (sequenceId !== this.geometryState.activeSequenceId) {
+            this.geometryState.activeSequenceId = sequenceId;
+            this.geometryState.sequenceStartGeometry = this.lastGeometryIndex;
+            this.geometryState.lastRandomIndex = this.lastGeometryIndex;
+            this.geometryState.lastRandomChangeTime = -Infinity;
+        }
+
+        const geometryIndex = this.computeGeometryTarget(
+            effects,
+            activeSequence,
+            currentTime,
+            audioData
+        );
+
+        if (geometryIndex !== null && geometryIndex !== undefined) {
+            setParam('geometry', geometryIndex);
+            this.lastGeometryIndex = geometryIndex;
+            this.geometryState.lastRandomIndex = geometryIndex;
+            this.updateGeometryReadout(geometryIndex);
         }
 
         // Rotation choreography (WITH audio overlay)
@@ -598,6 +1118,467 @@ export class MusicVideoChoreographer {
         if (this.currentEngine && this.currentEngine.audioEnabled !== undefined) {
             this.currentEngine.audioEnabled = true;
         }
+
+        // Allow AI-defined parameters and actions to override / extend the base behaviour
+        this.dynamicBridge.apply(effects, audioData);
+    }
+
+    computeGeometryTarget(effects, activeSequence, currentTime, audioData) {
+        if (!effects) return null;
+
+        const geometrySetting = effects.geometry;
+        if (geometrySetting === undefined || geometrySetting === null) {
+            return null;
+        }
+
+        if (typeof geometrySetting === 'number' && Number.isFinite(geometrySetting)) {
+            return this.normalizeGeometryIndex(geometrySetting);
+        }
+
+        if (typeof geometrySetting === 'string') {
+            const key = geometrySetting.toLowerCase().trim();
+            if (this.geometryNameLookup.has(key)) {
+                return this.geometryNameLookup.get(key);
+            }
+            return this.computeGeometryByMode(
+                key,
+                effects,
+                activeSequence,
+                currentTime,
+                audioData,
+                {}
+            );
+        }
+
+        if (typeof geometrySetting === 'object') {
+            if (typeof geometrySetting.index === 'number') {
+                return this.normalizeGeometryIndex(geometrySetting.index);
+            }
+
+            if (geometrySetting.name) {
+                const nameKey = String(geometrySetting.name).toLowerCase().trim();
+                if (this.geometryNameLookup.has(nameKey)) {
+                    return this.geometryNameLookup.get(nameKey);
+                }
+            }
+
+            const modeSource = geometrySetting.mode || geometrySetting.behavior || geometrySetting.type;
+            if (modeSource) {
+                const modeKey = String(modeSource).toLowerCase().trim();
+                return this.computeGeometryByMode(
+                    modeKey,
+                    effects,
+                    activeSequence,
+                    currentTime,
+                    audioData,
+                    geometrySetting
+                );
+            }
+        }
+
+        return null;
+    }
+
+    computeGeometryByMode(mode, effects, activeSequence, currentTime, audioData, config = {}) {
+        if (!mode) return null;
+
+        const normalizedList = this.normalizeGeometryList(config.list ?? effects.geometryList);
+        const interval = Math.max(0.1, config.interval ?? effects.geometryInterval ?? 2);
+        const direction = (config.direction === 'reverse' || config.direction === 'backward' || config.direction === -1)
+            ? -1
+            : 1;
+
+        switch (mode) {
+            case 'hold':
+                return this.lastGeometryIndex;
+            case 'cycle': {
+                const elapsed = Math.max(0, currentTime - activeSequence.time);
+                const rawSteps = Math.floor(elapsed / interval);
+
+                if (normalizedList && normalizedList.length) {
+                    const listLength = normalizedList.length;
+                    const stepIndex = rawSteps % listLength;
+                    const pointer = direction >= 0
+                        ? stepIndex
+                        : (listLength - ((stepIndex % listLength) + 1));
+                    return normalizedList[(pointer + listLength) % listLength];
+                }
+
+                const startIndex = this.normalizeGeometryIndex(
+                    config.startIndex ?? config.start ?? effects.geometryStart ?? this.geometryState.sequenceStartGeometry ?? this.lastGeometryIndex
+                );
+                return this.normalizeGeometryIndex(startIndex + rawSteps * direction);
+            }
+            case 'morph': {
+                const list = (normalizedList && normalizedList.length)
+                    ? normalizedList
+                    : this.geometryIndexList;
+                if (!list.length) {
+                    return this.lastGeometryIndex;
+                }
+
+                const duration = Math.max(activeSequence.duration || 0.001, 0.001);
+                const progress = Math.max(0, currentTime - activeSequence.time) / duration;
+                const cycles = Math.max(1, config.cycles ?? config.repeats ?? effects.geometryCycles ?? 1);
+                const scaled = progress * list.length * cycles;
+                const indexInList = Math.floor(scaled) % list.length;
+                return list[indexInList];
+            }
+            case 'random':
+            case 'explosive': {
+                const list = (normalizedList && normalizedList.length)
+                    ? normalizedList
+                    : this.geometryIndexList;
+                if (!list.length) {
+                    return this.lastGeometryIndex;
+                }
+
+                const axisKey = config.axis || config.audioAxis || effects.geometryAudioAxis;
+                const audioMetric = axisKey && audioData && audioData[axisKey] !== undefined
+                    ? audioData[axisKey]
+                    : (audioData?.energy ?? 0);
+                const threshold = config.threshold ?? effects.geometryEnergyThreshold ?? (mode === 'explosive' ? 0.4 : 0.6);
+                const minInterval = Math.max(0.05, config.interval ?? effects.geometryInterval ?? (mode === 'explosive' ? 0.4 : 0.75));
+                const force = config.always === true;
+
+                if ((force || audioMetric >= threshold) && (currentTime - this.geometryState.lastRandomChangeTime >= minInterval)) {
+                    let nextIndex = list[Math.floor(Math.random() * list.length)];
+                    if (config.avoidRepeats !== false && list.length > 1) {
+                        let attempts = 0;
+                        while (nextIndex === this.geometryState.lastRandomIndex && attempts < 5) {
+                            nextIndex = list[Math.floor(Math.random() * list.length)];
+                            attempts++;
+                        }
+                    }
+                    this.geometryState.lastRandomIndex = nextIndex;
+                    this.geometryState.lastRandomChangeTime = currentTime;
+                    return nextIndex;
+                }
+
+                return this.geometryState.lastRandomIndex;
+            }
+            default:
+                if (this.geometryNameLookup.has(mode)) {
+                    return this.geometryNameLookup.get(mode);
+                }
+                return this.lastGeometryIndex;
+        }
+    }
+
+    normalizeGeometryIndex(index) {
+        if (!Number.isFinite(index) || this.geometryCount <= 0) {
+            return 0;
+        }
+
+        const base = Math.floor(index);
+        const wrapped = ((base % this.geometryCount) + this.geometryCount) % this.geometryCount;
+        return wrapped;
+    }
+
+    normalizeGeometryList(source) {
+        if (!source) return null;
+        const list = Array.isArray(source) ? source : [source];
+        const normalized = list
+            .map((item, idx) => this.geometryDescriptorToIndex(item, idx))
+            .filter(value => value !== null && value !== undefined);
+        return normalized.length ? normalized : null;
+    }
+
+    geometryDescriptorToIndex(descriptor, fallback = 0) {
+        if (descriptor === undefined || descriptor === null) {
+            return this.normalizeGeometryIndex(fallback);
+        }
+
+        if (typeof descriptor === 'number' && Number.isFinite(descriptor)) {
+            return this.normalizeGeometryIndex(descriptor);
+        }
+
+        if (typeof descriptor === 'string') {
+            const key = descriptor.toLowerCase().trim();
+            if (this.geometryNameLookup.has(key)) {
+                return this.geometryNameLookup.get(key);
+            }
+        }
+
+        if (typeof descriptor === 'object') {
+            if (typeof descriptor.index === 'number') {
+                return this.normalizeGeometryIndex(descriptor.index);
+            }
+            if (descriptor.name) {
+                const key = String(descriptor.name).toLowerCase().trim();
+                if (this.geometryNameLookup.has(key)) {
+                    return this.geometryNameLookup.get(key);
+                }
+            }
+        }
+
+        return this.normalizeGeometryIndex(fallback);
+    }
+
+    resolveGeometryDescriptor(descriptor) {
+        if (descriptor === undefined || descriptor === null) {
+            return null;
+        }
+
+        if (typeof descriptor === 'number' && Number.isFinite(descriptor)) {
+            return this.normalizeGeometryIndex(descriptor);
+        }
+
+        if (typeof descriptor === 'string') {
+            const trimmed = descriptor.trim();
+            if (!trimmed) return null;
+            if (/^-?\d+$/.test(trimmed)) {
+                return this.normalizeGeometryIndex(Number(trimmed));
+            }
+            const key = GeometryLibrary.normalizeName(trimmed).toLowerCase();
+            if (this.geometryNameLookup.has(key)) {
+                return this.geometryNameLookup.get(key);
+            }
+            return null;
+        }
+
+        if (typeof descriptor === 'object') {
+            if (typeof descriptor.index === 'number') {
+                return this.normalizeGeometryIndex(descriptor.index);
+            }
+            if (descriptor.name) {
+                return this.resolveGeometryDescriptor(descriptor.name);
+            }
+        }
+
+        return null;
+    }
+
+    describeGeometryListInput(list) {
+        if (!list) return '';
+
+        const entries = Array.isArray(list)
+            ? list
+            : (typeof list === 'string' ? list.split(',') : [list]);
+
+        const formatted = entries.map((item) => {
+            if (item === undefined || item === null) return '';
+            if (typeof item === 'number' && Number.isFinite(item)) {
+                return this.getGeometryName(item);
+            }
+            if (typeof item === 'string') {
+                const trimmed = item.trim();
+                if (!trimmed) return '';
+                if (/^-?\d+$/.test(trimmed)) {
+                    return this.getGeometryName(Number(trimmed));
+                }
+                return GeometryLibrary.normalizeName(trimmed);
+            }
+            if (typeof item === 'object') {
+                if (typeof item.index === 'number') {
+                    return this.getGeometryName(item.index);
+                }
+                if (item.name) {
+                    return GeometryLibrary.normalizeName(item.name);
+                }
+            }
+            return '';
+        }).filter(Boolean);
+
+        return formatted.join(', ');
+    }
+
+    renderGeometryAxisOptions(selected) {
+        const normalized = (selected || '').toString().toLowerCase();
+        const options = [
+            { value: '', label: 'Auto (energy mix)' },
+            { value: 'bass', label: 'Bass' },
+            { value: 'mid', label: 'Mid' },
+            { value: 'high', label: 'High' },
+            { value: 'energy', label: 'Energy' }
+        ];
+
+        return options.map(({ value, label }) => {
+            const isSelected = value === '' ? !normalized : normalized === value;
+            return `<option value="${value}" ${isSelected ? 'selected' : ''}>${label}</option>`;
+        }).join('');
+    }
+
+    normalizeGeometryBehaviorValue(value) {
+        if (value === undefined || value === null) {
+            return null;
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return this.normalizeGeometryIndex(value);
+        }
+
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            if (/^-?\d+$/.test(trimmed)) {
+                return this.normalizeGeometryIndex(Number(trimmed));
+            }
+            const lower = trimmed.toLowerCase();
+            if (this.geometryModes.has(lower)) {
+                return lower;
+            }
+            const normalized = GeometryLibrary.normalizeName(trimmed);
+            const index = this.registerGeometryIfNeeded(normalized);
+            if (index !== null && index !== undefined) {
+                return this.getGeometryName(index);
+            }
+            return normalized;
+        }
+
+        if (typeof value === 'object') {
+            if (Array.isArray(value)) {
+                return value.slice();
+            }
+            return { ...value };
+        }
+
+        return value;
+    }
+
+    coerceGeometryIndexDescriptor(value) {
+        if (value === undefined || value === null) {
+            return null;
+        }
+
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return this.normalizeGeometryIndex(value);
+        }
+
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            if (/^-?\d+$/.test(trimmed)) {
+                return this.normalizeGeometryIndex(Number(trimmed));
+            }
+            const normalized = GeometryLibrary.normalizeName(trimmed);
+            const index = this.registerGeometryIfNeeded(normalized);
+            if (index !== null && index !== undefined) {
+                return index;
+            }
+            return null;
+        }
+
+        if (typeof value === 'object') {
+            if (typeof value.index === 'number') {
+                return this.normalizeGeometryIndex(value.index);
+            }
+            if (value.name) {
+                return this.coerceGeometryIndexDescriptor(value.name);
+            }
+        }
+
+        return null;
+    }
+
+    coerceGeometryList(value) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        let entries;
+        if (Array.isArray(value)) {
+            entries = value;
+        } else if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) return null;
+            entries = trimmed.split(',').map(token => token.trim()).filter(Boolean);
+        } else {
+            entries = [value];
+        }
+
+        const mapped = entries
+            .map(item => this.coerceGeometryIndexDescriptor(item))
+            .filter(idx => idx !== null && idx !== undefined);
+
+        return mapped.length ? mapped : null;
+    }
+
+    scanGeometryDescriptors(sequences) {
+        if (!Array.isArray(sequences)) return;
+
+        let needsRefresh = false;
+
+        const registerName = (candidate) => {
+            if (!candidate) return;
+            const normalized = GeometryLibrary.normalizeName(candidate);
+            if (!normalized) return;
+            const lower = normalized.toLowerCase();
+            if (this.geometryModes.has(lower)) return;
+            if (/^-?\d+$/.test(normalized)) return;
+            if (this.geometryNameLookup && this.geometryNameLookup.has(lower)) return;
+            if (GeometryLibrary.registerGeometry(normalized)) {
+                needsRefresh = true;
+            }
+        };
+
+        const visitDescriptor = (descriptor) => {
+            if (descriptor === undefined || descriptor === null) return;
+            if (Array.isArray(descriptor)) {
+                descriptor.forEach(item => visitDescriptor(item));
+                return;
+            }
+            if (typeof descriptor === 'number') return;
+            if (typeof descriptor === 'string') {
+                registerName(descriptor);
+                return;
+            }
+            if (typeof descriptor === 'object') {
+                if (typeof descriptor.index === 'number') return;
+                if (descriptor.name) {
+                    registerName(descriptor.name);
+                }
+                if (descriptor.list) {
+                    visitDescriptor(descriptor.list);
+                }
+            }
+        };
+
+        sequences.forEach(seq => {
+            const effects = seq.effects || {};
+            visitDescriptor(effects.geometry);
+            visitDescriptor(effects.geometryStart);
+            visitDescriptor(effects.geometryEnd);
+            visitDescriptor(effects.geometryList);
+        });
+
+        if (needsRefresh) {
+            this.refreshGeometryMetadata();
+        }
+    }
+
+    resetGeometryState(preserveLast = false) {
+        const baseIndex = preserveLast && Number.isFinite(this.lastGeometryIndex)
+            ? this.normalizeGeometryIndex(this.lastGeometryIndex)
+            : 0;
+
+        this.lastGeometryIndex = baseIndex;
+        this.geometryState = {
+            activeSequenceId: null,
+            sequenceStartGeometry: baseIndex,
+            lastRandomIndex: baseIndex,
+            lastRandomChangeTime: -Infinity
+        };
+
+        this.updateGeometryReadout(this.lastGeometryIndex);
+    }
+
+    ingestAIChoreography(sequenceData) {
+        try {
+            const normalized = this.dynamicBridge.normalizeSequences(sequenceData);
+            this.sequences = normalized.map(seq => ({
+                time: seq.time,
+                duration: seq.duration,
+                effects: seq.effects
+            }));
+            this.scanGeometryDescriptors(this.sequences);
+            this.resetGeometryState(true);
+            this.renderSequenceList();
+            this.updateStatus(`AI choreography loaded (${this.sequences.length} sequences)`);
+        } catch (error) {
+            console.error('Failed to ingest AI choreography', error);
+            this.updateStatus('AI choreography failed: ' + error.message);
+        }
     }
 
     updateTimeline() {
@@ -635,8 +1616,8 @@ export class MusicVideoChoreographer {
             const reader = new FileReader();
             reader.onload = (event) => {
                 try {
-                    this.sequences = JSON.parse(event.target.result);
-                    this.renderSequenceList();
+                    const data = JSON.parse(event.target.result);
+                    this.ingestAIChoreography(data);
                     console.log('📂 Imported choreography');
                 } catch (error) {
                     console.error('Failed to import choreography:', error);

--- a/music-video-choreographer.html
+++ b/music-video-choreographer.html
@@ -662,6 +662,12 @@
         // Initialize choreographer
         const choreographer = new MusicVideoChoreographer();
 
+        window.addEventListener('beforeunload', () => {
+            if (choreographer && typeof choreographer.destroy === 'function') {
+                choreographer.destroy();
+            }
+        });
+
         // Handle window resize
         window.addEventListener('resize', () => {
             document.querySelectorAll('canvas').forEach(canvas => {
@@ -669,6 +675,40 @@
                 canvas.height = window.innerHeight;
             });
         });
+
+        async function configureReactiveInspectorDebug() {
+            const params = new URLSearchParams(window.location.search);
+            const debugState = window.VIB34D_DEBUG = window.VIB34D_DEBUG || {};
+            debugState.reactiveInspector = debugState.reactiveInspector || {};
+
+            if (params.get('inspectorLog') === '1') {
+                debugState.reactiveInspector.log = true;
+            }
+
+            const shouldAutoPanel = params.get('inspectorPanel') === '1'
+                || debugState.reactiveInspector.autoPanel === true;
+
+            if (!shouldAutoPanel) {
+                return;
+            }
+
+            const anchor = params.get('inspectorAnchor') || debugState.reactiveInspector.anchor || 'bottom-right';
+            const widthParam = params.get('inspectorWidth') || debugState.reactiveInspector.width;
+            const parsedWidth = widthParam ? parseInt(widthParam, 10) : 320;
+
+            try {
+                const { installReactiveInspectorPanel } = await import('./src/ui/ReactiveInspectorPanel.js');
+                installReactiveInspectorPanel({
+                    anchor,
+                    width: Number.isFinite(parsedWidth) ? parsedWidth : 320,
+                    log: params.get('inspectorLog') === '1' || debugState.reactiveInspector.log === true
+                });
+            } catch (error) {
+                console.error('Failed to install reactive inspector panel:', error);
+            }
+        }
+
+        configureReactiveInspectorDebug();
     </script>
 </body>
 </html>

--- a/src/choreography/DynamicParameterBridge.js
+++ b/src/choreography/DynamicParameterBridge.js
@@ -1,0 +1,453 @@
+export class DynamicParameterBridge {
+    constructor(choreographer) {
+        this.choreographer = choreographer;
+        this.parameterRegistry = new Map();
+        this.actionHandlers = new Map();
+    }
+
+    registerParameter(name, definition = {}) {
+        if (!name) return;
+        const existing = this.parameterRegistry.get(name) || {};
+        const merged = { ...existing, ...definition };
+        this.parameterRegistry.set(name, merged);
+
+        this._registerWithEngine(name, merged);
+    }
+
+    bindToEngine(engine) {
+        if (!engine) return;
+        this.parameterRegistry.forEach((definition, name) => {
+            this._registerWithEngine(name, definition, engine);
+        });
+    }
+
+    registerAction(type, handler) {
+        if (!type || typeof handler !== 'function') return;
+        this.actionHandlers.set(type, handler);
+    }
+
+    normalizeSequences(rawSequences) {
+        if (!Array.isArray(rawSequences)) {
+            throw new Error('Choreography data must be an array');
+        }
+
+        return rawSequences.map((entry, index) => {
+            const safeEntry = entry || {};
+            const time = this._coerceNumber(
+                safeEntry.time,
+                safeEntry.start,
+                safeEntry.startTime,
+                safeEntry.begin,
+                0
+            );
+            const duration = Math.max(0.5, this._coerceNumber(
+                safeEntry.duration,
+                safeEntry.length,
+                safeEntry.dur,
+                safeEntry.span,
+                8
+            ));
+
+            const effectsSource = typeof safeEntry.effects === 'object' && safeEntry.effects !== null
+                ? { ...safeEntry.effects }
+                : {};
+
+            const effects = {
+                ...effectsSource,
+            };
+
+            if (safeEntry.system && !effects.system) effects.system = safeEntry.system;
+            if (safeEntry.geometry && !effects.geometry) effects.geometry = safeEntry.geometry;
+            if (safeEntry.rotation && !effects.rotation) effects.rotation = safeEntry.rotation;
+            if (safeEntry.colorShift && !effects.colorShift) effects.colorShift = safeEntry.colorShift;
+
+            const parameters = safeEntry.parameters || safeEntry.dynamicParameters || effects.parameters;
+            if (parameters) {
+                effects.parameters = { ...parameters };
+            }
+
+            const actions = safeEntry.actions || effects.actions;
+            if (actions) {
+                effects.actions = Array.isArray(actions) ? actions.slice() : [actions];
+            }
+
+            const definitions = safeEntry.define || effects.define;
+            if (definitions && typeof definitions === 'object') {
+                Object.entries(definitions).forEach(([name, definition]) => {
+                    this.registerParameter(name, definition);
+                });
+                delete effects.define;
+            }
+
+            return {
+                time,
+                duration,
+                effects,
+                index
+            };
+        }).sort((a, b) => a.time - b.time);
+    }
+
+    apply(effects, audioData) {
+        if (!effects) return;
+
+        if (effects.define && typeof effects.define === 'object') {
+            Object.entries(effects.define).forEach(([name, definition]) => {
+                this.registerParameter(name, definition);
+            });
+        }
+
+        if (effects.parameters) {
+            this._applyParameters(effects.parameters, audioData);
+        }
+
+        if (effects.actions) {
+            this._executeActions(effects.actions, audioData);
+        }
+    }
+
+    _applyParameters(parameters, audioData) {
+        Object.entries(parameters).forEach(([name, descriptor]) => {
+            const resolvedValue = this._resolveDescriptor(descriptor, audioData, name);
+            this._setEngineParameter(name, resolvedValue, descriptor);
+        });
+    }
+
+    _executeActions(actions, audioData) {
+        const list = Array.isArray(actions) ? actions : [actions];
+        list.forEach(action => {
+            if (!action) return;
+
+            if (typeof action === 'string') {
+                this._invokeAction({ type: action }, audioData);
+                return;
+            }
+
+            this._invokeAction(action, audioData);
+        });
+    }
+
+    _invokeAction(action, audioData) {
+        const { type, method, target = 'engine' } = action;
+        const handler = type && this.actionHandlers.get(type);
+        if (handler) {
+            try {
+                handler({ action, audioData, choreographer: this.choreographer });
+                return;
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] custom action failed', type, err);
+                return;
+            }
+        }
+
+        const engine = this.choreographer.currentEngine;
+        if (!engine) return;
+
+        const methodName = method || type;
+        if (!methodName) return;
+
+        const args = Array.isArray(action.args) ? action.args : (action.payload ? [action.payload] : []);
+        let context = engine;
+
+        if (target === 'manager' && this.choreographer.canvasManager) {
+            context = this.choreographer.canvasManager;
+        } else if (target === 'audio' && this.choreographer.audioContext) {
+            context = this.choreographer.audioContext;
+        }
+
+        const fn = context && context[methodName];
+        if (typeof fn === 'function') {
+            try {
+                fn.apply(context, [...args, audioData]);
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] action invocation failed', methodName, err);
+            }
+        }
+    }
+
+    _resolveDescriptor(descriptor, audioData, name) {
+        if (typeof descriptor === 'number' || Array.isArray(descriptor)) {
+            return descriptor;
+        }
+
+        if (typeof descriptor === 'string') {
+            if (audioData && descriptor in audioData) {
+                return audioData[descriptor];
+            }
+            return descriptor;
+        }
+
+        if (!descriptor || typeof descriptor !== 'object') {
+            return descriptor;
+        }
+
+        const registryMeta = this.parameterRegistry.get(name) || {};
+        const base = descriptor.value ?? descriptor.base ?? registryMeta.base ?? registryMeta.default ?? 0;
+        let value = base;
+
+        if (descriptor.randomize) {
+            const amount = typeof descriptor.randomize === 'number'
+                ? descriptor.randomize
+                : (descriptor.randomize.amount ?? 0);
+            value += (Math.random() * 2 - 1) * amount;
+        }
+
+        if (descriptor.audioAxis || descriptor.audio) {
+            const axis = descriptor.audioAxis || descriptor.audio;
+            const axisValue = this._sampleAudioAxis(axis, audioData);
+            const scale = descriptor.scale ?? descriptor.multiplier ?? 1;
+            const bias = descriptor.offset ?? descriptor.bias ?? 0;
+            value += axisValue * scale + bias;
+        }
+
+        if (descriptor.expression && audioData) {
+            try {
+                const fn = new Function('audio', `return (${descriptor.expression});`);
+                value = fn(audioData);
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] expression failed', err);
+            }
+        }
+
+        if (descriptor.wave) {
+            const { speed = 1, amplitude = 1, phase = 0 } = descriptor.wave;
+            const t = this.choreographer.audio ? this.choreographer.audio.currentTime : 0;
+            value += Math.sin(t * speed + phase) * amplitude;
+        }
+
+        if (descriptor.mode) {
+            const current = this._getCurrentParameterValue(name);
+            value = this._applyMode(current, value, descriptor.mode, descriptor);
+        }
+
+        const range = descriptor.range || registryMeta.range;
+        if (range) {
+            value = this._applyRange(value, range);
+        }
+
+        if (descriptor.precision !== undefined && typeof value === 'number') {
+            const factor = Math.pow(10, descriptor.precision);
+            value = Math.round(value * factor) / factor;
+        }
+
+        return value;
+    }
+
+    _sampleAudioAxis(axis, audioData) {
+        if (!audioData) return 0;
+        if (typeof axis === 'string' && axis in audioData) {
+            return audioData[axis];
+        }
+        if (Array.isArray(axis)) {
+            return axis
+                .map(key => (typeof key === 'string' && key in audioData) ? audioData[key] : 0)
+                .reduce((acc, val) => acc + val, 0) / axis.length;
+        }
+        if (typeof axis === 'function') {
+            try {
+                return axis(audioData);
+            } catch (err) {
+                console.warn('[DynamicParameterBridge] audio axis fn failed', err);
+            }
+        }
+        return 0;
+    }
+
+    _applyRange(value, range) {
+        if (!range) return value;
+        if (Array.isArray(range)) {
+            const [min, max] = range;
+            if (typeof value === 'number') {
+                return Math.min(max ?? value, Math.max(min ?? value, value));
+            }
+            return value;
+        }
+        if (typeof range === 'object') {
+            const min = range.min ?? range.lower;
+            const max = range.max ?? range.upper;
+            if (typeof value === 'number') {
+                return Math.min(max ?? value, Math.max(min ?? value, value));
+            }
+        }
+        return value;
+    }
+
+    _applyMode(current, incoming, mode, descriptor) {
+        if (current === undefined || current === null || typeof current !== 'number') {
+            return incoming;
+        }
+
+        switch (mode) {
+            case 'add':
+            case 'additive':
+                return current + incoming;
+            case 'multiply':
+            case 'mult':
+                return current * incoming;
+            case 'mix': {
+                const weight = descriptor?.weight ?? descriptor?.mix ?? 0.5;
+                return current * (1 - weight) + incoming * weight;
+            }
+            case 'max':
+                return Math.max(current, incoming);
+            case 'min':
+                return Math.min(current, incoming);
+            default:
+                return incoming;
+        }
+    }
+
+    _getCurrentParameterValue(name) {
+        const engine = this.choreographer.currentEngine;
+        if (!engine) return undefined;
+
+        try {
+            if (engine.parameterManager) {
+                if (engine.parameterManager.getParameterValue) {
+                    return engine.parameterManager.getParameterValue(name);
+                }
+                if (engine.parameterManager.getParameter) {
+                    return engine.parameterManager.getParameter(name);
+                }
+            }
+        } catch (err) {
+            console.warn('[DynamicParameterBridge] getParameterValue failed', name, err);
+        }
+
+        if (name in engine) {
+            return engine[name];
+        }
+
+        return undefined;
+    }
+
+    _setEngineParameter(name, value, descriptor) {
+        const engine = this.choreographer.currentEngine;
+        if (!engine) return;
+
+        const meta = (descriptor && typeof descriptor === 'object') ? descriptor : {};
+        const registryMeta = this.parameterRegistry.get(name) || {};
+        const methodName = meta.method || registryMeta.method;
+        const target = meta.target || registryMeta.target || 'engine';
+        const allowOverflow = meta.allowOverflow ?? registryMeta.allowOverflow ?? false;
+        const definition = meta.definition || registryMeta.definition || registryMeta;
+
+        const applyToEngine = (eng) => {
+            if (!eng) return false;
+
+            if (methodName && typeof eng[methodName] === 'function') {
+                try {
+                    eng[methodName](value, meta, this.choreographer, registryMeta);
+                    return true;
+                } catch (err) {
+                    console.warn('[DynamicParameterBridge] method application failed', methodName, err);
+                }
+            }
+
+            if (eng.parameterManager) {
+                const definitionPayload = this._createParameterDefinition(definition);
+                if (eng.parameterManager.setParameterExternal && eng.parameterManager.setParameterExternal(name, value, {
+                    allowOverflow,
+                    register: !!(definitionPayload && (allowOverflow || this.parameterRegistry.has(name))),
+                    definition: definitionPayload,
+                    defaultValue: definitionPayload?.defaultValue ?? registryMeta.base ?? 0
+                })) {
+                    return true;
+                }
+
+                if (eng.parameterManager.setParameter && eng.parameterManager.setParameter(name, value)) {
+                    return true;
+                }
+            }
+
+            if (eng.updateParameter) {
+                try {
+                    eng.updateParameter(name, value);
+                    return true;
+                } catch (err) {
+                    console.warn('[DynamicParameterBridge] updateParameter failed', name, err);
+                }
+            }
+
+            if (eng.updateParameters) {
+                try {
+                    eng.updateParameters({ [name]: value });
+                    return true;
+                } catch (err) {
+                    console.warn('[DynamicParameterBridge] updateParameters failed', name, err);
+                }
+            }
+
+            if (name in eng) {
+                eng[name] = value;
+                return true;
+            }
+
+            return false;
+        };
+
+        if (target === 'manager' && this.choreographer.canvasManager) {
+            if (applyToEngine(this.choreographer.canvasManager)) return;
+        }
+
+        if (!applyToEngine(engine) && meta.fallbackToManager && this.choreographer.canvasManager) {
+            applyToEngine(this.choreographer.canvasManager);
+        }
+    }
+
+    _coerceNumber(...candidates) {
+        for (const candidate of candidates) {
+            if (candidate === undefined || candidate === null) continue;
+            const value = Number(candidate);
+            if (!Number.isNaN(value)) {
+                return value;
+            }
+        }
+        return 0;
+    }
+
+    _registerWithEngine(name, definition, engine = this.choreographer?.currentEngine) {
+        if (!engine || !engine.parameterManager || !engine.parameterManager.registerDynamicParameter) {
+            return;
+        }
+
+        const normalized = this._createParameterDefinition(definition);
+        if (!normalized) {
+            return;
+        }
+
+        engine.parameterManager.registerDynamicParameter(name, normalized);
+    }
+
+    _createParameterDefinition(definition = {}) {
+        if (!definition || typeof definition !== 'object') {
+            return null;
+        }
+
+        const output = {};
+
+        if (definition.range) {
+            if (Array.isArray(definition.range)) {
+                output.min = definition.range[0];
+                output.max = definition.range[1];
+            } else if (typeof definition.range === 'object') {
+                output.min = definition.range.min ?? definition.range.lower;
+                output.max = definition.range.max ?? definition.range.upper;
+            }
+        }
+
+        if (definition.min !== undefined) output.min = definition.min;
+        if (definition.max !== undefined) output.max = definition.max;
+        if (definition.step !== undefined) output.step = definition.step;
+        if (definition.type) output.type = definition.type;
+        if (definition.allowOverflow !== undefined) output.allowOverflow = definition.allowOverflow;
+        if (definition.default !== undefined) output.defaultValue = definition.default;
+        if (definition.base !== undefined && output.defaultValue === undefined) output.defaultValue = definition.base;
+
+        if (Object.keys(output).length === 0) {
+            return null;
+        }
+
+        return output;
+    }
+}

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -30,7 +30,7 @@ export class VIB34DIntegratedEngine {
         
         // Current state
         this.currentVariation = 0;
-        this.totalVariations = 100; // 30 default + 70 custom
+        this.totalVariations = this.variationManager?.totalVariations || 0;
         
         // Mouse interaction state
         this.mouseX = 0.5;
@@ -519,7 +519,11 @@ export class VIB34DIntegratedEngine {
                 visualizer.destroy();
             }
         });
-        
+
+        if (this.variationManager?.destroy) {
+            this.variationManager.destroy();
+        }
+
         console.log('🔄 VIB34D Engine destroyed');
     }
 }

--- a/src/core/Visualizer.js
+++ b/src/core/Visualizer.js
@@ -4,6 +4,7 @@
  */
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import { ReactiveVisualizerInspector } from '../diagnostics/ReactiveVisualizerInspector.js';
 
 export class IntegratedHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
@@ -617,6 +618,18 @@ void main() {
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.roleIntensity, roleIntensities[this.role] || 1.0);
+
+        ReactiveVisualizerInspector.inspectAndReport('integrated-holographic', {
+            rot4dXW: this.params.rot4dXW,
+            rot4dYW: this.params.rot4dYW,
+            rot4dZW: this.params.rot4dZW
+        }, {
+            audioReactive: typeof window !== 'undefined' ? window.audioReactive : null,
+            geometryIndex: this.params.geometry,
+            geometryLabel: GeometryLibrary?.getGeometryName?.(this.params.geometry) || null,
+            canvasId: this.canvas?.id,
+            variant: this.variant || null
+        });
         
         try {
             this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);

--- a/src/diagnostics/ReactiveVisualizerInspector.js
+++ b/src/diagnostics/ReactiveVisualizerInspector.js
@@ -1,0 +1,784 @@
+/**
+ * Reactive Visualizer Inspector
+ * Provides lightweight diagnostics for 4D rotation parameters and audio reactivity
+ * across all visualizer implementations. Designed to work both in browser runtime
+ * and Node-based diagnostics so we can validate behaviour without a WebGL context.
+ */
+
+const ROTATION_MAX = 2;
+const ROTATION_TOLERANCE = 0.05;
+
+export class ReactiveVisualizerInspector {
+    static throttleMs = 750;
+    static lastLogByVisualizer = new Map();
+    static storedSummaries = [];
+    static listeners = new Set();
+    static lastSummary = null;
+    static lastSummaryByVisualizer = new Map();
+    static historyLimit = 50;
+    static sessionCounter = 0;
+    static currentSession = null;
+    static completedSessions = [];
+    static sessionListeners = new Set();
+    static rotationJitterThreshold = 0.65;
+    static rotationStillnessTolerance = 0.12;
+    static audioSpikeThreshold = 0.35;
+    static audioStillnessTolerance = 0.1;
+    static intervalWarningMs = 1500;
+
+    static get debugState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+        window.VIB34D_DEBUG = window.VIB34D_DEBUG || {};
+        window.VIB34D_DEBUG.reactiveInspector = window.VIB34D_DEBUG.reactiveInspector || {};
+        return window.VIB34D_DEBUG.reactiveInspector;
+    }
+
+    static resetContinuityState() {
+        this.lastSummaryByVisualizer.clear();
+    }
+
+    /**
+     * Inspect visualizer parameters and return a structured diagnostic summary.
+     * @param {string} visualizerName
+     * @param {{rot4dXW?: number, rot4dYW?: number, rot4dZW?: number}} params
+     * @param {{
+     *   audioReactive?: { bass?: number, mid?: number, high?: number, energy?: number },
+     *   geometryIndex?: number | null,
+     *   geometryLabel?: string | null,
+     *   canvasId?: string | null,
+     *   variant?: string | number | null
+     * }} context
+     */
+    static inspect(visualizerName, params = {}, context = {}) {
+        const rotation = this.computeRotationMetrics(params);
+        const audio = this.computeAudioMetrics(context.audioReactive);
+        const effect = this.describeEffect(rotation, audio);
+        const warnings = this.collectWarnings(rotation, effect);
+
+        return {
+            visualizer: visualizerName,
+            timestamp: Date.now(),
+            rotation,
+            audio,
+            effect,
+            warnings,
+            geometryIndex: context.geometryIndex ?? null,
+            geometryLabel: context.geometryLabel ?? null,
+            canvasId: context.canvasId ?? null,
+            variant: context.variant ?? null
+        };
+    }
+
+    static inspectAndReport(visualizerName, params = {}, context = {}) {
+        const summary = this.inspect(visualizerName, params, context);
+        const continuity = this.applyContinuityAnalysis(summary);
+        if (continuity) {
+            summary.continuity = continuity;
+            if (Array.isArray(continuity.warnings) && continuity.warnings.length) {
+                summary.warnings.push(...continuity.warnings);
+            }
+        }
+        this.warnIfNeeded(summary);
+        this.logIfRequested(summary);
+        this.storeSummary(summary);
+        return summary;
+    }
+
+    static computeRotationMetrics({ rot4dXW = 0, rot4dYW = 0, rot4dZW = 0 } = {}) {
+        const magnitude = Math.sqrt(rot4dXW ** 2 + rot4dYW ** 2 + rot4dZW ** 2);
+        const normalizedMagnitude = ROTATION_MAX === 0
+            ? 0
+            : magnitude / (Math.sqrt(3) * ROTATION_MAX);
+        const dominant = this.findDominantAxis({ rot4dXW, rot4dYW, rot4dZW });
+        const withinRange = [rot4dXW, rot4dYW, rot4dZW].every((value) =>
+            Math.abs(value) <= ROTATION_MAX + ROTATION_TOLERANCE
+        );
+
+        return {
+            values: { rot4dXW, rot4dYW, rot4dZW },
+            magnitude,
+            normalizedMagnitude,
+            withinRange,
+            dominantAxis: dominant.axis,
+            dominantValue: dominant.value
+        };
+    }
+
+    static computeAudioMetrics(audio = {}) {
+        const bass = this.normalizeAudioValue(audio.bass);
+        const mid = this.normalizeAudioValue(audio.mid);
+        const high = this.normalizeAudioValue(audio.high);
+        const energy = this.normalizeAudioValue(audio.energy);
+
+        const magnitude = Math.sqrt(bass ** 2 + mid ** 2 + high ** 2 + energy ** 2);
+        const normalizedMagnitude = Math.min(1, magnitude / 2);
+
+        return {
+            bass,
+            mid,
+            high,
+            energy,
+            magnitude,
+            normalizedMagnitude
+        };
+    }
+
+    static describeEffect(rotation, audio) {
+        const normalized = rotation.normalizedMagnitude;
+        let stage = 'intro';
+        if (normalized >= 0.75) {
+            stage = 'drop';
+        } else if (normalized >= 0.45) {
+            stage = 'build';
+        } else if (normalized >= 0.2) {
+            stage = 'verse';
+        }
+
+        const dominant = rotation.dominantAxis;
+        const axisDescriptions = {
+            rot4dXW: 'bass-driven horizontal hyper-spin',
+            rot4dYW: 'vertical melodic morph',
+            rot4dZW: 'depth-driven percussive rotation'
+        };
+
+        const stageDescriptions = {
+            intro: 'minimal rotational drift – ideal for ambient intros',
+            verse: 'steady multi-plane morph for structural grooves',
+            build: 'escalating multi-axis swirl preparing for a drop',
+            drop: 'full-spectrum 4D rotation with maximum impact'
+        };
+
+        return {
+            stage,
+            dominantAxis: dominant,
+            description: `${stageDescriptions[stage]} (${axisDescriptions[dominant]})`,
+            rotationIntensity: normalized,
+            audioSupport: audio.normalizedMagnitude
+        };
+    }
+
+    static collectWarnings(rotation, effect) {
+        const warnings = [];
+        if (!rotation.withinRange) {
+            warnings.push('4D rotation values exceed safe range (±2 radians).');
+        }
+        if (effect.rotationIntensity < 0.05 && effect.audioSupport > 0.6) {
+            warnings.push('High audio energy detected but rotations remain static.');
+        }
+        return warnings;
+    }
+
+    static applyContinuityAnalysis(summary) {
+        if (!summary || !summary.visualizer) {
+            return null;
+        }
+
+        const previous = this.lastSummaryByVisualizer.get(summary.visualizer) || null;
+        const continuity = {
+            hasPrevious: Boolean(previous),
+            rotationDelta: 0,
+            audioDelta: 0,
+            intervalMs: 0,
+            jitter: false,
+            lag: false,
+            intervalAnomaly: false,
+            warnings: []
+        };
+
+        if (previous) {
+            const currentRotation = summary?.rotation?.magnitude ?? 0;
+            const previousRotation = previous?.rotation?.magnitude ?? 0;
+            const currentAudio = summary?.effect?.audioSupport ?? 0;
+            const previousAudio = previous?.effect?.audioSupport ?? 0;
+
+            continuity.rotationDelta = Math.abs(currentRotation - previousRotation);
+            continuity.audioDelta = Math.abs(currentAudio - previousAudio);
+            continuity.intervalMs = Math.max(0, summary.timestamp - (previous.timestamp ?? summary.timestamp));
+
+            if (continuity.rotationDelta > this.rotationJitterThreshold && continuity.audioDelta <= this.audioStillnessTolerance) {
+                continuity.jitter = true;
+                continuity.warnings.push('Rotation jitter spike detected without matching audio change.');
+            }
+
+            if (continuity.audioDelta > this.audioSpikeThreshold && continuity.rotationDelta <= this.rotationStillnessTolerance) {
+                continuity.lag = true;
+                continuity.warnings.push('Audio-reactive spike detected without rotation response.');
+            }
+
+            if (continuity.intervalMs > this.intervalWarningMs) {
+                continuity.intervalAnomaly = true;
+                continuity.warnings.push(`Telemetry gap detected (${Math.round(continuity.intervalMs)}ms).`);
+            }
+        }
+
+        this.lastSummaryByVisualizer.set(summary.visualizer, summary);
+        return continuity;
+    }
+
+    static warnIfNeeded(summary) {
+        if (!summary.warnings.length) {
+            return;
+        }
+        const message = `⚠️ [${summary.visualizer}] ${summary.warnings.join(' ')}`;
+        if (typeof console !== 'undefined') {
+            console.warn(message, summary);
+        }
+    }
+
+    static logIfRequested(summary) {
+        if (!this.shouldLog()) {
+            return;
+        }
+        const now = Date.now();
+        const lastLog = this.lastLogByVisualizer.get(summary.visualizer) || 0;
+        if (now - lastLog < this.throttleMs) {
+            return;
+        }
+        this.lastLogByVisualizer.set(summary.visualizer, now);
+        const logFn = console?.table ? console.table.bind(console) : console.log.bind(console);
+        logFn({
+            visualizer: summary.visualizer,
+            canvas: summary.canvasId ?? 'n/a',
+            geometry: summary.geometryLabel ?? summary.geometryIndex ?? 'n/a',
+            rot4dXW: summary.rotation.values.rot4dXW.toFixed(2),
+            rot4dYW: summary.rotation.values.rot4dYW.toFixed(2),
+            rot4dZW: summary.rotation.values.rot4dZW.toFixed(2),
+            rotationStage: summary.effect.stage,
+            audioSupport: summary.effect.audioSupport.toFixed(2)
+        });
+    }
+
+    static storeSummary(summary) {
+        const session = this.ensureActiveSession();
+        summary.sessionId = session?.id ?? null;
+
+        this.lastSummary = summary;
+        const debugState = this.debugState;
+        if (debugState) {
+            debugState.lastSummary = summary;
+            if (!Array.isArray(debugState.history)) {
+                debugState.history = [];
+            }
+            debugState.history.push(summary);
+            const limit = typeof debugState.historyLimit === 'number'
+                ? Math.max(1, debugState.historyLimit)
+                : this.historyLimit;
+            if (debugState.history.length > limit) {
+                debugState.history.splice(0, debugState.history.length - limit);
+            }
+        } else {
+            // Node diagnostics fallback for unit tests
+            this.storedSummaries.push(summary);
+            if (this.storedSummaries.length > this.historyLimit) {
+                this.storedSummaries.splice(0, this.storedSummaries.length - this.historyLimit);
+            }
+        }
+        if (session) {
+            if (!session.firstSummaryTimestamp) {
+                session.firstSummaryTimestamp = summary.timestamp;
+            }
+            session.sampleCount += 1;
+            session.lastTimestamp = summary.timestamp;
+            session.endedAt = null;
+            this.notifySessionListeners(this.getSessionInfo());
+        }
+
+        this.notifyListeners(summary);
+    }
+
+    static getHistory() {
+        const debugState = this.debugState;
+        if (debugState && Array.isArray(debugState.history)) {
+            return [...debugState.history];
+        }
+        return [...this.storedSummaries];
+    }
+
+    static clearHistory() {
+        const debugState = this.debugState;
+        if (debugState) {
+            debugState.history = [];
+            debugState.lastSummary = null;
+        }
+        this.storedSummaries.length = 0;
+        this.lastSummary = null;
+        this.lastLogByVisualizer.clear();
+        this.resetContinuityState();
+
+        if (this.currentSession && !this.currentSession.endedAt) {
+            this.currentSession.sampleCount = 0;
+            this.currentSession.firstSummaryTimestamp = null;
+            this.currentSession.lastTimestamp = null;
+            this.notifySessionListeners(this.getSessionInfo());
+        }
+    }
+
+    static setHistoryLimit(limit) {
+        const parsed = Number(limit);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+            return this.historyLimit;
+        }
+        const normalized = Math.max(1, Math.floor(parsed));
+        this.historyLimit = normalized;
+
+        const debugState = this.debugState;
+        if (debugState) {
+            debugState.historyLimit = normalized;
+            if (Array.isArray(debugState.history) && debugState.history.length > normalized) {
+                debugState.history.splice(0, debugState.history.length - normalized);
+            }
+        }
+
+        if (this.storedSummaries.length > normalized) {
+            this.storedSummaries.splice(0, this.storedSummaries.length - normalized);
+        }
+
+        return this.historyLimit;
+    }
+
+    static computeRollingMetrics(sampleSize = 10) {
+        const history = this.getHistory();
+        if (!history.length) {
+            return {
+                sampleSize: 0,
+                rotationMagnitude: { average: 0, min: 0, max: 0 },
+                audioSupportAverage: 0,
+                warningRate: 0,
+                stageCounts: {},
+                dominantAxisFrequency: {},
+                latestSummary: null
+            };
+        }
+
+        const size = Math.min(history.length, Math.max(1, Math.floor(Number(sampleSize) || 1)));
+        const subset = history.slice(history.length - size);
+
+        const stageCounts = { intro: 0, verse: 0, build: 0, drop: 0 };
+        const dominantAxisFrequency = { rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 };
+        let rotationSum = 0;
+        let audioSupportSum = 0;
+        let warningsCount = 0;
+        let rotationMin = Number.POSITIVE_INFINITY;
+        let rotationMax = Number.NEGATIVE_INFINITY;
+
+        subset.forEach((entry) => {
+            const rotationMagnitude = entry?.rotation?.magnitude ?? 0;
+            const audioSupport = entry?.effect?.audioSupport ?? 0;
+            const stage = entry?.effect?.stage;
+            const axis = entry?.rotation?.dominantAxis;
+            const warningTotal = Array.isArray(entry?.warnings) ? entry.warnings.length : 0;
+
+            rotationSum += rotationMagnitude;
+            audioSupportSum += audioSupport;
+            warningsCount += warningTotal;
+            rotationMin = Math.min(rotationMin, rotationMagnitude);
+            rotationMax = Math.max(rotationMax, rotationMagnitude);
+
+            if (stage) {
+                stageCounts[stage] = (stageCounts[stage] ?? 0) + 1;
+            }
+            if (axis) {
+                dominantAxisFrequency[axis] = (dominantAxisFrequency[axis] ?? 0) + 1;
+            }
+        });
+
+        if (!Number.isFinite(rotationMin)) {
+            rotationMin = 0;
+        }
+        if (!Number.isFinite(rotationMax)) {
+            rotationMax = 0;
+        }
+
+        return {
+            sampleSize: subset.length,
+            rotationMagnitude: {
+                average: rotationSum / subset.length,
+                min: rotationMin,
+                max: rotationMax
+            },
+            audioSupportAverage: audioSupportSum / subset.length,
+            warningRate: subset.length ? warningsCount / subset.length : 0,
+            stageCounts,
+            dominantAxisFrequency,
+            latestSummary: subset[subset.length - 1] ?? null
+        };
+    }
+
+    static summarizeContinuity(history) {
+        const stats = {
+            samples: 0,
+            rotationJitterEvents: 0,
+            audioLagEvents: 0,
+            intervalAnomalies: 0,
+            averageIntervalMs: 0,
+            lastIntervalMs: 0,
+            lastRotationDelta: 0,
+            lastAudioDelta: 0
+        };
+
+        if (!Array.isArray(history) || !history.length) {
+            return stats;
+        }
+
+        let intervalSum = 0;
+
+        history.forEach((entry) => {
+            const continuity = entry?.continuity;
+            if (!continuity || !continuity.hasPrevious) {
+                return;
+            }
+
+            if (continuity.jitter) {
+                stats.rotationJitterEvents += 1;
+            }
+            if (continuity.lag) {
+                stats.audioLagEvents += 1;
+            }
+            if (continuity.intervalAnomaly) {
+                stats.intervalAnomalies += 1;
+            }
+
+            if (Number.isFinite(continuity.intervalMs) && continuity.intervalMs >= 0) {
+                intervalSum += continuity.intervalMs;
+                stats.samples += 1;
+                stats.lastIntervalMs = continuity.intervalMs;
+            }
+
+            if (Number.isFinite(continuity.rotationDelta)) {
+                stats.lastRotationDelta = continuity.rotationDelta;
+            }
+
+            if (Number.isFinite(continuity.audioDelta)) {
+                stats.lastAudioDelta = continuity.audioDelta;
+            }
+        });
+
+        if (stats.samples > 0) {
+            stats.averageIntervalMs = intervalSum / stats.samples;
+        }
+
+        return stats;
+    }
+
+    static getContinuityMetrics() {
+        return this.summarizeContinuity(this.getHistory());
+    }
+
+    static generateReport({ sampleSize = 12, includeHistory = false, includeMetrics = true, includeCompletedSessions = false } = {}) {
+        const history = this.getHistory();
+        const report = {
+            generatedAt: new Date().toISOString(),
+            historyLimit: this.historyLimit,
+            totalSamples: history.length,
+            visualizerUsage: {},
+            geometryUsage: {},
+            variantUsage: {},
+            warnings: { total: 0, byMessage: {} },
+            rangeViolations: 0,
+            stalledFrames: 0,
+            stageTotals: { intro: 0, verse: 0, build: 0, drop: 0 },
+            dominantAxisTotals: { rot4dXW: 0, rot4dYW: 0, rot4dZW: 0 },
+            audioEnergy: { min: 0, max: 0, average: 0 },
+            latestSummary: this.lastSummary,
+            session: this.getSessionInfo()
+        };
+
+        if (history.length) {
+            const warningMessages = report.warnings.byMessage;
+            let audioMin = Number.POSITIVE_INFINITY;
+            let audioMax = Number.NEGATIVE_INFINITY;
+            let audioSum = 0;
+
+            history.forEach((entry) => {
+                const name = entry?.visualizer ?? 'unknown';
+                report.visualizerUsage[name] = (report.visualizerUsage[name] ?? 0) + 1;
+
+                const geometryLabel = entry?.geometryLabel ?? (typeof entry?.geometryIndex === 'number'
+                    ? `#${entry.geometryIndex}`
+                    : 'unassigned');
+                report.geometryUsage[geometryLabel] = (report.geometryUsage[geometryLabel] ?? 0) + 1;
+
+                const variantKey = entry?.variant != null ? String(entry.variant) : 'unassigned';
+                report.variantUsage[variantKey] = (report.variantUsage[variantKey] ?? 0) + 1;
+
+                const stage = entry?.effect?.stage;
+                if (stage) {
+                    report.stageTotals[stage] = (report.stageTotals[stage] ?? 0) + 1;
+                }
+
+                const axis = entry?.rotation?.dominantAxis;
+                if (axis) {
+                    report.dominantAxisTotals[axis] = (report.dominantAxisTotals[axis] ?? 0) + 1;
+                }
+
+                if (entry?.warnings?.length) {
+                    report.warnings.total += entry.warnings.length;
+                    entry.warnings.forEach((warning) => {
+                        const key = warning || 'Unknown warning';
+                        warningMessages[key] = (warningMessages[key] ?? 0) + 1;
+                    });
+                }
+
+                if (entry?.rotation && entry.rotation.withinRange === false) {
+                    report.rangeViolations += 1;
+                }
+
+                const rotationIntensity = entry?.effect?.rotationIntensity ?? 0;
+                const audioSupport = entry?.effect?.audioSupport ?? 0;
+                if (audioSupport > 0.6 && rotationIntensity < 0.1) {
+                    report.stalledFrames += 1;
+                }
+
+                const energy = entry?.audio?.energy ?? 0;
+                audioMin = Math.min(audioMin, energy);
+                audioMax = Math.max(audioMax, energy);
+                audioSum += energy;
+            });
+
+            if (Number.isFinite(audioMin)) {
+                report.audioEnergy.min = audioMin;
+            }
+            if (Number.isFinite(audioMax)) {
+                report.audioEnergy.max = audioMax;
+            }
+            report.audioEnergy.average = history.length ? audioSum / history.length : 0;
+        }
+
+        if (includeMetrics) {
+            report.metrics = this.computeRollingMetrics(sampleSize);
+        }
+
+        report.continuity = this.summarizeContinuity(history);
+
+        if (includeHistory) {
+            report.history = history;
+        }
+
+        if (includeCompletedSessions) {
+            report.completedSessions = this.completedSessions.map((session) => ({ ...session }));
+        }
+
+        return report;
+    }
+
+    static addListener(listener, { replayLast = true } = {}) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+        this.listeners.add(listener);
+        if (replayLast && this.lastSummary) {
+            try {
+                listener(this.lastSummary);
+            } catch (error) {
+                console.error('ReactiveVisualizerInspector listener error (initial replay):', error);
+            }
+        }
+        return () => this.removeListener(listener);
+    }
+
+    static removeListener(listener) {
+        this.listeners.delete(listener);
+    }
+
+    static notifyListeners(summary) {
+        this.listeners.forEach((listener) => {
+            try {
+                listener(summary);
+            } catch (error) {
+                console.error('ReactiveVisualizerInspector listener error:', error);
+            }
+        });
+    }
+
+    static getLastSummary() {
+        return this.lastSummary;
+    }
+
+    static findDominantAxis(rotations) {
+        return Object.entries(rotations).reduce((dominant, [axis, value]) => {
+            if (Math.abs(value) > Math.abs(dominant.value)) {
+                return { axis, value };
+            }
+            return dominant;
+        }, { axis: 'rot4dXW', value: rotations.rot4dXW });
+    }
+
+    static normalizeAudioValue(value) {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(1, value));
+    }
+
+    static shouldLog() {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+        return Boolean(this.debugState?.log);
+    }
+
+    static ensureActiveSession() {
+        if (!this.currentSession || this.currentSession.endedAt) {
+            const now = Date.now();
+            this.sessionCounter += 1;
+            const label = this.currentSession?.endedAt && this.currentSession?.label
+                ? `${this.currentSession.label} · next`
+                : `Session ${this.sessionCounter}`;
+            const metadata = this.currentSession?.endedAt && this.currentSession?.metadata
+                ? { ...this.currentSession.metadata }
+                : {};
+            this.currentSession = {
+                id: `session-${now}-${Math.random().toString(16).slice(2, 8)}`,
+                label,
+                metadata,
+                startedAt: now,
+                sampleCount: 0,
+                firstSummaryTimestamp: null,
+                lastTimestamp: null,
+                endedAt: null
+            };
+            this.notifySessionListeners(this.getSessionInfo());
+        }
+        return this.currentSession;
+    }
+
+    static beginSession({ label, metadata = {}, resetHistory = true } = {}) {
+        const now = Date.now();
+        if (this.currentSession) {
+            if (!this.currentSession.endedAt) {
+                this.currentSession.endedAt = now;
+            }
+            const snapshot = this.getSessionInfo();
+            if (snapshot) {
+                this.completedSessions.push(snapshot);
+            }
+        }
+
+        if (resetHistory) {
+            this.clearHistory();
+        }
+
+        this.sessionCounter += 1;
+        const sessionLabel = typeof label === 'string' && label.trim()
+            ? label.trim()
+            : `Session ${this.sessionCounter}`;
+        this.currentSession = {
+            id: `session-${now}-${Math.random().toString(16).slice(2, 8)}`,
+            label: sessionLabel,
+            metadata: { ...metadata },
+            startedAt: now,
+            sampleCount: 0,
+            firstSummaryTimestamp: null,
+            lastTimestamp: null,
+            endedAt: null
+        };
+        this.notifySessionListeners(this.getSessionInfo());
+        return this.getSessionInfo();
+    }
+
+    static endSession({ finalizeReport = false, sampleSize = 12, includeHistory = true, includeMetrics = true, includeCompletedSessions = false, resetHistory = true } = {}) {
+        if (!this.currentSession) {
+            const emptyReport = finalizeReport
+                ? this.generateReport({ sampleSize, includeHistory, includeMetrics, includeCompletedSessions })
+                : null;
+            return { session: null, report: emptyReport };
+        }
+
+        const now = Date.now();
+        if (!this.currentSession.startedAt) {
+            this.currentSession.startedAt = now;
+        }
+        this.currentSession.endedAt = now;
+
+        const sessionSnapshot = this.getSessionInfo();
+        this.completedSessions.push(sessionSnapshot);
+        this.notifySessionListeners(sessionSnapshot);
+
+        const report = finalizeReport
+            ? this.generateReport({ sampleSize, includeHistory, includeMetrics, includeCompletedSessions })
+            : null;
+
+        if (resetHistory) {
+            this.clearHistory();
+        }
+
+        this.currentSession = null;
+        this.notifySessionListeners(null);
+        return { session: sessionSnapshot, report };
+    }
+
+    static getSessionInfo() {
+        if (!this.currentSession) {
+            return null;
+        }
+        const now = Date.now();
+        const endedAt = this.currentSession.endedAt ?? null;
+        const durationMs = (endedAt ?? now) - (this.currentSession.startedAt ?? now);
+        return {
+            id: this.currentSession.id,
+            label: this.currentSession.label,
+            metadata: { ...this.currentSession.metadata },
+            startedAt: this.currentSession.startedAt,
+            endedAt,
+            sampleCount: this.currentSession.sampleCount,
+            durationMs,
+            firstSummaryTimestamp: this.currentSession.firstSummaryTimestamp ?? null,
+            lastTimestamp: this.currentSession.lastTimestamp ?? null
+        };
+    }
+
+    static getCompletedSessions() {
+        return this.completedSessions.map((session) => ({ ...session }));
+    }
+
+    static updateSession({ label, metadata } = {}) {
+        const session = this.ensureActiveSession();
+        if (!session) {
+            return null;
+        }
+        if (typeof label === 'string') {
+            const trimmed = label.trim();
+            if (trimmed) {
+                session.label = trimmed;
+            }
+        }
+        if (metadata && typeof metadata === 'object') {
+            session.metadata = { ...session.metadata, ...metadata };
+        }
+        this.notifySessionListeners(this.getSessionInfo());
+        return this.getSessionInfo();
+    }
+
+    static addSessionListener(listener, { replayCurrent = true } = {}) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+        this.sessionListeners.add(listener);
+        if (replayCurrent) {
+            try {
+                listener(this.getSessionInfo());
+            } catch (error) {
+                console.error('ReactiveVisualizerInspector session listener error (initial replay):', error);
+            }
+        }
+        return () => this.removeSessionListener(listener);
+    }
+
+    static removeSessionListener(listener) {
+        this.sessionListeners.delete(listener);
+    }
+
+    static notifySessionListeners(sessionInfo) {
+        this.sessionListeners.forEach((listener) => {
+            try {
+                listener(sessionInfo);
+            } catch (error) {
+                console.error('ReactiveVisualizerInspector session listener error:', error);
+            }
+        });
+    }
+}
+
+export default ReactiveVisualizerInspector;

--- a/src/geometry/GeometryLibrary.js
+++ b/src/geometry/GeometryLibrary.js
@@ -5,24 +5,245 @@
  */
 
 export class GeometryLibrary {
+    static baseGeometries = [
+        'TETRAHEDRON',
+        'HYPERCUBE',
+        'SPHERE',
+        'TORUS',
+        'KLEIN BOTTLE',
+        'FRACTAL',
+        'WAVE',
+        'CRYSTAL'
+    ];
+
+    static baseGeometryClassMap = {
+        'TETRAHEDRON': 'tetrahedron',
+        'HYPERCUBE': 'hypercube',
+        'SPHERE': 'sphere',
+        'TORUS': 'torus',
+        'KLEIN BOTTLE': 'klein',
+        'FRACTAL': 'fractal',
+        'WAVE': 'wave',
+        'CRYSTAL': 'crystal'
+    };
+
+    static customGeometries = [];
+
+    static listeners = new Set();
+    static version = 0;
+
     static getGeometryNames() {
-        return [
-            'TETRAHEDRON',
-            'HYPERCUBE', 
-            'SPHERE',
-            'TORUS',
-            'KLEIN BOTTLE',
-            'FRACTAL',
-            'WAVE',
-            'CRYSTAL'
-        ];
+        return [...this.baseGeometries, ...this.customGeometries];
     }
-    
+
     static getGeometryName(type) {
         const names = this.getGeometryNames();
         return names[type] || 'UNKNOWN';
     }
-    
+
+    static normalizeName(name) {
+        if (typeof name !== 'string') {
+            return '';
+        }
+        return name.trim().replace(/\s+/g, ' ');
+    }
+
+    static formatDisplayName(name) {
+        return (name || '')
+            .split(' ')
+            .filter(Boolean)
+            .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+            .join(' ');
+    }
+
+    static formatCssClass(key, fallbackIndex = 0) {
+        const base = (key || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-');
+        if (!base) {
+            return `geometry-${fallbackIndex}`;
+        }
+        return `geometry-${base}`;
+    }
+
+    static getLevelCountForKey(key) {
+        switch (key) {
+            case 'FRACTAL':
+            case 'WAVE':
+                return 3;
+            default:
+                return 4;
+        }
+    }
+
+    static getGeometryMetadata(names) {
+        const list = Array.isArray(names) && names.length ? names : this.getGeometryNames();
+        const seen = new Set();
+
+        const metadata = [];
+        list.forEach((name) => {
+            const normalized = this.normalizeName(name);
+            if (!normalized) {
+                return;
+            }
+
+            const key = normalized.toUpperCase();
+            if (seen.has(key)) {
+                return;
+            }
+            seen.add(key);
+
+            const geometryIndex = metadata.length;
+            metadata.push({
+                key,
+                rawName: normalized,
+                displayName: this.formatDisplayName(normalized),
+                cssClass: this.baseGeometryClassMap[key] || this.formatCssClass(key, geometryIndex),
+                levels: this.getLevelCountForKey(key),
+                geometryIndex
+            });
+        });
+
+        return metadata;
+    }
+
+    static buildVariationDefinitions(metadata = this.getGeometryMetadata(), target = 30) {
+        if (!Array.isArray(metadata) || !metadata.length) {
+            return [];
+        }
+
+        const perGeometry = metadata.map(meta => {
+            const levelCount = Math.max(1, meta.levels || 1);
+            const entries = [];
+            for (let level = 0; level < levelCount; level += 1) {
+                entries.push({
+                    geometryIndex: meta.geometryIndex,
+                    geometryKey: meta.key,
+                    cssClass: meta.cssClass,
+                    displayName: meta.displayName,
+                    level,
+                    label: `${meta.key} LATTICE ${level + 1}`,
+                    displayLabel: `${meta.displayName} Lattice ${level + 1}`,
+                    shortLabel: `Level ${level + 1}`
+                });
+            }
+            return entries;
+        });
+
+        const definitions = [];
+        let levelIndex = 0;
+        let added = true;
+
+        while (definitions.length < target && added) {
+            added = false;
+            perGeometry.forEach(entries => {
+                if (definitions.length >= target) {
+                    return;
+                }
+                if (entries[levelIndex]) {
+                    definitions.push(entries[levelIndex]);
+                    added = true;
+                }
+            });
+            levelIndex += 1;
+        }
+
+        if (!definitions.length && perGeometry.length) {
+            const fallback = perGeometry.find(list => list.length);
+            if (fallback && fallback.length) {
+                definitions.push(fallback[0]);
+            }
+        }
+
+        return definitions;
+    }
+
+    static hasGeometry(name) {
+        const normalized = this.normalizeName(name).toUpperCase();
+        if (!normalized) return false;
+        return this.getGeometryNames().some(item => item.toUpperCase() === normalized);
+    }
+
+    static registerGeometry(name) {
+        const normalized = this.normalizeName(name);
+        if (!normalized) {
+            return false;
+        }
+
+        if (this.hasGeometry(normalized)) {
+            return false;
+        }
+
+        this.customGeometries.push(normalized.toUpperCase());
+        this.version += 1;
+        this.notifyListeners();
+        return true;
+    }
+
+    static clearCustomGeometries() {
+        if (!this.customGeometries.length) {
+            return;
+        }
+
+        this.customGeometries = [];
+        this.version += 1;
+        this.notifyListeners();
+    }
+
+    static replaceCustomGeometries(list = []) {
+        const normalized = Array.isArray(list) ? list : [list];
+        const newEntries = normalized
+            .map(name => this.normalizeName(name))
+            .filter(Boolean)
+            .map(name => name.toUpperCase());
+
+        const changed = newEntries.length !== this.customGeometries.length
+            || newEntries.some((entry, index) => entry !== this.customGeometries[index]);
+
+        if (!changed) {
+            return false;
+        }
+
+        this.customGeometries = newEntries;
+        this.version += 1;
+        this.notifyListeners();
+        return true;
+    }
+
+    static subscribe(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+
+        this.listeners.add(listener);
+        try {
+            listener({
+                names: this.getGeometryNames(),
+                version: this.version
+            });
+        } catch (err) {
+            console.warn('[GeometryLibrary] listener threw during subscribe', err);
+        }
+
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    static notifyListeners() {
+        const payload = {
+            names: this.getGeometryNames(),
+            version: this.version
+        };
+        this.listeners.forEach(listener => {
+            try {
+                listener(payload);
+            } catch (err) {
+                console.warn('[GeometryLibrary] listener failed', err);
+            }
+        });
+    }
+
     /**
      * Get variation parameters for specific geometry and level
      */

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -1,3 +1,12 @@
+import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import { ReactiveVisualizerInspector } from '../diagnostics/ReactiveVisualizerInspector.js';
+import {
+    DEFAULT_VARIATION_TARGET,
+    resolveVariantCatalog,
+    normalizeVariantIndex,
+    buildVariantParams
+} from './VariantCatalog.js';
+
 /**
  * Core Holographic Visualizer - Clean WebGL rendering engine
  * Extracted from working system, no debugging mess
@@ -8,6 +17,9 @@ export class HolographicVisualizer {
         this.role = role;
         this.reactivity = reactivity;
         this.variant = variant;
+        this.variantTarget = DEFAULT_VARIATION_TARGET;
+        this.variantDefinitions = [];
+        this.geometryUnsubscribe = null;
         
         // CRITICAL FIX: Define contextOptions as instance property to match SmartCanvasPool
         this.contextOptions = {
@@ -41,9 +53,18 @@ export class HolographicVisualizer {
             this.showWebGLError();
             throw new Error(`WebGL not supported for ${canvasId}`);
         }
-        
-        this.variantParams = this.generateVariantParams(variant);
+
+        this.refreshVariantDefinitions();
+        this.variant = normalizeVariantIndex(this.variant, this.variantDefinitions);
+        this.variantParams = this.generateVariantParams(this.variant);
         this.roleParams = this.generateRoleParams(role);
+
+        this.geometryUnsubscribe = GeometryLibrary.subscribe((payload) => {
+            this.refreshVariantDefinitions(payload?.names);
+            this.variant = normalizeVariantIndex(this.variant, this.variantDefinitions);
+            this.variantParams = this.generateVariantParams(this.variant);
+            this.roleParams = this.generateRoleParams(this.role);
+        });
         
         // Initialize state
         this.mouseX = 0.5;
@@ -83,54 +104,37 @@ export class HolographicVisualizer {
         this.resize();
     }
     
+    refreshVariantDefinitions(names) {
+        const { definitions } = resolveVariantCatalog(this.variantTarget, names);
+        if (definitions.length) {
+            this.variantDefinitions = definitions;
+        } else if (!this.variantDefinitions.length) {
+            this.variantDefinitions = [{
+                geometryIndex: 0,
+                geometryKey: 'TETRAHEDRON',
+                cssClass: 'tetrahedron',
+                displayName: 'Tetrahedron',
+                displayLabel: 'Tetrahedron Lattice 1',
+                level: 0
+            }];
+        }
+    }
+
+    ensureVariantDefinitions() {
+        if (!Array.isArray(this.variantDefinitions) || !this.variantDefinitions.length) {
+            this.refreshVariantDefinitions();
+        }
+    }
+
+    getVariantCount() {
+        this.ensureVariantDefinitions();
+        return this.variantDefinitions.length;
+    }
+
     generateVariantParams(variant) {
-        const vib3Geometries = [
-            'TETRAHEDRON', 'HYPERCUBE', 'SPHERE', 'TORUS', 
-            'KLEIN BOTTLE', 'FRACTAL', 'WAVE', 'CRYSTAL'
-        ];
-        
-        const geometryMap = [
-            0, 0, 0, 0,  // 0-3: TETRAHEDRON variations
-            1, 1, 1, 1,  // 4-7: HYPERCUBE variations
-            2, 2, 2, 2,  // 8-11: SPHERE variations
-            3, 3, 3, 3,  // 12-15: TORUS variations
-            4, 4, 4, 4,  // 16-19: KLEIN BOTTLE variations
-            5, 5, 5,     // 20-22: FRACTAL variations
-            6, 6, 6,     // 23-25: WAVE variations
-            7, 7, 7, 7   // 26-29: CRYSTAL variations
-        ];
-        
-        const baseGeometry = geometryMap[variant] || 0;
-        const variationLevel = variant % 4;
-        const geometryName = vib3Geometries[baseGeometry];
-        
-        const suffixes = [' LATTICE', ' FIELD', ' MATRIX', ' RESONANCE'];
-        const finalName = geometryName + suffixes[variationLevel];
-        
-        const geometryConfigs = {
-            0: { density: 0.8 + variationLevel * 0.2, speed: 0.3 + variationLevel * 0.1, chaos: variationLevel * 0.1, morph: 0.0 + variationLevel * 0.2 },
-            1: { density: 1.0 + variationLevel * 0.3, speed: 0.5 + variationLevel * 0.1, chaos: variationLevel * 0.15, morph: variationLevel * 0.2 },
-            2: { density: 1.2 + variationLevel * 0.4, speed: 0.4 + variationLevel * 0.2, chaos: 0.1 + variationLevel * 0.1, morph: 0.3 + variationLevel * 0.2 },
-            3: { density: 0.9 + variationLevel * 0.3, speed: 0.6 + variationLevel * 0.2, chaos: 0.2 + variationLevel * 0.2, morph: 0.5 + variationLevel * 0.1 },
-            4: { density: 1.4 + variationLevel * 0.5, speed: 0.7 + variationLevel * 0.1, chaos: 0.3 + variationLevel * 0.2, morph: 0.7 + variationLevel * 0.1 },
-            5: { density: 1.8 + variationLevel * 0.3, speed: 0.5 + variationLevel * 0.3, chaos: 0.5 + variationLevel * 0.2, morph: 0.8 + variationLevel * 0.05 },
-            6: { density: 0.6 + variationLevel * 0.4, speed: 0.8 + variationLevel * 0.4, chaos: 0.4 + variationLevel * 0.3, morph: 0.6 + variationLevel * 0.2 },
-            7: { density: 1.6 + variationLevel * 0.2, speed: 0.2 + variationLevel * 0.1, chaos: 0.1 + variationLevel * 0.1, morph: 0.2 + variationLevel * 0.2 }
-        };
-        
-        const config = geometryConfigs[baseGeometry];
-        
-        return {
-            geometryType: baseGeometry,
-            name: finalName,
-            density: config.density,
-            speed: config.speed,
-            hue: (variant * 12.27) % 360,
-            saturation: 0.8 + (variationLevel * 0.05), // Add saturation parameter
-            intensity: 0.5 + (variationLevel * 0.1),
-            chaos: config.chaos,
-            morph: config.morph
-        };
+        this.ensureVariantDefinitions();
+        const index = normalizeVariantIndex(variant, this.variantDefinitions);
+        return buildVariantParams(this.variantDefinitions[index]);
     }
     
     generateRoleParams(role) {
@@ -809,6 +813,18 @@ export class HolographicVisualizer {
         this.gl.uniform1f(this.uniforms.rot4dXW, this.variantParams.rot4dXW || 0.0);
         this.gl.uniform1f(this.uniforms.rot4dYW, this.variantParams.rot4dYW || 0.0);
         this.gl.uniform1f(this.uniforms.rot4dZW, this.variantParams.rot4dZW || 0.0);
+
+        ReactiveVisualizerInspector.inspectAndReport('holographic', {
+            rot4dXW: this.variantParams.rot4dXW || 0.0,
+            rot4dYW: this.variantParams.rot4dYW || 0.0,
+            rot4dZW: this.variantParams.rot4dZW || 0.0
+        }, {
+            audioReactive: typeof window !== 'undefined' ? window.audioReactive : null,
+            geometryIndex: this.variantParams.geometryType ?? this.variant ?? 0,
+            geometryLabel: GeometryLibrary?.getGeometryName?.(this.variantParams.geometryType ?? this.variant ?? 0) || null,
+            canvasId: this.canvas?.id,
+            variant: this.variantTarget?.id || this.variant
+        });
         
         this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
     }
@@ -897,7 +913,7 @@ export class HolographicVisualizer {
             'gridDensity': 'density',
             'morphFactor': 'morph',
             'rot4dXW': 'rot4dXW',
-            'rot4dYW': 'rot4dYW', 
+            'rot4dYW': 'rot4dYW',
             'rot4dZW': 'rot4dZW',
             'hue': 'hue',
             'intensity': 'intensity',
@@ -907,5 +923,19 @@ export class HolographicVisualizer {
             'geometry': 'geometryType'
         };
         return paramMap[globalParam] || globalParam;
+    }
+
+    destroy() {
+        if (typeof this.geometryUnsubscribe === 'function') {
+            this.geometryUnsubscribe();
+            this.geometryUnsubscribe = null;
+        }
+
+        if (this.gl && this.program) {
+            this.gl.deleteProgram(this.program);
+        }
+        if (this.gl && this.buffer) {
+            this.gl.deleteBuffer(this.buffer);
+        }
     }
 }

--- a/src/holograms/VariantCatalog.js
+++ b/src/holograms/VariantCatalog.js
@@ -1,0 +1,92 @@
+import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+
+export const DEFAULT_VARIATION_TARGET = 30;
+
+export function resolveVariantCatalog(target = DEFAULT_VARIATION_TARGET, names) {
+    const metadata = GeometryLibrary.getGeometryMetadata(names);
+    let definitions = GeometryLibrary.buildVariationDefinitions(metadata, target);
+
+    if (!definitions.length) {
+        const fallbackNames = GeometryLibrary.baseGeometries.length
+            ? [GeometryLibrary.baseGeometries[0]]
+            : ['TETRAHEDRON'];
+        const fallbackMetadata = GeometryLibrary.getGeometryMetadata(fallbackNames);
+        definitions = GeometryLibrary.buildVariationDefinitions(fallbackMetadata, Math.max(1, target));
+        return {
+            metadata: fallbackMetadata,
+            definitions
+        };
+    }
+
+    return { metadata, definitions };
+}
+
+export function normalizeVariantIndex(index, definitions) {
+    if (!Array.isArray(definitions) || !definitions.length) {
+        return 0;
+    }
+
+    if (index < 0) {
+        return 0;
+    }
+
+    if (index >= definitions.length) {
+        return definitions.length - 1;
+    }
+
+    return index;
+}
+
+export function buildVariantParams(definition) {
+    if (!definition) {
+        return {
+            geometryType: 0,
+            name: 'Tetrahedron Lattice 1',
+            density: 1.0,
+            speed: 0.5,
+            hue: 0,
+            saturation: 0.8,
+            intensity: 0.5,
+            chaos: 0.1,
+            morph: 0.2,
+            rot4dXW: 0.0,
+            rot4dYW: 0.0,
+            rot4dZW: 0.0
+        };
+    }
+
+    const geometryIndex = definition.geometryIndex ?? 0;
+    const level = definition.level ?? 0;
+    const baseParams = GeometryLibrary.getVariationParameters(geometryIndex, level);
+    const rotations = computeDefaultRotations(geometryIndex, level);
+
+    const density = Math.max(0.3, baseParams.gridDensity / 10);
+    const saturation = Math.min(1, 0.75 + level * 0.06);
+    const intensity = Math.min(1, 0.45 + level * 0.12);
+
+    return {
+        geometryType: geometryIndex,
+        name: definition.displayLabel || `${definition.displayName || 'Geometry'} Level ${level + 1}`,
+        density,
+        speed: baseParams.speed,
+        hue: baseParams.hue,
+        saturation,
+        intensity,
+        chaos: baseParams.chaos,
+        morph: baseParams.morphFactor,
+        rot4dXW: rotations.rot4dXW,
+        rot4dYW: rotations.rot4dYW,
+        rot4dZW: rotations.rot4dZW
+    };
+}
+
+function computeDefaultRotations(geometryIndex, level) {
+    const normalizedLevel = typeof level === 'number' ? level : 0;
+    const centeredLevel = normalizedLevel - 1.5;
+
+    return {
+        rot4dXW: centeredLevel * 0.45,
+        rot4dYW: ((geometryIndex % 3) - 1) * 0.35,
+        rot4dZW: (((geometryIndex + normalizedLevel) % 4) - 1.5) * 0.28
+    };
+}

--- a/src/quantum/QuantumVisualizer.js
+++ b/src/quantum/QuantumVisualizer.js
@@ -5,6 +5,7 @@
  */
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import { ReactiveVisualizerInspector } from '../diagnostics/ReactiveVisualizerInspector.js';
 
 export class QuantumHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
@@ -67,7 +68,13 @@ export class QuantumHolographicVisualizer {
             rot4dYW: 0.0,
             rot4dZW: 0.0
         };
-        
+
+        const initialCatalog = this.buildGeometryList(GeometryLibrary.getGeometryNames());
+        this.geometryNames = initialCatalog.length ? initialCatalog : this.getFallbackGeometryNames();
+        this.geometryMetadata = GeometryLibrary.getGeometryMetadata(this.geometryNames);
+        this.params.geometry = this.resolveGeometryIndex(this.params.geometry);
+        this.activeGeometryName = this.geometryNames[this.params.geometry] || 'Unknown';
+
         this.init();
     }
     
@@ -831,13 +838,133 @@ void main() {
             ctx.fillText('Please enable WebGL in your browser', this.canvas.width / 2, this.canvas.height / 2 + 25);
         }
     }
-    
+
+    buildGeometryList(source = []) {
+        const list = Array.isArray(source) ? source : [];
+        const deduped = [];
+        const seen = new Set();
+
+        list.forEach((name) => {
+            const normalized = GeometryLibrary.normalizeName(name);
+            if (!normalized) {
+                return;
+            }
+
+            const key = normalized.toUpperCase();
+            if (seen.has(key)) {
+                return;
+            }
+
+            seen.add(key);
+            deduped.push(GeometryLibrary.formatDisplayName(normalized));
+        });
+
+        return deduped;
+    }
+
+    getFallbackGeometryNames() {
+        if (Array.isArray(GeometryLibrary?.baseGeometries) && GeometryLibrary.baseGeometries.length) {
+            return this.buildGeometryList(GeometryLibrary.baseGeometries);
+        }
+
+        return [
+            'Tetrahedron',
+            'Hypercube',
+            'Sphere',
+            'Torus',
+            'Klein Bottle',
+            'Fractal',
+            'Wave',
+            'Crystal'
+        ];
+    }
+
+    resolveGeometryIndex(value) {
+        const catalog = this.geometryNames && this.geometryNames.length
+            ? this.geometryNames
+            : this.getFallbackGeometryNames();
+
+        if (!catalog.length) {
+            return 0;
+        }
+
+        if (typeof value === 'string') {
+            const normalized = GeometryLibrary.normalizeName(value);
+            if (normalized) {
+                const searchKey = normalized.toUpperCase();
+                const foundIndex = catalog.findIndex(
+                    (name) => GeometryLibrary.normalizeName(name).toUpperCase() === searchKey
+                );
+
+                if (foundIndex !== -1) {
+                    return foundIndex;
+                }
+            }
+
+            const parsed = Number(value);
+            if (Number.isFinite(parsed)) {
+                return this.resolveGeometryIndex(parsed);
+            }
+
+            return 0;
+        }
+
+        let numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+            numeric = 0;
+        }
+
+        numeric = Math.round(numeric);
+        if (numeric < 0) {
+            numeric = 0;
+        }
+
+        if (numeric >= catalog.length) {
+            numeric = catalog.length - 1;
+        }
+
+        return numeric;
+    }
+
+    updateGeometryMetadata(names = [], metadata = null) {
+        const nextCatalog = this.buildGeometryList(names);
+        if (nextCatalog.length) {
+            this.geometryNames = nextCatalog;
+        }
+
+        if (Array.isArray(metadata) && metadata.length) {
+            this.geometryMetadata = metadata;
+        } else {
+            this.geometryMetadata = GeometryLibrary.getGeometryMetadata(this.geometryNames);
+        }
+
+        const activeIndex = this.resolveGeometryIndex(this.params.geometry);
+        this.params.geometry = activeIndex;
+        this.activeGeometryName = this.geometryNames[activeIndex] || this.activeGeometryName || 'Unknown';
+
+        // Re-log render parameters with the new geometry context
+        this._renderParamsLogged = false;
+    }
+
     /**
      * Update visualization parameters with immediate GPU sync
      */
     updateParameters(params) {
-        this.params = { ...this.params, ...params };
-        
+        if (!params || typeof params !== 'object') {
+            return;
+        }
+
+        const merged = { ...this.params, ...params };
+
+        if (Object.prototype.hasOwnProperty.call(params, 'geometry')) {
+            merged.geometry = this.resolveGeometryIndex(params.geometry);
+        }
+
+        this.params = merged;
+        this.activeGeometryName = this.geometryNames[this.params.geometry]
+            || this.activeGeometryName
+            || 'Unknown';
+
         // Don't call render() here - engine will call it to prevent infinite loop
     }
     
@@ -869,9 +996,17 @@ void main() {
         this.gl.clearColor(0.0, 0.0, 0.0, 0.0);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
         
+        const geometryIndex = this.resolveGeometryIndex(this.params.geometry);
+        if (geometryIndex !== this.params.geometry) {
+            this.params.geometry = geometryIndex;
+        }
+
+        const geometryLabel = this.geometryNames[geometryIndex] || this.activeGeometryName || 'Unknown';
+        this.activeGeometryName = geometryLabel;
+
         // Mobile optimization: Log render parameters once per canvas (console only)
         if (!this._renderParamsLogged) {
-            console.log(`[Mobile] ${this.canvas?.id}: Render params - geometry=${this.params.geometry}, gridDensity=${this.params.gridDensity}, intensity=${this.params.intensity}`);
+            console.log(`[Mobile] ${this.canvas?.id}: Render params - geometry=${geometryIndex} (${geometryLabel}), gridDensity=${this.params.gridDensity}, intensity=${this.params.intensity}`);
             this._renderParamsLogged = true;
         }
         
@@ -890,7 +1025,7 @@ void main() {
         this.gl.uniform2f(this.uniforms.resolution, this.canvas.width, this.canvas.height);
         this.gl.uniform1f(this.uniforms.time, time);
         this.gl.uniform2f(this.uniforms.mouse, this.mouseX, this.mouseY);
-        this.gl.uniform1f(this.uniforms.geometry, this.params.geometry);
+        this.gl.uniform1f(this.uniforms.geometry, geometryIndex);
         // 🎵 QUANTUM AUDIO REACTIVITY - Direct and effective
         let gridDensity = this.params.gridDensity;
         let morphFactor = this.params.morphFactor;
@@ -925,7 +1060,19 @@ void main() {
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.roleIntensity, roleIntensities[this.role] || 1.0);
-        
+
+        ReactiveVisualizerInspector.inspectAndReport('quantum-holographic', {
+            rot4dXW: this.params.rot4dXW,
+            rot4dYW: this.params.rot4dYW,
+            rot4dZW: this.params.rot4dZW
+        }, {
+            audioReactive: typeof window !== 'undefined' ? window.audioReactive : null,
+            geometryIndex,
+            geometryLabel: GeometryLibrary?.getGeometryName?.(geometryIndex) || null,
+            canvasId: this.canvas?.id,
+            variant: this.variant || null
+        });
+
         this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
     }
     

--- a/src/ui/ReactiveInspectorPanel.js
+++ b/src/ui/ReactiveInspectorPanel.js
@@ -1,0 +1,678 @@
+import { ReactiveVisualizerInspector } from '../diagnostics/ReactiveVisualizerInspector.js';
+
+const PANEL_ID = 'reactive-visualizer-inspector-panel';
+const ANCHOR_POSITIONS = {
+    'bottom-right': { bottom: '16px', right: '16px' },
+    'bottom-left': { bottom: '16px', left: '16px' },
+    'top-right': { top: '16px', right: '16px' },
+    'top-left': { top: '16px', left: '16px' }
+};
+
+function applyAnchorPosition(element, anchor) {
+    Object.assign(element.style, {
+        top: 'auto',
+        right: 'auto',
+        bottom: 'auto',
+        left: 'auto'
+    });
+    const position = ANCHOR_POSITIONS[anchor] || ANCHOR_POSITIONS['bottom-right'];
+    Object.assign(element.style, position);
+}
+
+function createRow(label) {
+    const row = document.createElement('div');
+    row.className = 'row';
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'label';
+    labelEl.textContent = label;
+
+    const valueEl = document.createElement('span');
+    valueEl.className = 'value';
+    valueEl.textContent = '—';
+
+    row.append(labelEl, valueEl);
+    return { row, valueEl };
+}
+
+export function installReactiveInspectorPanel({
+    anchor = 'bottom-right',
+    log = false,
+    width = 320,
+    sampleSize = 12
+} = {}) {
+    if (typeof document === 'undefined') {
+        console.warn('ReactiveInspectorPanel requires a browser environment.');
+        return () => {};
+    }
+
+    const existing = document.getElementById(PANEL_ID);
+    if (existing) {
+        applyAnchorPosition(existing, anchor);
+        existing.style.width = `${width}px`;
+        return () => existing.remove();
+    }
+
+    const panel = document.createElement('aside');
+    panel.id = PANEL_ID;
+    panel.setAttribute('data-anchor', anchor);
+    panel.style.position = 'fixed';
+    panel.style.width = `${width}px`;
+    panel.style.maxWidth = '90vw';
+    panel.style.background = 'rgba(0, 0, 0, 0.82)';
+    panel.style.backdropFilter = 'blur(8px)';
+    panel.style.border = '1px solid rgba(0, 255, 255, 0.35)';
+    panel.style.borderRadius = '12px';
+    panel.style.boxShadow = '0 12px 32px rgba(0, 0, 0, 0.45)';
+    panel.style.color = '#d7f9ff';
+    panel.style.fontFamily = "'Orbitron', 'Segoe UI', sans-serif";
+    panel.style.fontSize = '12px';
+    panel.style.lineHeight = '1.6';
+    panel.style.padding = '14px 16px';
+    panel.style.zIndex = '2147483647';
+    panel.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+
+    applyAnchorPosition(panel, anchor);
+
+    const header = document.createElement('div');
+    header.className = 'header';
+    header.style.display = 'flex';
+    header.style.alignItems = 'center';
+    header.style.justifyContent = 'space-between';
+    header.style.marginBottom = '12px';
+
+    const title = document.createElement('h2');
+    title.textContent = '4D Reactive Inspector';
+    title.style.fontSize = '14px';
+    title.style.letterSpacing = '0.08em';
+    title.style.textTransform = 'uppercase';
+    title.style.margin = '0';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.textContent = '×';
+    closeBtn.title = 'Close inspector panel';
+    closeBtn.setAttribute('aria-label', 'Close inspector panel');
+    closeBtn.style.background = 'transparent';
+    closeBtn.style.border = 'none';
+    closeBtn.style.color = '#8be9ff';
+    closeBtn.style.fontSize = '18px';
+    closeBtn.style.cursor = 'pointer';
+    closeBtn.style.lineHeight = '1';
+    closeBtn.style.padding = '0 4px';
+
+    header.append(title, closeBtn);
+
+    const controls = document.createElement('div');
+    controls.className = 'controls';
+    controls.style.display = 'flex';
+    controls.style.flexWrap = 'wrap';
+    controls.style.gap = '8px';
+    controls.style.marginBottom = '12px';
+
+    const makeButton = (label, theme = {}) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = label;
+        const defaultTheme = {
+            baseBg: 'rgba(21, 115, 135, 0.35)',
+            hoverBg: 'rgba(21, 115, 135, 0.55)',
+            baseBorder: 'rgba(139, 233, 255, 0.45)',
+            hoverBorder: 'rgba(139, 233, 255, 0.75)'
+        };
+        const appliedTheme = { ...defaultTheme, ...theme };
+        btn.dataset.baseBg = appliedTheme.baseBg;
+        btn.dataset.hoverBg = appliedTheme.hoverBg;
+        btn.dataset.baseBorder = appliedTheme.baseBorder;
+        btn.dataset.hoverBorder = appliedTheme.hoverBorder;
+        btn.style.background = appliedTheme.baseBg;
+        btn.style.border = `1px solid ${appliedTheme.baseBorder}`;
+        btn.style.borderRadius = '8px';
+        btn.style.color = '#b3f4ff';
+        btn.style.cursor = 'pointer';
+        btn.style.fontSize = '11px';
+        btn.style.letterSpacing = '0.05em';
+        btn.style.padding = '6px 10px';
+        btn.style.flex = '0 0 auto';
+        btn.style.transition = 'background 0.2s ease, border 0.2s ease';
+        btn.addEventListener('mouseenter', () => {
+            btn.style.background = btn.dataset.hoverBg;
+            btn.style.borderColor = btn.dataset.hoverBorder;
+        });
+        btn.addEventListener('mouseleave', () => {
+            btn.style.background = btn.dataset.baseBg;
+            btn.style.borderColor = btn.dataset.baseBorder;
+        });
+        return btn;
+    };
+
+    const pauseBtn = makeButton('Pause');
+    pauseBtn.setAttribute('aria-pressed', 'false');
+
+    const copyBtn = makeButton('Copy JSON');
+    const reportBtn = makeButton('Report');
+    const clearBtn = makeButton('Clear');
+    const newSessionBtn = makeButton('New Session', {
+        baseBg: 'rgba(68, 32, 115, 0.45)',
+        hoverBg: 'rgba(88, 42, 145, 0.7)',
+        baseBorder: 'rgba(187, 160, 255, 0.55)',
+        hoverBorder: 'rgba(212, 190, 255, 0.85)'
+    });
+
+    const sessionLabelInput = document.createElement('input');
+    sessionLabelInput.type = 'text';
+    sessionLabelInput.placeholder = 'Session label';
+    sessionLabelInput.style.flex = '1 1 120px';
+    sessionLabelInput.style.minWidth = '120px';
+    sessionLabelInput.style.maxWidth = '180px';
+    sessionLabelInput.style.padding = '6px 8px';
+    sessionLabelInput.style.borderRadius = '8px';
+    sessionLabelInput.style.border = '1px solid rgba(139, 233, 255, 0.45)';
+    sessionLabelInput.style.background = 'rgba(0, 25, 35, 0.55)';
+    sessionLabelInput.style.color = '#e6fcff';
+    sessionLabelInput.style.fontSize = '11px';
+    sessionLabelInput.style.letterSpacing = '0.05em';
+    sessionLabelInput.style.outline = 'none';
+    sessionLabelInput.setAttribute('aria-label', 'Inspector session label');
+
+    const sampleWrapper = document.createElement('label');
+    sampleWrapper.textContent = 'Window';
+    sampleWrapper.style.display = 'flex';
+    sampleWrapper.style.alignItems = 'center';
+    sampleWrapper.style.gap = '6px';
+    sampleWrapper.style.fontSize = '11px';
+    sampleWrapper.style.letterSpacing = '0.05em';
+    sampleWrapper.style.opacity = '0.8';
+
+    const sampleInput = document.createElement('input');
+    sampleInput.type = 'number';
+    sampleInput.min = '1';
+    sampleInput.max = '250';
+    sampleInput.value = String(Math.max(1, Math.floor(sampleSize)));
+    sampleInput.style.width = '56px';
+    sampleInput.style.padding = '4px 6px';
+    sampleInput.style.borderRadius = '6px';
+    sampleInput.style.border = '1px solid rgba(139, 233, 255, 0.45)';
+    sampleInput.style.background = 'rgba(0, 25, 35, 0.6)';
+    sampleInput.style.color = '#e6fcff';
+    sampleInput.style.fontSize = '11px';
+    sampleInput.style.textAlign = 'center';
+
+    sampleWrapper.appendChild(sampleInput);
+
+    controls.append(pauseBtn, copyBtn, reportBtn, clearBtn, sessionLabelInput, newSessionBtn, sampleWrapper);
+
+    const setPauseButtonTheme = (paused) => {
+        if (paused) {
+            pauseBtn.dataset.baseBg = 'rgba(82, 21, 21, 0.55)';
+            pauseBtn.dataset.hoverBg = 'rgba(110, 35, 35, 0.75)';
+            pauseBtn.dataset.baseBorder = 'rgba(255, 149, 128, 0.75)';
+            pauseBtn.dataset.hoverBorder = 'rgba(255, 174, 150, 0.9)';
+        } else {
+            pauseBtn.dataset.baseBg = 'rgba(21, 115, 135, 0.35)';
+            pauseBtn.dataset.hoverBg = 'rgba(21, 115, 135, 0.55)';
+            pauseBtn.dataset.baseBorder = 'rgba(139, 233, 255, 0.45)';
+            pauseBtn.dataset.hoverBorder = 'rgba(139, 233, 255, 0.75)';
+        }
+        pauseBtn.style.background = pauseBtn.dataset.baseBg;
+        pauseBtn.style.borderColor = pauseBtn.dataset.baseBorder;
+    };
+
+    setPauseButtonTheme(false);
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    content.style.display = 'grid';
+    content.style.gap = '8px';
+
+    const sessionRow = createRow('Session');
+    const sessionStatsRow = createRow('Session Stats');
+    const visualizerRow = createRow('Visualizer');
+    const stageRow = createRow('Stage');
+    const dominantRow = createRow('Dominant Axis');
+    const rotationRow = createRow('4D Rotation');
+    const audioRow = createRow('Audio Support');
+    const geometryRow = createRow('Geometry');
+    const variantRow = createRow('Variant');
+    const warningsRow = createRow('Warnings');
+    const continuityRow = createRow('Continuity');
+    const rollingRow = createRow('Rolling Metrics');
+
+    rotationRow.valueEl.style.fontFamily = 'monospace';
+    rotationRow.valueEl.style.letterSpacing = '0.05em';
+    audioRow.valueEl.style.fontFamily = 'monospace';
+    audioRow.valueEl.style.letterSpacing = '0.05em';
+    continuityRow.valueEl.style.fontFamily = 'monospace';
+    continuityRow.valueEl.style.letterSpacing = '0.05em';
+    rollingRow.valueEl.style.fontFamily = 'monospace';
+    rollingRow.valueEl.style.letterSpacing = '0.05em';
+
+    const rows = [
+        sessionRow,
+        sessionStatsRow,
+        visualizerRow,
+        stageRow,
+        dominantRow,
+        rotationRow,
+        audioRow,
+        geometryRow,
+        variantRow,
+        warningsRow,
+        continuityRow,
+        rollingRow
+    ];
+
+    rows.forEach(({ row }) => {
+        row.style.display = 'flex';
+        row.style.justifyContent = 'space-between';
+        row.style.alignItems = 'center';
+        row.style.gap = '8px';
+        row.style.padding = '2px 0';
+        content.appendChild(row);
+    });
+
+    rows.forEach(({ row }) => {
+        const labelEl = row.querySelector('.label');
+        const valueEl = row.querySelector('.value');
+        labelEl.style.opacity = '0.75';
+        labelEl.style.fontWeight = '600';
+        labelEl.style.letterSpacing = '0.06em';
+        valueEl.style.textAlign = 'right';
+        valueEl.style.flex = '1';
+    });
+
+    const footer = document.createElement('footer');
+    footer.style.marginTop = '12px';
+    footer.style.fontSize = '10px';
+    footer.style.opacity = '0.7';
+    footer.textContent = 'Tip: Append ?inspectorPanel=1 to enable this overlay automatically. Use Pause/Copy/Report/Clear to manage telemetry.';
+
+    panel.append(header, controls, content, footer);
+    document.body.appendChild(panel);
+
+    const formatValue = (value) => (typeof value === 'number' ? value.toFixed(2) : '0.00');
+
+    const formatDuration = (ms) => {
+        if (!Number.isFinite(ms) || ms <= 0) {
+            return '0s';
+        }
+        const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        if (minutes > 0) {
+            return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+        }
+        return `${seconds}s`;
+    };
+
+    const renderSessionInfo = (info) => {
+        if (!info) {
+            sessionRow.valueEl.textContent = 'Inactive';
+            sessionStatsRow.valueEl.textContent = '—';
+            return;
+        }
+        sessionRow.valueEl.textContent = info.label || info.id;
+        sessionStatsRow.valueEl.textContent = `${info.sampleCount ?? 0} frames · ${formatDuration(info.durationMs ?? 0)}`;
+    };
+
+    const renderSummary = (summary) => {
+        if (!summary) {
+            visualizerRow.valueEl.textContent = 'Waiting for render…';
+            stageRow.valueEl.textContent = '—';
+            dominantRow.valueEl.textContent = '—';
+            rotationRow.valueEl.textContent = '—';
+            audioRow.valueEl.textContent = '—';
+            geometryRow.valueEl.textContent = '—';
+            variantRow.valueEl.textContent = '—';
+            warningsRow.valueEl.textContent = 'None';
+            warningsRow.valueEl.style.color = '#9de5ff';
+            continuityRow.valueEl.textContent = 'Stable · awaiting history';
+            continuityRow.valueEl.style.color = '#9de5ff';
+            rollingRow.valueEl.textContent = 'No history yet';
+            return;
+        }
+
+        const rotationValues = summary.rotation?.values || {};
+        const rotationText = `XW ${formatValue(rotationValues.rot4dXW)} · YW ${formatValue(rotationValues.rot4dYW)} · ZW ${formatValue(rotationValues.rot4dZW)}`;
+
+        visualizerRow.valueEl.textContent = summary.visualizer || '—';
+        stageRow.valueEl.textContent = summary.effect
+            ? `${summary.effect.stage.toUpperCase()} (${Math.round((summary.effect.rotationIntensity || 0) * 100)}%)`
+            : '—';
+        dominantRow.valueEl.textContent = summary.rotation?.dominantAxis || '—';
+        rotationRow.valueEl.textContent = rotationText;
+        audioRow.valueEl.textContent = summary.effect
+            ? `${Math.round((summary.effect.audioSupport || 0) * 100)}% energy`
+            : '—';
+        geometryRow.valueEl.textContent = summary.geometryLabel
+            ? `${summary.geometryLabel} (#${summary.geometryIndex ?? '—'})`
+            : (typeof summary.geometryIndex === 'number' ? `#${summary.geometryIndex}` : '—');
+        variantRow.valueEl.textContent = summary.variant != null ? `${summary.variant}` : '—';
+        warningsRow.valueEl.textContent = summary.warnings?.length
+            ? summary.warnings.join(' · ')
+            : 'None';
+
+        warningsRow.valueEl.style.color = summary.warnings?.length ? '#ffb86c' : '#9de5ff';
+    };
+
+    const renderContinuity = (summary) => {
+        const metrics = ReactiveVisualizerInspector.getContinuityMetrics();
+        const latestContinuity = summary?.continuity;
+
+        if ((!metrics.samples && !(latestContinuity?.hasPrevious))) {
+            continuityRow.valueEl.textContent = 'Stable · awaiting history';
+            continuityRow.valueEl.style.color = '#9de5ff';
+            return;
+        }
+
+        const interval = latestContinuity?.hasPrevious
+            ? latestContinuity.intervalMs
+            : metrics.lastIntervalMs;
+        const rotationDelta = latestContinuity?.hasPrevious
+            ? latestContinuity.rotationDelta
+            : metrics.lastRotationDelta;
+        const audioDelta = latestContinuity?.hasPrevious
+            ? latestContinuity.audioDelta
+            : metrics.lastAudioDelta;
+
+        const normalizedRotationDelta = Number.isFinite(rotationDelta) ? rotationDelta : 0;
+        const normalizedAudioDelta = Number.isFinite(audioDelta) ? audioDelta : 0;
+        const avgIntervalMs = metrics.samples ? Math.round(metrics.averageIntervalMs) : 0;
+        const latestIntervalText = Number.isFinite(interval) && interval > 0
+            ? `${Math.round(interval)}ms`
+            : '—';
+        const avgIntervalText = metrics.samples ? `${avgIntervalMs}ms` : '—';
+        const jitterEvents = metrics.rotationJitterEvents;
+        const lagEvents = metrics.audioLagEvents;
+        const gapEvents = metrics.intervalAnomalies;
+        const alertCount = latestContinuity?.hasPrevious ? (latestContinuity.warnings?.length ?? 0) : 0;
+
+        continuityRow.valueEl.textContent = `${latestIntervalText} latest · avg ${avgIntervalText} · Δrot ${formatValue(normalizedRotationDelta)} · Δaudio ${formatValue(normalizedAudioDelta)} · jitter ${jitterEvents} · lag ${lagEvents} · gaps ${gapEvents} · alerts ${alertCount}`;
+
+        const hasIssues = Boolean(
+            (latestContinuity && (latestContinuity.jitter || latestContinuity.lag || latestContinuity.intervalAnomaly))
+            || jitterEvents
+            || lagEvents
+            || gapEvents
+            || alertCount
+        );
+        continuityRow.valueEl.style.color = hasIssues ? '#ffb86c' : '#9de5ff';
+    };
+
+    const renderRolling = (size) => {
+        const metrics = ReactiveVisualizerInspector.computeRollingMetrics(size);
+        if (!metrics.sampleSize) {
+            rollingRow.valueEl.textContent = 'No history yet';
+            return;
+        }
+        const rotationAverage = formatValue(metrics.rotationMagnitude.average);
+        const audioAverage = (metrics.audioSupportAverage * 100).toFixed(0);
+        const warningPercent = (metrics.warningRate * 100).toFixed(0);
+        const dominantAxis = Object.entries(metrics.dominantAxisFrequency)
+            .sort(([, a], [, b]) => b - a)[0]?.[0] || 'n/a';
+        rollingRow.valueEl.textContent = `${metrics.sampleSize} frames · rot ${rotationAverage} · audio ${audioAverage}% · warn ${warningPercent}% · axis ${dominantAxis}`;
+    };
+
+    let isPaused = false;
+    let pendingSummary = null;
+    let latestSummary = null;
+    let currentSampleSize = Math.max(1, Math.floor(sampleSize));
+    let sessionInfo = null;
+    let sessionTicker = null;
+    let sessionLabelEditing = false;
+
+    const stopSessionTicker = () => {
+        if (sessionTicker) {
+            clearInterval(sessionTicker);
+            sessionTicker = null;
+        }
+    };
+
+    const refreshSessionTicker = () => {
+        stopSessionTicker();
+        if (!sessionInfo || sessionInfo.endedAt) {
+            return;
+        }
+        sessionTicker = setInterval(() => {
+            const latest = ReactiveVisualizerInspector.getSessionInfo();
+            sessionInfo = latest;
+            renderSessionInfo(latest);
+        }, 1000);
+    };
+
+    const onSessionUpdate = (info) => {
+        sessionInfo = info;
+        renderSessionInfo(info);
+        if (!sessionLabelEditing) {
+            sessionLabelInput.value = info?.label ?? '';
+        }
+        refreshSessionTicker();
+    };
+
+    const update = (summary) => {
+        latestSummary = summary;
+        if (isPaused) {
+            pendingSummary = summary;
+            return;
+        }
+        renderSummary(summary);
+        renderRolling(currentSampleSize);
+        renderContinuity(summary);
+    };
+
+    const unsubscribe = ReactiveVisualizerInspector.addListener(update);
+    const removeSessionListener = ReactiveVisualizerInspector.addSessionListener(onSessionUpdate);
+
+    if (log) {
+        window.VIB34D_DEBUG = window.VIB34D_DEBUG || {};
+        window.VIB34D_DEBUG.reactiveInspector = window.VIB34D_DEBUG.reactiveInspector || {};
+        window.VIB34D_DEBUG.reactiveInspector.log = true;
+    }
+
+    if (typeof window !== 'undefined') {
+        window.VIB34D_DEBUG = window.VIB34D_DEBUG || {};
+        window.VIB34D_DEBUG.reactiveInspector = window.VIB34D_DEBUG.reactiveInspector || {};
+        window.VIB34D_DEBUG.reactiveInspector.panelElement = panel;
+    }
+
+    let copyResetTimeout = null;
+    let reportResetTimeout = null;
+
+    const teardown = () => {
+        unsubscribe();
+        removeSessionListener();
+        clearTimeout(copyResetTimeout);
+        clearTimeout(reportResetTimeout);
+        stopSessionTicker();
+        if (typeof window !== 'undefined' && window.VIB34D_DEBUG?.reactiveInspector) {
+            delete window.VIB34D_DEBUG.reactiveInspector.panelElement;
+        }
+        if (panel.isConnected) {
+            panel.remove();
+        }
+    };
+
+    closeBtn.addEventListener('click', teardown);
+
+    const resetCopyLabel = () => {
+        copyBtn.textContent = 'Copy JSON';
+    };
+
+    const resetReportLabel = () => {
+        reportBtn.textContent = 'Report';
+    };
+
+    pauseBtn.addEventListener('click', () => {
+        isPaused = !isPaused;
+        pauseBtn.textContent = isPaused ? 'Resume' : 'Pause';
+        pauseBtn.setAttribute('aria-pressed', String(isPaused));
+        setPauseButtonTheme(isPaused);
+        if (!isPaused && pendingSummary) {
+            renderSummary(pendingSummary);
+            renderRolling(currentSampleSize);
+            renderContinuity(pendingSummary);
+            pendingSummary = null;
+        }
+    });
+
+    copyBtn.addEventListener('click', async () => {
+        const history = ReactiveVisualizerInspector.getHistory();
+        if (!history.length) {
+            copyBtn.textContent = 'No data';
+            clearTimeout(copyResetTimeout);
+            copyResetTimeout = setTimeout(resetCopyLabel, 1200);
+            return;
+        }
+        const payload = JSON.stringify(history, null, 2);
+        let copied = false;
+        if (navigator?.clipboard?.writeText) {
+            try {
+                await navigator.clipboard.writeText(payload);
+                copied = true;
+            } catch (error) {
+                console.warn('ReactiveInspectorPanel clipboard write failed:', error);
+            }
+        }
+        if (!copied) {
+            const blob = new Blob([payload], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const tempLink = document.createElement('a');
+            tempLink.href = url;
+            tempLink.download = 'reactive-inspector-history.json';
+            document.body.appendChild(tempLink);
+            tempLink.click();
+            tempLink.remove();
+            URL.revokeObjectURL(url);
+            copied = true;
+        }
+        if (copied) {
+            copyBtn.textContent = 'Copied!';
+            clearTimeout(copyResetTimeout);
+            copyResetTimeout = setTimeout(resetCopyLabel, 1600);
+        }
+    });
+
+    reportBtn.addEventListener('click', async () => {
+        const history = ReactiveVisualizerInspector.getHistory();
+        if (!history.length) {
+            reportBtn.textContent = 'No data';
+            clearTimeout(reportResetTimeout);
+            reportResetTimeout = setTimeout(resetReportLabel, 1200);
+            return;
+        }
+
+        const report = ReactiveVisualizerInspector.generateReport({
+            sampleSize: currentSampleSize,
+            includeHistory: true
+        });
+
+        const payload = JSON.stringify(report, null, 2);
+        let exported = false;
+
+        if (navigator?.clipboard?.writeText) {
+            try {
+                await navigator.clipboard.writeText(payload);
+                exported = true;
+                reportBtn.textContent = 'Report Copied!';
+            } catch (error) {
+                console.warn('ReactiveInspectorPanel report clipboard write failed:', error);
+            }
+        }
+
+        if (!exported) {
+            const blob = new Blob([payload], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const tempLink = document.createElement('a');
+            tempLink.href = url;
+            tempLink.download = 'reactive-inspector-report.json';
+            document.body.appendChild(tempLink);
+            tempLink.click();
+            tempLink.remove();
+            URL.revokeObjectURL(url);
+            exported = true;
+            reportBtn.textContent = 'Report Saved!';
+        }
+
+        if (exported) {
+            clearTimeout(reportResetTimeout);
+            reportResetTimeout = setTimeout(resetReportLabel, 2000);
+        }
+    });
+
+    clearBtn.addEventListener('click', () => {
+        ReactiveVisualizerInspector.clearHistory();
+        latestSummary = null;
+        pendingSummary = null;
+        renderSummary(null);
+        renderRolling(currentSampleSize);
+        renderContinuity(null);
+    });
+
+    sampleInput.addEventListener('change', () => {
+        const nextValue = Number(sampleInput.value);
+        if (!Number.isFinite(nextValue) || nextValue <= 0) {
+            sampleInput.value = String(currentSampleSize);
+            return;
+        }
+        currentSampleSize = Math.max(1, Math.floor(nextValue));
+        sampleInput.value = String(currentSampleSize);
+        if (!isPaused) {
+            renderRolling(currentSampleSize);
+        }
+    });
+
+    renderRolling(currentSampleSize);
+    renderContinuity(latestSummary);
+    if (!latestSummary) {
+        renderSummary(null);
+    }
+
+    const initialSession = ReactiveVisualizerInspector.getSessionInfo();
+    renderSessionInfo(initialSession);
+    if (initialSession) {
+        sessionInfo = initialSession;
+        sessionLabelInput.value = initialSession.label || '';
+        refreshSessionTicker();
+    }
+
+    sessionLabelInput.addEventListener('focus', () => {
+        sessionLabelEditing = true;
+    });
+
+    sessionLabelInput.addEventListener('blur', () => {
+        sessionLabelEditing = false;
+        const value = sessionLabelInput.value.trim();
+        if (value) {
+            ReactiveVisualizerInspector.updateSession({ label: value });
+        } else if (sessionInfo?.label) {
+            sessionLabelInput.value = sessionInfo.label;
+        }
+    });
+
+    sessionLabelInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            sessionLabelInput.blur();
+        }
+    });
+
+    newSessionBtn.addEventListener('click', () => {
+        const label = sessionLabelInput.value.trim();
+        const nextSession = ReactiveVisualizerInspector.beginSession({ label, resetHistory: true });
+        sessionInfo = nextSession;
+        latestSummary = null;
+        pendingSummary = null;
+        renderSummary(null);
+        renderRolling(currentSampleSize);
+        renderContinuity(null);
+        if (!sessionLabelEditing) {
+            sessionLabelInput.value = nextSession?.label ?? '';
+        }
+        refreshSessionTicker();
+    });
+
+    return teardown;
+}
+
+export default installReactiveInspectorPanel;
+

--- a/src/variations/VariationManager.js
+++ b/src/variations/VariationManager.js
@@ -1,143 +1,193 @@
 /**
  * VIB34D Variation Management System
- * Manages 100 total variations: 30 default + 70 custom
+ * Dynamically manages default and custom variations using the live geometry library.
  */
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+import {
+    DEFAULT_VARIATION_TARGET as DEFAULT_VARIATION_LIMIT,
+    resolveVariantCatalog
+} from '../holograms/VariantCatalog.js';
+
+const CUSTOM_VARIATION_SLOTS = 70;
 
 export class VariationManager {
     constructor(engine) {
         this.engine = engine;
-        
-        // Default variation names (30 total)
-        this.variationNames = [
-            // Tetrahedron Lattice (0-3)
-            'TETRAHEDRON LATTICE 1', 'TETRAHEDRON LATTICE 2', 'TETRAHEDRON LATTICE 3', 'TETRAHEDRON LATTICE 4',
-            
-            // Hypercube Lattice (4-7)
-            'HYPERCUBE LATTICE 1', 'HYPERCUBE LATTICE 2', 'HYPERCUBE LATTICE 3', 'HYPERCUBE LATTICE 4',
-            
-            // Sphere Lattice (8-11)
-            'SPHERE LATTICE 1', 'SPHERE LATTICE 2', 'SPHERE LATTICE 3', 'SPHERE LATTICE 4',
-            
-            // Torus Lattice (12-15)
-            'TORUS LATTICE 1', 'TORUS LATTICE 2', 'TORUS LATTICE 3', 'TORUS LATTICE 4',
-            
-            // Klein Bottle Lattice (16-19)
-            'KLEIN BOTTLE LATTICE 1', 'KLEIN BOTTLE LATTICE 2', 'KLEIN BOTTLE LATTICE 3', 'KLEIN BOTTLE LATTICE 4',
-            
-            // Fractal Lattice (20-22)
-            'FRACTAL LATTICE 1', 'FRACTAL LATTICE 2', 'FRACTAL LATTICE 3',
-            
-            // Wave Lattice (23-25)
-            'WAVE LATTICE 1', 'WAVE LATTICE 2', 'WAVE LATTICE 3',
-            
-            // Crystal Lattice (26-29)
-            'CRYSTAL LATTICE 1', 'CRYSTAL LATTICE 2', 'CRYSTAL LATTICE 3', 'CRYSTAL LATTICE 4'
-        ];
-        
-        // Custom variations storage (70 slots)
-        this.customVariations = new Array(70).fill(null);
-        
-        // Total variation count
-        this.totalVariations = 100;
+        this.defaultVariationTarget = DEFAULT_VARIATION_LIMIT;
+        this.customSlotCount = CUSTOM_VARIATION_SLOTS;
+
+        this.geometryMetadata = [];
+        this.defaultVariations = [];
+        this.customVariations = new Array(this.customSlotCount).fill(null);
+
+        this.geometryUnsubscribe = null;
+        this.pendingGridRefresh = false;
+
+        this.handleGeometryUpdate(GeometryLibrary.getGeometryNames());
+        this.subscribeToGeometryLibrary();
     }
-    
-    /**
-     * Get variation name for display
-     */
-    getVariationName(index) {
-        if (index < 30) {
-            return this.variationNames[index];
-        } else {
-            const customIndex = index - 30;
-            const customVar = this.customVariations[customIndex];
-            return customVar ? customVar.name : `CUSTOM ${customIndex + 1}`;
+
+    subscribeToGeometryLibrary() {
+        if (typeof GeometryLibrary?.subscribe !== 'function') {
+            return;
+        }
+
+        this.geometryUnsubscribe = GeometryLibrary.subscribe(({ names }) => {
+            this.handleGeometryUpdate(names);
+        });
+    }
+
+    destroy() {
+        if (typeof this.geometryUnsubscribe === 'function') {
+            this.geometryUnsubscribe();
+            this.geometryUnsubscribe = null;
         }
     }
-    
-    /**
-     * Generate default variation parameters
-     */
-    generateDefaultVariation(index) {
-        if (index >= 30) return null;
-        
-        const geometryType = Math.floor(index / 4);
-        const level = index % 4;
-        
-        // Special handling for reduced geometry sets
-        let adjustedGeometryType = geometryType;
-        if (geometryType === 5 && level > 2) { // Fractal only has 3 levels
-            adjustedGeometryType = 5;
-            level = 2;
-        }
-        if (geometryType === 6 && level > 2) { // Wave only has 3 levels  
-            adjustedGeometryType = 6;
-            level = 2;
-        }
-        
-        return {
-            variation: index,
-            geometry: adjustedGeometryType,
-            gridDensity: 8 + adjustedGeometryType * 2 + level * 1.5,
-            morphFactor: 0.2 + level * 0.2,
-            chaos: level * 0.2,
-            speed: 0.8 + level * 0.2,
-            hue: (index * 12.27) % 360,
-            rot4dXW: (level - 1.5) * 0.3,
-            rot4dYW: (adjustedGeometryType % 2) * 0.2,
-            rot4dZW: ((adjustedGeometryType + level) % 3) * 0.15,
-            dimension: 3.2 + level * 0.2
-        };
+
+    handleGeometryUpdate(names) {
+        const { metadata, definitions } = resolveVariantCatalog(
+            this.defaultVariationTarget,
+            names
+        );
+
+        this.geometryMetadata = metadata;
+        this.defaultVariations = definitions;
+        this.updateEngineVariationMetadata();
+        this.syncCurrentVariationIndex();
+        this.refreshGridIfMounted();
     }
-    
-    /**
-     * Apply specific variation to the engine
-     */
-    applyVariation(index) {
-        if (index < 0 || index >= this.totalVariations) return false;
-        
-        let params;
-        
-        if (index < 30) {
-            // Default variation
-            params = this.generateDefaultVariation(index);
-        } else {
-            // Custom variation
-            const customIndex = index - 30;
-            const customVar = this.customVariations[customIndex];
-            
-            if (customVar) {
-                params = { ...customVar.parameters, variation: index };
-            } else {
-                // Empty slot - use current parameters
-                params = { ...this.engine.parameterManager.getAllParameters(), variation: index };
+
+    updateEngineVariationMetadata() {
+        this.totalVariations = this.defaultVariations.length + this.customVariations.length;
+
+        if (this.engine) {
+            this.engine.totalVariations = this.totalVariations;
+            if (this.engine.parameterManager?.updateVariationMetadata) {
+                this.engine.parameterManager.updateVariationMetadata({
+                    defaults: this.defaultVariations,
+                    customCount: this.customVariations.length,
+                    totalVariations: this.totalVariations
+                });
             }
         }
-        
-        if (params) {
-            this.engine.parameterManager.setParameters(params);
+    }
+
+    syncCurrentVariationIndex() {
+        if (!this.engine) {
+            return;
+        }
+
+        if (!this.totalVariations) {
+            this.engine.currentVariation = 0;
+            if (this.engine.parameterManager) {
+                this.engine.parameterManager.setParameter('variation', 0);
+            }
+            return;
+        }
+
+        if (this.engine.currentVariation >= this.totalVariations) {
+            const newIndex = this.totalVariations - 1;
+            this.engine.currentVariation = newIndex;
+            if (this.engine.parameterManager) {
+                this.engine.parameterManager.setParameter('variation', newIndex);
+            }
+        }
+    }
+
+    refreshGridIfMounted() {
+        const gridContainer = typeof document !== 'undefined'
+            ? document.getElementById('variationGrid')
+            : null;
+
+        if (gridContainer) {
+            this.populateGrid();
+        } else {
+            this.pendingGridRefresh = true;
+        }
+    }
+
+    getDefaultVariationCount() {
+        return this.defaultVariations.length;
+    }
+
+    getCustomOffset() {
+        return this.getDefaultVariationCount();
+    }
+
+    getGeometryDisplayName(index) {
+        const meta = this.geometryMetadata[index];
+        if (meta) {
+            return meta.displayName;
+        }
+
+        const rawName = GeometryLibrary.getGeometryName(index);
+        const normalized = GeometryLibrary.normalizeName(rawName);
+        return normalized ? GeometryLibrary.formatDisplayName(normalized) : 'Unknown';
+    }
+
+    getVariationName(index) {
+        const defaultCount = this.getDefaultVariationCount();
+        if (index < defaultCount) {
+            const definition = this.defaultVariations[index];
+            return definition ? definition.label : `VARIATION ${index + 1}`;
+        }
+
+        const customIndex = index - defaultCount;
+        const customVar = this.customVariations[customIndex];
+        return customVar ? customVar.name : `CUSTOM ${customIndex + 1}`;
+    }
+
+    generateDefaultVariation(index) {
+        if (index >= this.getDefaultVariationCount()) {
+            return null;
+        }
+
+        const params = this.engine?.parameterManager?.generateVariationParameters(index);
+        return params ? { ...params, variation: index } : null;
+    }
+
+    applyVariation(index) {
+        if (index < 0 || index >= this.totalVariations) {
+            return false;
+        }
+
+        const defaultCount = this.getDefaultVariationCount();
+
+        if (index < defaultCount) {
+            if (this.engine?.parameterManager?.applyVariation) {
+                this.engine.parameterManager.applyVariation(index);
+            }
             this.engine.currentVariation = index;
             return true;
         }
-        
+
+        const customIndex = index - defaultCount;
+        const customVar = this.customVariations[customIndex];
+
+        if (customVar) {
+            this.engine.parameterManager.setParameters({
+                ...customVar.parameters,
+                variation: index
+            });
+            this.engine.currentVariation = index;
+            return true;
+        }
+
+        this.engine.parameterManager.setParameter('variation', index);
+        this.engine.currentVariation = index;
         return false;
     }
-    
-    /**
-     * Save current state as custom variation
-     */
+
     saveCurrentAsCustom() {
-        // Find first empty custom slot
         const emptyIndex = this.customVariations.findIndex(slot => slot === null);
-        
         if (emptyIndex === -1) {
-            return -1; // No empty slots
+            return -1;
         }
-        
+
         const currentParams = this.engine.parameterManager.getAllParameters();
         const currentGeometry = GeometryLibrary.getGeometryName(currentParams.geometry);
-        
+
         const customVariation = {
             name: `${currentGeometry} CUSTOM ${emptyIndex + 1}`,
             timestamp: new Date().toISOString(),
@@ -147,127 +197,160 @@ export class VariationManager {
                 createdFrom: 'current-state'
             }
         };
-        
+
         this.customVariations[emptyIndex] = customVariation;
         this.saveCustomVariations();
-        
-        return 30 + emptyIndex; // Return absolute variation index
+        this.updateEngineVariationMetadata();
+
+        return this.getCustomOffset() + emptyIndex;
     }
-    
-    /**
-     * Delete custom variation
-     */
+
     deleteCustomVariation(customIndex) {
-        if (customIndex >= 0 && customIndex < 70) {
+        if (customIndex >= 0 && customIndex < this.customVariations.length) {
             this.customVariations[customIndex] = null;
             this.saveCustomVariations();
+            this.updateEngineVariationMetadata();
             return true;
         }
         return false;
     }
-    
-    /**
-     * Populate the variation grid UI
-     */
+
     populateGrid() {
         const gridContainer = document.getElementById('variationGrid');
-        if (!gridContainer) return;
-        
+        if (!gridContainer) {
+            this.pendingGridRefresh = true;
+            return;
+        }
+
+        this.pendingGridRefresh = false;
         gridContainer.innerHTML = '';
-        
-        // Create sections for different geometry types
-        const sections = [
-            { name: 'Tetrahedron', range: [0, 3], class: 'tetrahedron' },
-            { name: 'Hypercube', range: [4, 7], class: 'hypercube' },
-            { name: 'Sphere', range: [8, 11], class: 'sphere' },
-            { name: 'Torus', range: [12, 15], class: 'torus' },
-            { name: 'Klein Bottle', range: [16, 19], class: 'klein' },
-            { name: 'Fractal', range: [20, 22], class: 'fractal' },
-            { name: 'Wave', range: [23, 25], class: 'wave' },
-            { name: 'Crystal', range: [26, 29], class: 'crystal' }
-        ];
-        
-        // Add default variations
-        sections.forEach(section => {
+
+        const groups = this.getDefaultVariationGroups();
+        groups.forEach(group => {
+            if (!group.variations.length) {
+                return;
+            }
+
             const sectionDiv = document.createElement('div');
             sectionDiv.className = 'variation-section';
-            sectionDiv.innerHTML = `<h3>${section.name} Lattice</h3>`;
-            
+            sectionDiv.innerHTML = `<h3>${group.name}</h3>`;
+
             const buttonContainer = document.createElement('div');
             buttonContainer.className = 'variation-buttons';
-            
-            for (let i = section.range[0]; i <= section.range[1]; i++) {
-                if (i < this.variationNames.length) {
-                    const button = this.createVariationButton(i, true, section.class);
-                    buttonContainer.appendChild(button);
-                }
-            }
-            
+
+            group.variations.forEach(({ index, shortLabel }) => {
+                const definition = this.defaultVariations[index];
+                const button = this.createVariationButton(
+                    index,
+                    true,
+                    group.cssClass,
+                    shortLabel || definition?.shortLabel || 'Level'
+                );
+                buttonContainer.appendChild(button);
+            });
+
             sectionDiv.appendChild(buttonContainer);
             gridContainer.appendChild(sectionDiv);
         });
-        
-        // Add custom variations section
+
         const customSection = document.createElement('div');
         customSection.className = 'variation-section custom-section';
         customSection.innerHTML = '<h3>Custom Variations</h3>';
-        
+
         const customContainer = document.createElement('div');
         customContainer.className = 'variation-buttons custom-grid';
-        
-        for (let i = 0; i < 70; i++) {
-            const button = this.createVariationButton(30 + i, false, 'custom');
+
+        const customOffset = this.getCustomOffset();
+        for (let i = 0; i < this.customVariations.length; i += 1) {
+            const button = this.createVariationButton(customOffset + i, false, 'custom');
             customContainer.appendChild(button);
         }
-        
+
         customSection.appendChild(customContainer);
         gridContainer.appendChild(customSection);
+
+        this.updateVariationGrid();
     }
-    
-    /**
-     * Create individual variation button
-     */
-    createVariationButton(variationIndex, isDefault, geomClass) {
+
+    getDefaultVariationGroups() {
+        const groups = new Map();
+
+        this.defaultVariations.forEach((definition, index) => {
+            if (!definition) {
+                return;
+            }
+
+            const existing = groups.get(definition.geometryIndex);
+            if (!existing) {
+                groups.set(definition.geometryIndex, {
+                    geometryIndex: definition.geometryIndex,
+                    name: `${definition.displayName} Lattice`,
+                    cssClass: definition.cssClass || 'geometry',
+                    variations: []
+                });
+            }
+
+            groups.get(definition.geometryIndex).variations.push({
+                index,
+                level: definition.level ?? 0,
+                shortLabel: definition.shortLabel
+            });
+        });
+
+        return Array.from(groups.values()).map(group => ({
+            ...group,
+            variations: group.variations
+                .sort((a, b) => {
+                    if (a.level === b.level) {
+                        return a.index - b.index;
+                    }
+                    return a.level - b.level;
+                })
+                .map(({ index, shortLabel }) => ({ index, shortLabel }))
+        }));
+    }
+
+    createVariationButton(variationIndex, isDefault, geomClass, levelLabel = '') {
         const button = document.createElement('button');
         const name = this.getVariationName(variationIndex);
-        
-        button.className = `preset-btn ${geomClass} ${isDefault ? 'default-variation' : 'custom-variation'}`;
+        const numberLabel = (variationIndex + 1).toString().padStart(2, '0');
+
+        const classes = ['preset-btn', geomClass || 'geometry'];
+        classes.push(isDefault ? 'default-variation' : 'custom-variation');
+        button.className = classes.join(' ');
         button.dataset.variation = variationIndex;
         button.title = `${variationIndex + 1}. ${name}`;
-        
-        // Button content
+
         if (isDefault) {
             button.innerHTML = `
-                <div class="variation-number">${(variationIndex + 1).toString().padStart(2, '0')}</div>
-                <div class="variation-level">Level ${(variationIndex % 4) + 1}</div>
+                <div class="variation-number">${numberLabel}</div>
+                <div class="variation-level">${levelLabel}</div>
             `;
         } else {
-            const customIndex = variationIndex - 30;
+            const customIndex = variationIndex - this.getDefaultVariationCount();
             const hasCustom = this.customVariations[customIndex] !== null;
-            
+
             button.innerHTML = `
-                <div class="variation-number">${(variationIndex + 1).toString()}</div>
+                <div class="variation-number">${variationIndex + 1}</div>
                 <div class="variation-type">${hasCustom ? 'CUSTOM' : 'EMPTY'}</div>
             `;
-            
+
             if (!hasCustom) {
                 button.classList.add('empty-slot');
             }
         }
-        
-        // Click handler
+
         button.addEventListener('click', () => {
-            if (isDefault || this.customVariations[variationIndex - 30] !== null) {
+            if (isDefault || this.customVariations[variationIndex - this.getDefaultVariationCount()] !== null) {
                 this.engine.setVariation(variationIndex);
                 this.updateVariationGrid();
             }
         });
-        
-        // Right-click for custom variations (delete)
+
         if (!isDefault) {
-            button.addEventListener('contextmenu', (e) => {
-                e.preventDefault();
-                const customIndex = variationIndex - 30;
+            button.addEventListener('contextmenu', (event) => {
+                event.preventDefault();
+                const customIndex = variationIndex - this.getDefaultVariationCount();
                 if (this.customVariations[customIndex] !== null) {
                     if (confirm(`Delete custom variation ${variationIndex + 1}?`)) {
                         this.deleteCustomVariation(customIndex);
@@ -276,43 +359,38 @@ export class VariationManager {
                 }
             });
         }
-        
+
         return button;
     }
-    
-    /**
-     * Update variation grid to show current selection
-     */
+
     updateVariationGrid() {
         const buttons = document.querySelectorAll('.preset-btn');
         buttons.forEach(btn => {
             btn.classList.remove('active');
-            if (parseInt(btn.dataset.variation) === this.engine.currentVariation) {
+            if (parseInt(btn.dataset.variation, 10) === this.engine.currentVariation) {
                 btn.classList.add('active');
             }
         });
     }
-    
-    /**
-     * Load custom variations from localStorage
-     */
+
     loadCustomVariations() {
         try {
             const stored = localStorage.getItem('vib34d-custom-variations');
             if (stored) {
                 const parsed = JSON.parse(stored);
-                if (Array.isArray(parsed) && parsed.length === 70) {
-                    this.customVariations = parsed;
+                if (Array.isArray(parsed)) {
+                    this.customVariations = new Array(this.customSlotCount)
+                        .fill(null)
+                        .map((_, index) => parsed[index] || null);
                 }
             }
         } catch (error) {
             console.warn('Failed to load custom variations:', error);
         }
+
+        this.updateEngineVariationMetadata();
     }
-    
-    /**
-     * Save custom variations to localStorage
-     */
+
     saveCustomVariations() {
         try {
             localStorage.setItem('vib34d-custom-variations', JSON.stringify(this.customVariations));
@@ -320,10 +398,7 @@ export class VariationManager {
             console.warn('Failed to save custom variations:', error);
         }
     }
-    
-    /**
-     * Export all custom variations as JSON
-     */
+
     exportCustomVariations() {
         const exportData = {
             type: 'vib34d-custom-variations',
@@ -331,64 +406,58 @@ export class VariationManager {
             timestamp: new Date().toISOString(),
             variations: this.customVariations.filter(v => v !== null)
         };
-        
+
         const json = JSON.stringify(exportData, null, 2);
         const blob = new Blob([json], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
-        
+
         const link = document.createElement('a');
         link.href = url;
         link.download = 'vib34d-custom-variations.json';
         link.click();
-        
+
         URL.revokeObjectURL(url);
     }
-    
-    /**
-     * Import custom variations from JSON
-     */
+
     async importCustomVariations(file) {
         try {
             const text = await file.text();
             const data = JSON.parse(text);
-            
+
             if (data.type === 'vib34d-custom-variations' && Array.isArray(data.variations)) {
-                // Merge imported variations
                 let importCount = 0;
-                
+
                 data.variations.forEach(variation => {
                     const emptyIndex = this.customVariations.findIndex(slot => slot === null);
                     if (emptyIndex !== -1) {
                         this.customVariations[emptyIndex] = variation;
-                        importCount++;
+                        importCount += 1;
                     }
                 });
-                
+
                 this.saveCustomVariations();
                 this.populateGrid();
-                
+                this.updateEngineVariationMetadata();
+
                 return importCount;
             }
         } catch (error) {
             console.error('Failed to import custom variations:', error);
         }
-        
+
         return 0;
     }
-    
-    /**
-     * Get variation statistics
-     */
+
     getStatistics() {
         const customCount = this.customVariations.filter(v => v !== null).length;
-        
+
         return {
             totalVariations: this.totalVariations,
-            defaultVariations: 30,
+            defaultVariations: this.getDefaultVariationCount(),
             customVariations: customCount,
-            emptySlots: 70 - customCount,
+            emptySlots: this.customVariations.length - customCount,
             currentVariation: this.engine.currentVariation,
-            isCustom: this.engine.currentVariation >= 30
+            isCustom: this.engine.currentVariation >= this.getDefaultVariationCount()
         };
     }
 }

--- a/test-parameters.html
+++ b/test-parameters.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>VIB34D Parameter Test</title>
+    <style>
+        body { margin: 0; font-family: monospace; background: #000; color: #0ff; }
+        #test-container { display: flex; height: 100vh; }
+        #canvas-area { flex: 1; position: relative; }
+        #controls { width: 400px; padding: 20px; background: #111; overflow-y: auto; }
+        canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+        .param { margin: 15px 0; }
+        .param label { display: block; margin-bottom: 5px; }
+        .param input { width: 100%; }
+        .param .value { color: #f0f; float: right; }
+        button { width: 100%; padding: 10px; margin: 5px 0; background: #0ff; color: #000; border: none; cursor: pointer; }
+        #log { margin-top: 20px; font-size: 11px; max-height: 200px; overflow-y: auto; background: #000; padding: 10px; }
+        .log-entry { margin: 2px 0; }
+    </style>
+</head>
+<body>
+    <div id="test-container">
+        <div id="canvas-area">
+            <div class="holographic-layers" id="vib34dLayers"></div>
+            <div class="holographic-layers" id="quantumLayers" style="display:none;"></div>
+            <div class="holographic-layers" id="holographicLayers" style="display:none;"></div>
+        </div>
+        <div id="controls">
+            <h2>PARAMETER TEST</h2>
+
+            <div class="param">
+                <label>System</label>
+                <button onclick="switchTo('faceted')">FACETED</button>
+                <button onclick="switchTo('quantum')">QUANTUM</button>
+                <button onclick="switchTo('holographic')">HOLOGRAPHIC</button>
+            </div>
+
+            <div class="param">
+                <label>Geometry <span class="value" id="v-geometry">0</span></label>
+                <input type="range" id="geometry" min="0" max="7" value="0" step="1" oninput="update('geometry', this.value)">
+            </div>
+
+            <div class="param">
+                <label>rot4dXW <span class="value" id="v-rot4dXW">0.00</span></label>
+                <input type="range" id="rot4dXW" min="-2" max="2" value="0" step="0.1" oninput="update('rot4dXW', this.value)">
+            </div>
+
+            <div class="param">
+                <label>rot4dYW <span class="value" id="v-rot4dYW">0.00</span></label>
+                <input type="range" id="rot4dYW" min="-2" max="2" value="0" step="0.1" oninput="update('rot4dYW', this.value)">
+            </div>
+
+            <div class="param">
+                <label>rot4dZW <span class="value" id="v-rot4dZW">0.00</span></label>
+                <input type="range" id="rot4dZW" min="-2" max="2" value="0" step="0.1" oninput="update('rot4dZW', this.value)">
+            </div>
+
+            <div class="param">
+                <label>gridDensity <span class="value" id="v-gridDensity">15</span></label>
+                <input type="range" id="gridDensity" min="4" max="100" value="15" step="1" oninput="update('gridDensity', this.value)">
+            </div>
+
+            <div class="param">
+                <label>morphFactor <span class="value" id="v-morphFactor">1.00</span></label>
+                <input type="range" id="morphFactor" min="0" max="2" value="1" step="0.1" oninput="update('morphFactor', this.value)">
+            </div>
+
+            <div class="param">
+                <label>chaos <span class="value" id="v-chaos">0.20</span></label>
+                <input type="range" id="chaos" min="0" max="1" value="0.2" step="0.1" oninput="update('chaos', this.value)">
+            </div>
+
+            <div class="param">
+                <label>speed <span class="value" id="v-speed">1.00</span></label>
+                <input type="range" id="speed" min="0.1" max="3" value="1" step="0.1" oninput="update('speed', this.value)">
+            </div>
+
+            <div class="param">
+                <label>hue <span class="value" id="v-hue">200°</span></label>
+                <input type="range" id="hue" min="0" max="360" value="200" step="10" oninput="update('hue', this.value)">
+            </div>
+
+            <div class="param">
+                <label>intensity <span class="value" id="v-intensity">0.50</span></label>
+                <input type="range" id="intensity" min="0" max="1" value="0.5" step="0.1" oninput="update('intensity', this.value)">
+            </div>
+
+            <div class="param">
+                <label>saturation <span class="value" id="v-saturation">0.80</span></label>
+                <input type="range" id="saturation" min="0" max="1" value="0.8" step="0.1" oninput="update('saturation', this.value)">
+            </div>
+
+            <button onclick="testRotations()">🔄 TEST ALL ROTATIONS</button>
+            <button onclick="testDensity()">📊 TEST DENSITY RANGE</button>
+            <button onclick="testGeometries()">🔷 TEST ALL GEOMETRIES</button>
+
+            <div id="log">
+                <div class="log-entry">Ready to test parameters...</div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { VIB34DIntegratedEngine } from './src/core/Engine.js';
+        import { QuantumEngine } from './src/quantum/QuantumEngine.js';
+        import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { CanvasManager } from './src/core/CanvasManager.js';
+
+        let mgr = new CanvasManager();
+        let eng = null;
+        let currentSystem = 'faceted';
+
+        const cls = { VIB34DIntegratedEngine, QuantumEngine, RealHolographicSystem };
+
+        (async function() {
+            eng = await mgr.switchToSystem('faceted', cls);
+            log('✅ Faceted system initialized');
+        })();
+
+        function log(msg) {
+            const logDiv = document.getElementById('log');
+            const entry = document.createElement('div');
+            entry.className = 'log-entry';
+            entry.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+            logDiv.insertBefore(entry, logDiv.firstChild);
+            if (logDiv.children.length > 20) logDiv.lastChild.remove();
+        }
+
+        window.switchTo = async function(system) {
+            log(`Switching to ${system}...`);
+            eng = await mgr.switchToSystem(system, cls);
+            currentSystem = system;
+            log(`✅ ${system} active`);
+        };
+
+        window.update = function(param, value) {
+            const val = parseFloat(value);
+            const display = param === 'hue' ? val + '°' :
+                          (param === 'geometry' || param === 'gridDensity' ? Math.round(val) : val.toFixed(2));
+            document.getElementById('v-' + param).textContent = display;
+
+            if (!eng) return;
+
+            try {
+                if (eng.parameterManager) {
+                    eng.parameterManager.setParameter(param, val);
+                } else if (eng.updateParameter) {
+                    eng.updateParameter(param, val);
+                } else if (eng.updateParameters) {
+                    eng.updateParameters({ [param]: val });
+                } else if (eng.parameters) {
+                    eng.parameters.setParameter(param, val);
+                }
+                log(`Set ${param} = ${display}`);
+            } catch (err) {
+                log(`❌ Error setting ${param}: ${err.message}`);
+            }
+        };
+
+        window.testRotations = async function() {
+            log('🔄 Testing all rotation parameters...');
+
+            const tests = [
+                { name: 'XW only', xw: 1.5, yw: 0, zw: 0 },
+                { name: 'YW only', xw: 0, yw: 1.5, zw: 0 },
+                { name: 'ZW only', xw: 0, yw: 0, zw: 1.5 },
+                { name: 'All planes', xw: 1.2, yw: 0.9, zw: 0.7 },
+                { name: 'Counter-rotation', xw: -1.0, yw: 0.5, zw: -0.3 }
+            ];
+
+            for (const test of tests) {
+                log(`Testing: ${test.name}`);
+                document.getElementById('rot4dXW').value = test.xw;
+                document.getElementById('rot4dYW').value = test.yw;
+                document.getElementById('rot4dZW').value = test.zw;
+                window.update('rot4dXW', test.xw);
+                window.update('rot4dYW', test.yw);
+                window.update('rot4dZW', test.zw);
+                await new Promise(r => setTimeout(r, 2000));
+            }
+
+            log('✅ Rotation test complete');
+        };
+
+        window.testDensity = async function() {
+            log('📊 Testing density range...');
+
+            for (let d = 10; d <= 100; d += 20) {
+                log(`Density: ${d}`);
+                document.getElementById('gridDensity').value = d;
+                window.update('gridDensity', d);
+                await new Promise(r => setTimeout(r, 1500));
+            }
+
+            log('✅ Density test complete');
+        };
+
+        window.testGeometries = async function() {
+            log('🔷 Testing all geometries...');
+
+            const names = ['Tetrahedron', 'Hypercube', 'Sphere', 'Torus', 'Klein', 'Fractal', 'Wave', 'Crystal'];
+
+            for (let g = 0; g < 8; g++) {
+                log(`Geometry ${g}: ${names[g]}`);
+                document.getElementById('geometry').value = g;
+                window.update('geometry', g);
+                await new Promise(r => setTimeout(r, 2000));
+            }
+
+            log('✅ Geometry test complete');
+        };
+    </script>
+</body>
+</html>

--- a/tests/reactive-inspector.test.mjs
+++ b/tests/reactive-inspector.test.mjs
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const sourcePath = path.resolve(__dirname, '../src/diagnostics/ReactiveVisualizerInspector.js');
+const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'reactive-visualizer-'));
+const tempModulePath = path.join(tempDir, 'ReactiveVisualizerInspector.mjs');
+await fs.writeFile(tempModulePath, await fs.readFile(sourcePath, 'utf8'), 'utf8');
+const module = await import(pathToFileURL(tempModulePath));
+const { ReactiveVisualizerInspector } = module;
+
+const summary = ReactiveVisualizerInspector.inspect('unit-test', {
+    rot4dXW: 1.4,
+    rot4dYW: 1.1,
+    rot4dZW: 0.5
+}, {
+    audioReactive: { bass: 0.7, mid: 0.4, high: 0.3, energy: 0.5 },
+    geometryIndex: 5
+});
+
+assert.equal(summary.rotation.withinRange, true, 'Expected rotation within safe range');
+assert.equal(summary.rotation.dominantAxis, 'rot4dXW', 'XW should be dominant rotation axis');
+assert.equal(summary.effect.stage, 'build', 'Normalized rotation should classify as build stage');
+assert(summary.effect.description.includes('multi-axis'), 'Effect description should explain motion');
+
+const overflow = ReactiveVisualizerInspector.inspect('unit-test-overflow', {
+    rot4dXW: 2.5,
+    rot4dYW: 0.0,
+    rot4dZW: 0.0
+});
+
+assert.equal(overflow.rotation.withinRange, false, 'Overflow rotation should be flagged');
+assert(overflow.warnings.length > 0, 'Overflow should trigger at least one warning');
+
+const updates = [];
+const unsubscribe = ReactiveVisualizerInspector.addListener((summary) => {
+    updates.push(summary.visualizer);
+}, { replayLast: false });
+
+ReactiveVisualizerInspector.inspectAndReport('listener-test', {
+    rot4dXW: 0.25,
+    rot4dYW: 0.1,
+    rot4dZW: 0.05
+});
+
+assert.deepEqual(updates, ['listener-test'], 'Listener should capture inspectAndReport summaries');
+
+unsubscribe();
+
+ReactiveVisualizerInspector.inspectAndReport('listener-test-after-unsubscribe', {
+    rot4dXW: 0.4
+});
+
+assert.deepEqual(updates, ['listener-test'], 'Listener should stop receiving updates after unsubscribe');
+
+ReactiveVisualizerInspector.clearHistory();
+
+const defaultMetrics = ReactiveVisualizerInspector.computeRollingMetrics();
+assert.equal(defaultMetrics.sampleSize, 0, 'Rolling metrics should handle empty history');
+assert.equal(defaultMetrics.rotationMagnitude.average, 0, 'Average rotation should default to 0 for empty history');
+
+const limit = ReactiveVisualizerInspector.setHistoryLimit(5);
+assert.equal(limit, 5, 'History limit should be configurable');
+
+for (let i = 1; i <= 6; i += 1) {
+    ReactiveVisualizerInspector.inspectAndReport(`history-${i}`, {
+        rot4dXW: i * 0.1
+    }, {
+        audioReactive: { energy: i * 0.1 }
+    });
+}
+
+const history = ReactiveVisualizerInspector.getHistory();
+assert.equal(history.length, 5, 'History length should respect the configured limit');
+assert.equal(history[0].visualizer, 'history-2', 'History should drop the earliest entries beyond the limit');
+
+const metrics = ReactiveVisualizerInspector.computeRollingMetrics(3);
+assert.equal(metrics.sampleSize, 3, 'Rolling metrics should use the requested window size');
+assert(Math.abs(metrics.rotationMagnitude.average - 0.5) < 0.0001, 'Average rotation magnitude should match the latest samples');
+assert.equal(metrics.stageCounts.intro, 3, 'Expected intro stage counts for low rotation magnitudes');
+assert.equal(metrics.dominantAxisFrequency.rot4dXW, 3, 'Dominant axis frequency should reflect the latest samples');
+assert.equal(metrics.warningRate, 0, 'Warnings should not appear for safe rotations');
+
+ReactiveVisualizerInspector.clearHistory();
+assert.equal(ReactiveVisualizerInspector.getHistory().length, 0, 'Clearing history should remove stored summaries');
+assert.equal(ReactiveVisualizerInspector.getLastSummary(), null, 'Clearing history should reset the last summary reference');
+
+ReactiveVisualizerInspector.setHistoryLimit(50);
+
+const dataset = [
+    {
+        visualizer: 'viz-alpha',
+        params: { rot4dXW: 0.05 },
+        context: {
+            audioReactive: { bass: 1, mid: 0.9, high: 0.8, energy: 1 },
+            geometryLabel: 'Prism',
+            variant: 'alpha'
+        }
+    },
+    {
+        visualizer: 'viz-beta',
+        params: { rot4dXW: 0.9, rot4dYW: 0.85, rot4dZW: 0.2 },
+        context: {
+            audioReactive: { bass: 0.5, energy: 0.3 },
+            geometryIndex: 2,
+            variant: 'beta'
+        }
+    },
+    {
+        visualizer: 'viz-warning',
+        params: { rot4dXW: 2.8 },
+        context: {
+            audioReactive: { bass: 0.7, energy: 0.8 },
+            geometryLabel: 'Prism',
+            variant: 'beta'
+        }
+    },
+    {
+        visualizer: 'viz-drop',
+        params: { rot4dXW: 2.0, rot4dYW: 2.0, rot4dZW: 1.8 },
+        context: {
+            audioReactive: { bass: 0.9, mid: 0.85, high: 0.82, energy: 0.95 },
+            geometryLabel: 'Sphere',
+            variant: 'gamma'
+        }
+    }
+];
+
+dataset.forEach(({ visualizer, params, context }) => {
+    ReactiveVisualizerInspector.inspectAndReport(visualizer, params, context);
+});
+
+const report = ReactiveVisualizerInspector.generateReport({ sampleSize: 2 });
+assert.equal(report.totalSamples, dataset.length, 'Report should count all history entries');
+assert.equal(report.metrics.sampleSize, 2, 'Report metrics should respect requested sample size');
+assert.ok(report.visualizerUsage['viz-alpha'] === 1 && report.visualizerUsage['viz-warning'] === 1, 'Visualizer usage should track sample counts');
+assert.equal(report.geometryUsage.Prism, 2, 'Geometry usage should count repeated geometry labels');
+assert.equal(report.variantUsage.beta, 2, 'Variant usage should track repeated variant labels');
+assert(report.warnings.total >= 1, 'Report should aggregate warning totals');
+assert.equal(report.rangeViolations, 1, 'Out of range rotations should be counted');
+assert(report.stalledFrames >= 1, 'High audio / low rotation frames should be tallied');
+assert(report.stageTotals.drop >= 1, 'Drop stage samples should be counted');
+assert(report.dominantAxisTotals.rot4dXW >= dataset.length - 1, 'Dominant axis totals should accumulate');
+assert(report.audioEnergy.max <= 1 && report.audioEnergy.min >= 0, 'Audio energy bounds should reflect normalized values');
+
+const reportWithHistory = ReactiveVisualizerInspector.generateReport({ includeHistory: true, includeMetrics: false });
+assert.equal(Array.isArray(reportWithHistory.history), true, 'Report should include full history when requested');
+assert.equal(reportWithHistory.history.length, dataset.length, 'Included history should match stored summaries');
+assert.equal(Object.prototype.hasOwnProperty.call(reportWithHistory, 'metrics'), false, 'Metrics should be omitted when includeMetrics=false');
+
+ReactiveVisualizerInspector.clearHistory();
+
+const originalThresholds = {
+    rotationJitterThreshold: ReactiveVisualizerInspector.rotationJitterThreshold,
+    rotationStillnessTolerance: ReactiveVisualizerInspector.rotationStillnessTolerance,
+    audioSpikeThreshold: ReactiveVisualizerInspector.audioSpikeThreshold,
+    audioStillnessTolerance: ReactiveVisualizerInspector.audioStillnessTolerance,
+    intervalWarningMs: ReactiveVisualizerInspector.intervalWarningMs
+};
+
+const originalDateNow = Date.now;
+let fakeNow = 1_000;
+Date.now = () => fakeNow;
+
+ReactiveVisualizerInspector.rotationJitterThreshold = 0.2;
+ReactiveVisualizerInspector.audioSpikeThreshold = 0.3;
+
+const baselineContinuity = ReactiveVisualizerInspector.inspectAndReport('continuity-test', { rot4dXW: 0.1 }, {
+    audioReactive: { energy: 0.2 }
+});
+
+assert.equal(baselineContinuity.continuity.hasPrevious, false, 'Initial continuity sample should not report previous frame data');
+
+fakeNow += 1_700;
+
+const jitterSummary = ReactiveVisualizerInspector.inspectAndReport('continuity-test', { rot4dXW: 1.0 }, {
+    audioReactive: { energy: 0.25 }
+});
+
+assert.equal(jitterSummary.continuity.jitter, true, 'Large rotation delta with static audio should register jitter');
+assert.equal(jitterSummary.continuity.intervalAnomaly, true, 'Extended telemetry gap should be flagged as an interval anomaly');
+assert(jitterSummary.warnings.some((msg) => msg.includes('Rotation jitter spike')), 'Jitter warning should surface in summary warnings');
+
+fakeNow += 200;
+
+const lagSummary = ReactiveVisualizerInspector.inspectAndReport('continuity-test', { rot4dXW: 1.05 }, {
+    audioReactive: { energy: 0.95 }
+});
+
+assert.equal(lagSummary.continuity.lag, true, 'Audio spike without matching rotation should trigger lag flag');
+assert(lagSummary.warnings.some((msg) => msg.includes('Audio-reactive spike')), 'Lag warning should be appended to the summary');
+
+const continuityMetrics = ReactiveVisualizerInspector.getContinuityMetrics();
+assert.equal(continuityMetrics.rotationJitterEvents >= 1, true, 'Continuity metrics should count jitter events');
+assert.equal(continuityMetrics.audioLagEvents >= 1, true, 'Continuity metrics should count lag events');
+assert.equal(continuityMetrics.intervalAnomalies >= 1, true, 'Continuity metrics should count interval anomalies');
+assert.equal(continuityMetrics.lastIntervalMs, lagSummary.continuity.intervalMs, 'Continuity metrics should track the latest interval duration');
+assert(Math.abs(continuityMetrics.lastRotationDelta - lagSummary.continuity.rotationDelta) < 1e-9, 'Continuity metrics should preserve the latest rotation delta');
+assert(Math.abs(continuityMetrics.lastAudioDelta - lagSummary.continuity.audioDelta) < 1e-9, 'Continuity metrics should preserve the latest audio delta');
+
+const continuityReport = ReactiveVisualizerInspector.generateReport({ sampleSize: 3 });
+assert(continuityReport.continuity.rotationJitterEvents >= 1, 'Report continuity section should include jitter totals');
+assert(continuityReport.continuity.audioLagEvents >= 1, 'Report continuity section should include lag totals');
+assert(continuityReport.continuity.intervalAnomalies >= 1, 'Report continuity section should include interval anomaly totals');
+assert.equal(continuityReport.continuity.lastIntervalMs, lagSummary.continuity.intervalMs, 'Continuity report should carry the latest interval duration');
+assert(Math.abs(continuityReport.continuity.lastRotationDelta - lagSummary.continuity.rotationDelta) < 1e-9, 'Continuity report should carry the latest rotation delta');
+assert(Math.abs(continuityReport.continuity.lastAudioDelta - lagSummary.continuity.audioDelta) < 1e-9, 'Continuity report should carry the latest audio delta');
+assert.equal(continuityReport.continuity.samples >= 2, true, 'Continuity report should track interval samples');
+
+Object.entries(originalThresholds).forEach(([key, value]) => {
+    ReactiveVisualizerInspector[key] = value;
+});
+Date.now = originalDateNow;
+ReactiveVisualizerInspector.clearHistory();
+
+const preSession = ReactiveVisualizerInspector.getSessionInfo();
+if (preSession) {
+    ReactiveVisualizerInspector.endSession({ resetHistory: true });
+}
+
+const sessionDetails = ReactiveVisualizerInspector.beginSession({ label: 'Unit Session', metadata: { mode: 'test' } });
+assert.equal(sessionDetails.label, 'Unit Session', 'Session label should match requested value');
+assert.equal(sessionDetails.sampleCount, 0, 'New session should start with zero samples');
+
+const sessionSummary = ReactiveVisualizerInspector.inspectAndReport('session-visualizer', { rot4dXW: 0.3 }, { audioReactive: { energy: 0.4 } });
+assert.equal(sessionSummary.sessionId, sessionDetails.id, 'Session identifier should be attached to telemetry summaries');
+
+const liveSession = ReactiveVisualizerInspector.getSessionInfo();
+assert.equal(liveSession.sampleCount, 1, 'Session should track sample counts as telemetry arrives');
+
+const updatedSession = ReactiveVisualizerInspector.updateSession({ label: 'Renamed Session', metadata: { iteration: 1 } });
+assert.equal(updatedSession.label, 'Renamed Session', 'Session rename should propagate through inspector state');
+assert.equal(updatedSession.metadata.iteration, 1, 'Session metadata updates should merge with existing values');
+
+const { session: finalSession, report: finalReport } = ReactiveVisualizerInspector.endSession({
+    finalizeReport: true,
+    includeHistory: true,
+    includeMetrics: true,
+    includeCompletedSessions: true
+});
+
+assert(finalSession, 'Ending a session should return the final session snapshot');
+assert.equal(finalSession.label, 'Renamed Session', 'Ended session snapshot should use the latest label');
+assert.equal(finalSession.sampleCount, 1, 'Ended session should retain sample counts');
+assert(finalReport.session && finalReport.session.label === 'Renamed Session', 'Generated report should include the ended session details');
+assert(Array.isArray(finalReport.completedSessions), 'Report should be able to include completed session history');
+const lastCompletedSession = finalReport.completedSessions[finalReport.completedSessions.length - 1];
+assert(lastCompletedSession.id === finalSession.id, 'Completed sessions list should contain the ended session');
+
+assert.equal(ReactiveVisualizerInspector.getSessionInfo(), null, 'Inspector should not track an active session after endSession');
+
+await fs.rm(tempDir, { recursive: true, force: true });
+
+console.log('✅ ReactiveVisualizerInspector diagnostics verified');

--- a/ultimate-choreographer.html
+++ b/ultimate-choreographer.html
@@ -361,15 +361,7 @@
         <div class="section">
             <h3>🔮 GEOMETRY</h3>
             <div class="param-group">
-                <select id="geometry" onchange="choreographer.setParam('geometry', parseInt(this.value))">
-                    <option value="0">Tetrahedron</option>
-                    <option value="1" selected>Hypercube</option>
-                    <option value="2">Sphere</option>
-                    <option value="3">Torus</option>
-                    <option value="4">Klein Bottle</option>
-                    <option value="5">Fractal</option>
-                    <option value="6">Wave</option>
-                    <option value="7">Crystal</option>
+                <select id="geometry" onchange="choreographer.setParam('geometry', Number(this.value))">
                 </select>
             </div>
             <div class="param-group">
@@ -461,6 +453,18 @@
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
+        import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
+
+        const DEFAULT_GEOMETRY_NAMES = [
+            'Tetrahedron',
+            'Hypercube',
+            'Sphere',
+            'Torus',
+            'Klein Bottle',
+            'Fractal',
+            'Wave',
+            'Crystal'
+        ];
 
         window.togglePanel = function() {
             document.getElementById('panel').classList.toggle('open');
@@ -482,15 +486,15 @@
                 this.currentSystem = 'faceted';
                 this.isPlaying = false;
 
-                // Geometry names
-                this.geometryNames = [
-                    'Tetrahedron', 'Hypercube', 'Sphere', 'Torus',
-                    'Klein Bottle', 'Fractal', 'Wave', 'Crystal'
-                ];
+                this.geometrySubscriptionCleanup = null;
+                this.geometryNames = this.buildGeometryList(GeometryLibrary.getGeometryNames());
+                if (!this.geometryNames.length) {
+                    this.geometryNames = [...DEFAULT_GEOMETRY_NAMES];
+                }
 
                 // Base parameters (user-set, NOT affected by audio)
                 this.baseParams = {
-                    geometry: 1,
+                    geometry: this.resolveGeometryIndex(1),
                     gridDensity: 15,
                     morphFactor: 1.0,
                     chaos: 0.2,
@@ -502,6 +506,9 @@
                     rot4dYW: 0.0,
                     rot4dZW: 0.0
                 };
+
+                this.subscribeToGeometryLibrary();
+                this.refreshGeometryUI();
 
                 // Audio reactivity settings
                 this.audioReactivityEnabled = true;
@@ -519,6 +526,184 @@
                 this.kickHistory = [];
 
                 this.init();
+            }
+
+            buildGeometryList(source = []) {
+                const list = Array.isArray(source) ? source : [];
+                const deduped = [];
+                const seen = new Set();
+
+                list.forEach(name => {
+                    const normalized = GeometryLibrary.normalizeName(name);
+                    if (!normalized) return;
+                    const key = normalized.toUpperCase();
+                    if (seen.has(key)) return;
+                    seen.add(key);
+                    deduped.push(this.formatGeometryName(normalized));
+                });
+
+                return deduped;
+            }
+
+            formatGeometryName(name) {
+                const normalized = GeometryLibrary.normalizeName(name);
+                if (!normalized) return 'Unknown';
+
+                if (normalized === normalized.toUpperCase()) {
+                    return normalized
+                        .toLowerCase()
+                        .split(' ')
+                        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+                        .join(' ');
+                }
+
+                return normalized;
+            }
+
+            escapeGeometryLabel(name) {
+                return String(name)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            geometryListsEqual(a = [], b = []) {
+                if (a.length !== b.length) {
+                    return false;
+                }
+
+                for (let i = 0; i < a.length; i += 1) {
+                    if (a[i] !== b[i]) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            getFallbackGeometryNames() {
+                return [...DEFAULT_GEOMETRY_NAMES];
+            }
+
+            resolveGeometryIndex(value) {
+                const names = this.geometryNames.length ? this.geometryNames : this.getFallbackGeometryNames();
+                if (!names.length) {
+                    return 0;
+                }
+
+                if (typeof value === 'string') {
+                    const normalized = GeometryLibrary.normalizeName(value);
+                    if (normalized) {
+                        const searchKey = normalized.toUpperCase();
+                        const foundIndex = names.findIndex(name => GeometryLibrary.normalizeName(name).toUpperCase() === searchKey);
+                        if (foundIndex !== -1) {
+                            return foundIndex;
+                        }
+                    }
+
+                    const parsed = Number(value);
+                    if (Number.isFinite(parsed)) {
+                        return this.resolveGeometryIndex(parsed);
+                    }
+
+                    return 0;
+                }
+
+                let numeric = Number(value);
+                if (!Number.isFinite(numeric)) {
+                    numeric = 0;
+                }
+
+                numeric = Math.round(numeric);
+                if (numeric < 0) {
+                    numeric = 0;
+                }
+                if (numeric >= names.length) {
+                    numeric = names.length - 1;
+                }
+
+                return numeric;
+            }
+
+            getGeometryCount() {
+                return this.geometryNames.length ? this.geometryNames.length : this.getFallbackGeometryNames().length;
+            }
+
+            refreshGeometryUI() {
+                const select = document.getElementById('geometry');
+                const label = document.getElementById('geometry-name');
+                const activeIndex = this.resolveGeometryIndex(this.baseParams.geometry);
+                const names = this.geometryNames.length ? this.geometryNames : this.getFallbackGeometryNames();
+
+                if (!this.geometryNames.length && names.length) {
+                    this.geometryNames = [...names];
+                }
+
+                if (select) {
+                    const optionsNeedUpdate = select.options.length !== names.length ||
+                        Array.from(select.options).some((option, index) => option.textContent !== names[index]);
+
+                    if (optionsNeedUpdate) {
+                        select.innerHTML = names
+                            .map((name, index) => `<option value="${index}">${this.escapeGeometryLabel(name)}</option>`)
+                            .join('');
+                    }
+
+                    select.value = String(activeIndex);
+                }
+
+                if (label) {
+                    label.textContent = names[activeIndex] || 'Unknown';
+                }
+            }
+
+            syncGeometrySelector(index) {
+                const select = document.getElementById('geometry');
+                if (select && select.value !== String(index)) {
+                    select.value = String(index);
+                }
+            }
+
+            subscribeToGeometryLibrary() {
+                if (typeof GeometryLibrary?.subscribe !== 'function') {
+                    return;
+                }
+
+                const handleUpdate = ({ names }) => {
+                    const nextNames = this.buildGeometryList(Array.isArray(names) ? names : []);
+                    const finalNames = nextNames.length ? nextNames : this.getFallbackGeometryNames();
+
+                    if (!this.geometryListsEqual(this.geometryNames, finalNames)) {
+                        this.geometryNames = finalNames;
+                        const clamped = this.resolveGeometryIndex(this.baseParams.geometry);
+                        if (clamped !== this.baseParams.geometry) {
+                            this.baseParams.geometry = clamped;
+                        }
+                        this.refreshGeometryUI();
+                        this.applyBaseParameters();
+                    } else {
+                        this.refreshGeometryUI();
+                    }
+                };
+
+                try {
+                    this.geometrySubscriptionCleanup = GeometryLibrary.subscribe(handleUpdate);
+                } catch (error) {
+                    console.warn('Failed to subscribe to GeometryLibrary', error);
+                }
+            }
+
+            destroy() {
+                if (typeof this.geometrySubscriptionCleanup === 'function') {
+                    try {
+                        this.geometrySubscriptionCleanup();
+                    } catch (error) {
+                        console.warn('Failed to dispose geometry subscription', error);
+                    }
+                    this.geometrySubscriptionCleanup = null;
+                }
             }
 
             async init() {
@@ -675,21 +860,28 @@
             }
 
             setParam(param, value) {
+                let nextValue = value;
+
+                if (param === 'geometry') {
+                    nextValue = this.resolveGeometryIndex(value);
+                }
+
                 // Store in BASE parameters (user-set values)
-                this.baseParams[param] = value;
+                this.baseParams[param] = nextValue;
 
                 // Apply to all engines
                 this.applyBaseParameters();
 
-                // Update UI
-                const valSpan = document.getElementById(`${param}-val`);
-                if (valSpan) {
-                    valSpan.textContent = typeof value === 'number' ? value.toFixed(2) : value;
+                if (param === 'geometry') {
+                    this.syncGeometrySelector(nextValue);
+                    this.refreshGeometryUI();
+                    return;
                 }
 
-                // Update geometry name
-                if (param === 'geometry') {
-                    document.getElementById('geometry-name').textContent = this.geometryNames[value];
+                // Update UI readouts for non-geometry params
+                const valSpan = document.getElementById(`${param}-val`);
+                if (valSpan) {
+                    valSpan.textContent = typeof nextValue === 'number' ? nextValue.toFixed(2) : nextValue;
                 }
             }
 
@@ -850,9 +1042,12 @@
             onKick(audioData) {
                 // Heavy kicks can trigger geometry change
                 if (audioData.bass > 0.85 && Math.random() < 0.3) {
-                    const nextGeom = (this.baseParams.geometry + 1) % 8;
-                    this.setParam('geometry', nextGeom);
-                    document.getElementById('geometry').value = nextGeom;
+                    const count = this.getGeometryCount();
+                    if (count > 0) {
+                        const current = this.resolveGeometryIndex(this.baseParams.geometry);
+                        const nextGeom = (current + 1) % count;
+                        this.setParam('geometry', nextGeom);
+                    }
                 }
             }
 
@@ -1002,7 +1197,10 @@
             }
 
             randomize() {
-                this.setParam('geometry', Math.floor(Math.random() * 8));
+                const geometryCount = this.getGeometryCount();
+                if (geometryCount > 0) {
+                    this.setParam('geometry', Math.floor(Math.random() * geometryCount));
+                }
                 this.setParam('gridDensity', Math.floor(5 + Math.random() * 95));
                 this.setParam('morphFactor', Math.random() * 3);
                 this.setParam('chaos', Math.random());
@@ -1016,7 +1214,7 @@
             }
 
             reset() {
-                this.setParam('geometry', 1);
+                this.setParam('geometry', this.geometryNames.length > 1 ? 1 : 0);
                 this.setParam('gridDensity', 15);
                 this.setParam('morphFactor', 1.0);
                 this.setParam('chaos', 0.2);
@@ -1039,12 +1237,18 @@
                     if (slider) slider.value = value;
                     if (valSpan) valSpan.textContent = typeof value === 'number' ? value.toFixed(2) : value;
                 });
+
+                this.refreshGeometryUI();
             }
         }
 
         // Initialize
         const choreographer = new UltimateChoreographer();
         window.choreographer = choreographer;
+
+        window.addEventListener('beforeunload', () => {
+            choreographer.destroy();
+        }, { once: true });
     </script>
 
     <!-- Signature -->


### PR DESCRIPTION
## Summary
- add per-visualizer continuity analysis to the reactive inspector, including configurable thresholds, continuity reports, and history resets
- surface the new continuity metrics in the overlay panel with live interval, delta, and alert summaries alongside existing telemetry
- expand the diagnostic test suite to validate continuity warnings, metrics exports, and report aggregation under controlled timestamps

## Testing
- node tests/reactive-inspector.test.mjs
- npm test *(fails: playwright Permission denied in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9684b29c83299ff05503cdae64a6