### PR TITLE
Bridge choreographer playback into advanced audio engine

### DIFF
--- a/UNIFIED-REFACTOR-PLAN.md
+++ b/UNIFIED-REFACTOR-PLAN.md
@@ -1,0 +1,735 @@
+# 🎯 VIB34D MUSIC CHOREOGRAPHER - UNIFIED REFACTORING PLAN
+
+**Date**: October 5, 2025
+**Objective**: Refactor multiple systems together, make elegant, expand colors and audio reactivity
+
+---
+
+## 📊 REPOSITORY ANALYSIS COMPLETE
+
+### **Branch Structure:**
+```
+* html-versions-catalog (current)
+  - Contains comprehensive HTML versions catalog at versions-index.html
+  - Latest commit: "🌟 Add comprehensive HTML versions catalog"
+
+* main / origin/main
+  - Primary development branch
+  - Latest: "🎥 PROPER FIX: Composite canvas for export with smart system switching"
+
+* v3-professional
+  - Advanced audio-visual system experimentation
+  - NOT YET MERGED
+
+* music-video-choreographer-refactor (remote)
+  - Previous refactoring attempt
+  - Useful learnings in branch history
+```
+
+### **Key Files Count:**
+- **14 index-*.html variants** (514-3526 lines each)
+- **57 JavaScript modules** in src/
+- **3 visualization engines**: Faceted, Quantum, Holographic
+- **1 specialized system**: Polychora (4D mathematics)
+
+---
+
+## 🔍 CURRENT SYSTEM INVENTORY
+
+### **INDEX.HTML VARIANTS ANALYSIS:**
+
+| File | Lines | Purpose | Status |
+|------|-------|---------|--------|
+| **index-MASTER.html** | 678 | Beat-synced choreography + manual sequences + video export | ✅ WORKING |
+| **index-ULTIMATE-V2.html** | 645 | Musical timing with 4D rotation focus | ✅ WORKING |
+| **index-ULTIMATE.html** | 514 | Original AI choreography system | ✅ WORKING |
+| **index-WORKING-GOLD.html** | 3526 | Full features + reactivity (original backup) | ✅ ARCHIVE |
+| **index-enhanced.html** | 2225 | Enhanced UI + features | ⚠️ LEGACY |
+| **index-working-simple.html** | 1070 | Hybrid mode + timeline | ✅ USEFUL |
+| **index-FINAL.html** | 812 | Simplified choreographer | ✅ CLEAN |
+| **index-ULTRA.html** | 813 | Ultra version (experimental) | ⚠️ EXPERIMENTAL |
+
+**BEST VERSIONS IDENTIFIED:**
+1. **index-MASTER.html** - Most complete, working export, beat sync
+2. **index-ULTIMATE-V2.html** - Best 4D rotation usage, musical timing
+3. **index-working-simple.html** - Clean hybrid mode implementation
+
+---
+
+## 🎨 SOURCE ARCHITECTURE ANALYSIS
+
+### **Current Module Structure:**
+```
+src/
+├── core/ (14 files)
+│   ├── Engine.js                    // Faceted system
+│   ├── Visualizer.js                // Faceted visualizer (GLSL shaders)
+│   ├── ParameterMapper.js           // V3 advanced mapping (INCOMPLETE)
+│   ├── Parameters.js                // Parameter definitions + validation
+│   ├── CanvasManager.js             // Canvas lifecycle management
+│   ├── ReactivityManager.js         // Mouse/touch/scroll interactions
+│   └── UnifiedEngine.js             // Attempted unification (partial)
+│
+├── quantum/ (2 files)
+│   ├── QuantumEngine.js             // Complex 3D system
+│   └── QuantumVisualizer.js         // Advanced GLSL with volumetric lighting
+│
+├── holograms/ (6 files)
+│   ├── RealHolographicSystem.js     // Audio-reactive system
+│   ├── HolographicVisualizer.js     // Core holographic rendering
+│   ├── ActiveHolographicSystem.js   // Enhanced version
+│   └── HolographicSystem.js         // Legacy version
+│
+├── core/PolychoraSystem.js          // 4D polytope mathematics
+│
+├── export/ (15 files)
+│   └── Trading card + video export systems (per-engine variants)
+│
+├── audio/
+│   ├── AudioAnalyzer.js           // ✅ Implemented: 7-band + spectral analysis
+│   ├── ADSREnvelope.js            // ✅ Implemented: ADSR smoothing utilities
+│   └── ParameterMapper.js         // ✅ Implemented: audio-to-parameter routing
+│
+├── color/
+│   └── ColorSystem.js             // ✅ Implemented: palettes, gradients, reactive blending
+│
+└── geometry/
+    └── GeometryLibrary.js           // 8 geometry types shared
+```
+
+Supporting modules:
+- `js/audio/audio-engine.js` // ✅ AdvancedAudioEngine wiring analyzer → global state + color pipeline bridge
+- `window.colorState` // ✅ Shared color palette + gradient state exposed for visualizers/UI
+
+### **🚨 CRITICAL ARCHITECTURE PROBLEMS:**
+1. **INCONSISTENT INTERFACES**: Each system has different initialization patterns
+2. **NO UNIFIED PARAMETER SYSTEM**: 3 different parameter management approaches
+3. **DUPLICATE VISUALIZERS**: Multiple versions of Holographic system
+4. **LEGACY V3 GAPS**: Systems still need to adopt the new AudioAnalyzer + ParameterMapper pipeline
+5. **COLOR SYSTEM INTEGRATION**: New ColorSystem drives palettes + gradients, but shaders/UI still need full adoption
+6. **AUDIO INTEGRATION DRIFT**: Advanced analyzer now powers the global engine, but each visualization still needs bespoke mappings
+
+---
+
+## 🎯 UNIFIED REFACTORING GOALS
+
+### **1. ELEGANT SYSTEM ARCHITECTURE**
+
+Create **BaseSystem** interface that all engines implement:
+```javascript
+class BaseSystem {
+    constructor(config) {
+        this.name = config.name;
+        this.type = config.type; // 'faceted'|'quantum'|'holographic'|'polychora'
+        this.canvas = null;
+        this.visualizer = null;
+        this.parameters = new UnifiedParameters();
+        this.interactions = new UnifiedInteractions();
+    }
+
+    async initialize() {
+        // Standard init sequence
+        await this.createCanvas();
+        await this.createVisualizer();
+        await this.setupInteractions();
+        await this.setupAudio();
+    }
+
+    updateParameter(name, value) {
+        // Unified parameter update
+    }
+
+    render() {
+        // Unified render loop
+    }
+
+    destroy() {
+        // Proper cleanup
+    }
+}
+```
+
+**Benefits:**
+- ✅ Switch between systems with identical API
+- ✅ Predictable behavior across all engines
+- ✅ Easy to add new visualization systems
+- ✅ Clean separation of concerns
+
+---
+
+### **2. ADVANCED COLOR SYSTEM**
+
+**Current Limitation**: Single hue parameter (0-360)
+
+**New Color Architecture:**
+```javascript
+class ColorSystem {
+    constructor() {
+        // Multiple color modes
+        this.modes = {
+            single: this.singleHue,
+            dual: this.dualHue,
+            triad: this.triadHue,
+            complementary: this.complementaryHue,
+            analogous: this.analogousHue,
+            palette: this.paletteMode,
+            gradient: this.gradientMode,
+            reactive: this.audioReactiveMode
+        };
+
+        // Color palettes
+        this.palettes = {
+            vaporwave: ['#ff71ce', '#01cdfe', '#05ffa1', '#b967ff'],
+            cyberpunk: ['#ff006e', '#fb5607', '#ffbe0b', '#8338ec'],
+            synthwave: ['#f72585', '#7209b7', '#3a0ca3', '#4361ee'],
+            holographic: ['#ff00ff', '#00ffff', '#ff00aa', '#00aaff'],
+            neon: ['#fe00fe', '#00fefe', '#fefe00', '#00fe00'],
+            fire: ['#ff0000', '#ff4400', '#ff8800', '#ffcc00'],
+            ocean: ['#001eff', '#0088ff', '#00ccff', '#00ffee'],
+            forest: ['#004d00', '#008800', '#00cc00', '#88ff00']
+        };
+
+        // Gradient definitions
+        this.gradients = {
+            horizontal: (time, pos) => this.horizontalGradient(time, pos),
+            vertical: (time, pos) => this.verticalGradient(time, pos),
+            radial: (time, pos) => this.radialGradient(time, pos),
+            spiral: (time, pos) => this.spiralGradient(time, pos),
+            wave: (time, pos) => this.waveGradient(time, pos)
+        };
+    }
+
+    // Audio-reactive color
+    audioReactiveColor(audioData) {
+        const { bass, mid, high, spectralCentroid, spectralFlux } = audioData;
+
+        // Brightness from loudness
+        const brightness = audioData.rms;
+
+        // Hue from spectral centroid (brightness of sound)
+        const hue = spectralCentroid * 360;
+
+        // Saturation from spectral flux (energy change)
+        const saturation = 0.5 + (spectralFlux * 0.5);
+
+        return { h: hue, s: saturation, v: brightness };
+    }
+
+    // Multi-hue systems
+    triadHue(baseHue) {
+        return [
+            baseHue,
+            (baseHue + 120) % 360,
+            (baseHue + 240) % 360
+        ];
+    }
+
+    complementaryHue(baseHue) {
+        return [
+            baseHue,
+            (baseHue + 180) % 360
+        ];
+    }
+}
+```
+
+**New Parameters:**
+- `colorMode`: 'single'|'dual'|'triad'|'complementary'|'palette'|'gradient'|'reactive'
+- `colorPalette`: Selection from predefined palettes
+- `gradientType`: 'horizontal'|'vertical'|'radial'|'spiral'|'wave'
+- `gradientSpeed`: Animation speed of gradient
+- `colorReactivity`: How much audio influences color (0-1)
+- `colorSaturation`: Independent from hue (0-1) - ALREADY EXISTS
+- `colorIntensity`: Independent brightness (0-1) - ALREADY EXISTS
+
+**Implementation in Shaders:**
+```glsl
+uniform int u_colorMode;
+uniform vec3 u_palette[4];
+uniform int u_paletteSize;
+uniform float u_gradientPhase;
+
+vec3 getColor(vec2 uv, float audioData) {
+    if (u_colorMode == MODE_PALETTE) {
+        // Cycle through palette based on position + audio
+        int index = int(mod(uv.x * float(u_paletteSize) + audioData, float(u_paletteSize)));
+        return u_palette[index];
+    } else if (u_colorMode == MODE_GRADIENT) {
+        // Gradient between colors
+        return mix(u_palette[0], u_palette[1], uv.x + u_gradientPhase);
+    }
+    // ... other modes
+}
+```
+
+---
+
+### **3. PROFESSIONAL AUDIO REACTIVITY**
+
+**Current Limitation**: 3 frequency bands (bass, mid, high) with simple addition
+
+**New Audio Architecture** (from V3 plan):
+```javascript
+class AudioAnalyzer {
+    constructor(analyserNode) {
+        this.analyser = analyserNode;
+
+        // 7 frequency bands instead of 3
+        this.bands = {
+            subBass: { low: 20, high: 60, value: 0 },      // Kick drums, sub bass
+            bass: { low: 60, high: 250, value: 0 },        // Bass guitar, low toms
+            lowMid: { low: 250, high: 500, value: 0 },     // Guitars, keyboards
+            mid: { low: 500, high: 2000, value: 0 },       // Vocals, snares
+            highMid: { low: 2000, high: 4000, value: 0 },  // Cymbals, guitars
+            high: { low: 4000, high: 8000, value: 0 },     // Hi-hats, strings
+            air: { low: 8000, high: 20000, value: 0 }      // Airiness, sparkle
+        };
+
+        // Spectral features
+        this.spectralCentroid = 0;  // Brightness of sound (0-1)
+        this.spectralRolloff = 0;   // Frequency where 85% energy below (0-1)
+        this.spectralFlux = 0;      // Rate of spectral change (onset detection)
+        this.rms = 0;               // Overall loudness (0-1)
+
+        // Onset detection
+        this.onsetHistory = [];
+        this.lastOnsetTime = 0;
+        this.onsetThreshold = 0.15;
+
+        // BPM estimation
+        this.estimatedBPM = 120;
+
+        // Smoothing buffers
+        this.smoothingFactor = 0.8;
+        this.smoothedBands = { ...this.bands };
+    }
+
+    analyze() {
+        // Multi-band analysis
+        this.analyzeBands();
+
+        // Spectral features
+        this.calcSpectralCentroid();   // Brightness
+        this.calcSpectralRolloff();    // High frequency content
+        this.calcSpectralFlux();       // Change detection
+        this.calcRMS();                // Loudness
+
+        // Onset detection (kicks, snares, transients)
+        const onset = this.detectOnset();
+
+        // BPM estimation from onsets
+        if (this.onsetHistory.length > 8) {
+            this.estimateBPM();
+        }
+
+        return {
+            bands: this.smoothedBands,
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset: onset,
+            bpm: this.estimatedBPM
+        };
+    }
+}
+```
+
+**Parameter Mapping with ADSR Envelopes:**
+```javascript
+class ParameterMapper {
+    constructor() {
+        this.mappings = {
+            // 4D rotations react to different bands
+            rot4dXW: {
+                source: 'bass',
+                curve: 'exponential',  // Exponential response
+                range: [-2, 2],
+                envelope: new ADSREnvelope(200, 500, 0.6, 1000) // Attack, Decay, Sustain, Release
+            },
+            rot4dYW: {
+                source: 'mid',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(100, 300, 0.7, 800)
+            },
+            rot4dZW: {
+                source: 'high',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(50, 200, 0.8, 600)
+            },
+
+            // Grid density reacts to spectral flux (onsets)
+            gridDensity: {
+                source: 'spectralFlux',
+                curve: 'threshold',  // Only responds to strong onsets
+                range: [10, 100],
+                threshold: 0.15,
+                envelope: new ADSREnvelope(50, 1000, 0.3, 2000)
+            },
+
+            // Hue follows spectral centroid (brightness of sound)
+            hue: {
+                source: 'spectralCentroid',
+                curve: 'linear',
+                range: [0, 360],
+                envelope: null  // Instant response for color
+            },
+
+            // Intensity follows RMS (loudness)
+            intensity: {
+                source: 'rms',
+                curve: 'logarithmic',
+                range: [0.3, 1.0],
+                envelope: new ADSREnvelope(10, 50, 0.8, 200)
+            }
+        };
+    }
+
+    applyCurve(value, curve) {
+        switch(curve) {
+            case 'exponential':
+                return Math.pow(value, 2);
+            case 'logarithmic':
+                return Math.log10(1 + value * 9) / Math.log10(10);
+            case 's-curve':
+                return 1 / (1 + Math.exp(-10 * (value - 0.5)));
+            case 'threshold':
+                return value > this.threshold ? 1 : 0;
+            default:
+                return value; // linear
+        }
+    }
+}
+```
+
+**ADSR Envelope for Smooth Parameter Changes:**
+```javascript
+class ADSREnvelope {
+    constructor(attackMs, decayMs, sustain, releaseMs) {
+        this.attack = attackMs;
+        this.decay = decayMs;
+        this.sustain = sustain;  // 0-1
+        this.release = releaseMs;
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = 0;
+    }
+
+    trigger(value) {
+        this.targetValue = value;
+        this.phase = 'attack';
+        this.phaseStartTime = Date.now();
+    }
+
+    update() {
+        const now = Date.now();
+        const elapsed = now - this.phaseStartTime;
+
+        switch(this.phase) {
+            case 'attack':
+                this.value = (elapsed / this.attack) * this.targetValue;
+                if (elapsed >= this.attack) {
+                    this.phase = 'decay';
+                    this.phaseStartTime = now;
+                }
+                break;
+
+            case 'decay':
+                const decayProgress = elapsed / this.decay;
+                this.value = this.targetValue * (1 - decayProgress * (1 - this.sustain));
+                if (elapsed >= this.decay) {
+                    this.phase = 'sustain';
+                }
+                break;
+
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+
+            case 'release':
+                this.value *= 1 - (elapsed / this.release);
+                if (elapsed >= this.release) {
+                    this.phase = 'idle';
+                    this.value = 0;
+                }
+                break;
+        }
+
+        return this.value;
+    }
+}
+```
+
+---
+
+## 🏗️ REFACTORING IMPLEMENTATION PLAN
+
+### **PHASE 1: FOUNDATION (Week 1)**
+
+**1.1 Create BaseSystem Interface** ✅
+- [x] Write `src/systems/shared/BaseSystem.js`
+- [x] Define standard lifecycle: init → render → update → destroy
+- [x] Standard parameter interface
+- [x] Standard canvas management via reusable canvas factory
+- [x] Add `BaseVisualizer` + `SystemRegistry` scaffolding for consistent engine wiring
+- [x] Wrap faceted/quantum/holographic engines with new BaseSystem adapters
+
+**1.2 Extract Best Features from Each Index Variant**
+- [ ] From `index-MASTER.html`: Beat sync + video export
+- [ ] From `index-ULTIMATE-V2.html`: 4D rotation focus + musical timing
+- [ ] From `index-working-simple.html`: Clean hybrid mode
+- [ ] Document which features to preserve from each
+
+**1.3 Consolidate Parameter System**
+- [ ] Unify `Parameters.js` to work across all systems
+- [x] Add new color parameters
+- [ ] Add audio reactivity parameters
+- [ ] Validation + ranges for all parameters
+
+> ✅ ParameterManager now defines color mode, palette, and gradient controls with enum-aware validation and default ranges; audio mapping fields remain to be unified.
+
+---
+
+### **PHASE 2: COLOR SYSTEM (Week 1-2)**
+
+**2.1 Implement ColorSystem Class**
+- [x] Create `src/color/ColorSystem.js`
+- [x] Define 8+ color palettes
+- [x] Implement gradient functions
+- [x] Audio-reactive color mapping (palettes + gradients respond to analyzer state)
+
+**2.2 Update Shaders**
+- [ ] Modify `Visualizer.js` shader for multi-color support
+- [ ] Modify `QuantumVisualizer.js` shader
+- [ ] Modify `HolographicVisualizer.js` shader
+- [ ] Add palette uniforms to GLSL
+
+**2.3 UI for Color Control** ✅
+- [x] Color mode selector
+- [x] Palette picker
+- [x] Gradient controls
+- [x] Preview system with live gradient loop
+
+---
+
+### **PHASE 3: AUDIO SYSTEM (Week 2-3)**
+
+**3.1 Implement AudioAnalyzer**
+- [x] Create `src/audio/AudioAnalyzer.js` (complete V3 implementation)
+- [x] 7-band frequency analysis
+- [x] Spectral features (centroid, rolloff, flux)
+- [x] Onset detection
+- [x] BPM estimation
+
+**3.2 Implement ADSR Envelopes**
+- [x] Create `src/audio/ADSREnvelope.js`
+- [x] Attack/Decay/Sustain/Release phases
+- [x] Per-parameter envelope configuration
+- [x] Smooth parameter transitions
+
+**3.3 Implement ParameterMapper**
+- [x] Create `src/audio/ParameterMapper.js`
+- [x] Curve functions (exponential, logarithmic, s-curve, threshold)
+- [x] Band-to-parameter routing
+- [x] Envelope integration
+
+**3.4 Integration**
+- [x] Connect AudioAnalyzer to the global audio engine used by all systems (`js/audio/audio-engine.js`)
+- [x] Map audio features to parameters intelligently via default ParameterMapper presets
+- [ ] Test with various music genres
+- [ ] Optimize performance
+
+---
+
+### **PHASE 4: SYSTEM REFACTORING (Week 3-4)**
+
+**4.1 Refactor Faceted System**
+- [ ] Migrate `Engine.js` to extend `BaseSystem`
+- [ ] Integrate ColorSystem
+- [ ] Integrate AudioAnalyzer + ParameterMapper
+- [ ] Test all features
+
+**4.2 Refactor Quantum System**
+- [ ] Migrate `QuantumEngine.js` to extend `BaseSystem`
+- [ ] Integrate advanced color
+- [ ] Integrate advanced audio
+- [ ] Test volumetric lighting with new audio
+
+**4.3 Refactor Holographic System**
+- [ ] Consolidate 3 holographic variants into 1
+- [ ] Extend `BaseSystem`
+- [ ] Enhance audio reactivity with new system
+- [ ] Test multi-layer rendering
+
+**4.4 Refactor Polychora System**
+- [x] Migrate `PolychoraSystem.js` to extend `BaseSystem`
+- [x] 4D rotation optimization
+- [x] Audio-reactive 4D transformations
+- [ ] Test polytope rendering
+
+---
+
+### **PHASE 5: UNIFIED INTERFACE (Week 4-5)**
+
+**5.1 Create Single Master Index**
+- [ ] New `index.html` using BaseSystem architecture
+- [ ] Dynamic system loading
+- [ ] Unified UI that adapts per system
+- [ ] System switcher with smooth transitions
+
+**5.2 Consolidate CSS**
+- [ ] Extract inline CSS to modules
+- [ ] Per-system themes
+- [ ] Responsive design
+- [ ] Animation system
+
+**5.3 Export System**
+- [ ] Unify trading card generation across all systems
+- [ ] Video export with proper canvas handling
+- [ ] JSON save/load for all systems
+- [ ] Gallery system integration
+
+---
+
+### **PHASE 6: OPTIMIZATION & POLISH (Week 5-6)**
+
+**6.1 Performance**
+- [ ] WebGL optimization
+- [ ] Mobile performance testing
+- [ ] Memory leak prevention
+- [ ] Frame rate monitoring
+
+**6.2 Testing**
+- [ ] Unit tests for audio analysis
+- [ ] Integration tests for system switching
+- [ ] Visual regression tests
+- [ ] Mobile device testing
+
+**6.3 Documentation**
+- [ ] API documentation
+- [ ] User guide
+- [ ] Developer guide
+- [ ] Example presets
+
+---
+
+## 📁 NEW FILE STRUCTURE
+```
+vib34d-music-video-choreographer-alternative/
+├── index.html                           // NEW: Unified master interface
+├── src/
+│   ├── systems/
+│   │   ├── shared/
+│   │   │   ├── BaseSystem.js           // NEW: Base class all systems extend
+│   │   │   ├── BaseVisualizer.js       // NEW: Base visualizer interface
+│   │   │   └── SystemRegistry.js       // NEW: System management
+│   │   ├── faceted/
+│   │   │   ├── FacetedSystem.js        // REFACTORED: from Engine.js
+│   │   │   └── FacetedVisualizer.js    // REFACTORED: from Visualizer.js
+│   │   ├── quantum/
+│   │   │   ├── QuantumSystem.js        // REFACTORED: from QuantumEngine.js
+│   │   │   └── QuantumVisualizer.js    // REFACTORED
+│   │   ├── holographic/
+│   │   │   ├── HolographicSystem.js    // CONSOLIDATED: from 3 variants
+│   │   │   └── HolographicVisualizer.js
+│   │   └── polychora/
+│   │       ├── PolychoraSystem.js      // REFACTORED
+│   │       └── PolychoraVisualizer.js  // EXTRACTED
+│   ├── core/
+│   │   ├── Parameters.js               // ENHANCED: unified parameters
+│   │   ├── CanvasManager.js            // KEEP: working well
+│   │   └── ReactivityManager.js        // KEEP: working well
+│   ├── audio/
+│   │   ├── AudioAnalyzer.js            // NEW: 7-band + spectral analysis
+│   │   ├── ADSREnvelope.js             // NEW: smooth parameter transitions
+│   │   └── ParameterMapper.js          // NEW: audio-to-parameter routing
+│   ├── color/
+│   │   └── ColorSystem.js              // NEW: palettes + gradients + reactive
+│   ├── geometry/
+│   │   └── GeometryLibrary.js          // KEEP: shared geometries
+│   └── export/
+│       ├── UnifiedExportManager.js     // NEW: single export system
+│       └── [consolidate card generators]
+├── styles/
+│   ├── base.css                        // NEW: extracted from inline
+│   ├── systems/
+│   │   ├── faceted.css                 // NEW: system-specific styling
+│   │   ├── quantum.css
+│   │   ├── holographic.css
+│   │   └── polychora.css
+│   └── ui/
+│       ├── controls.css                // NEW: unified controls
+│       └── mobile.css                  // NEW: responsive design
+└── archive/
+    └── [move all old index-*.html here]
+```
+
+---
+
+## 🎯 SUCCESS CRITERIA
+
+### **Elegance:**
+- ✅ Single `index.html` under 500 lines
+- ✅ All systems extend `BaseSystem` with identical API
+- ✅ No code duplication between systems
+- ✅ Clean separation: systems / audio / color / export
+
+### **Color Expansion:**
+- ✅ 8+ color modes (single, dual, triad, palette, gradient, reactive)
+- ✅ 8+ predefined palettes
+- ✅ 5+ gradient types
+- ✅ Audio-reactive color that responds to spectral features
+
+### **Audio Reactivity:**
+- ✅ 7 frequency bands (vs current 3)
+- ✅ 4 spectral features (centroid, rolloff, flux, rms)
+- ✅ Onset detection for transients
+- ✅ BPM estimation
+- ✅ ADSR envelopes for smooth parameter changes
+- ✅ Multiple mapping curves (exponential, logarithmic, s-curve, threshold)
+
+### **Performance:**
+- ✅ 60 FPS on desktop
+- ✅ 45+ FPS on mobile
+- ✅ Smooth system switching (< 500ms)
+- ✅ No memory leaks
+
+---
+
+## 🚀 IMMEDIATE NEXT STEPS
+
+1. **Advanced Audio Pipeline Integration** ✅
+   - Faceted, Quantum, and Holographic renderers now consume the analyzer's multi-band + spectral output with smoothing envelopes
+   - Audio-driven boosts power grid density, morphing, chaos, color, and 4D rotation without destabilizing base parameters
+   - Debug hooks remain for spot-checking live signals while preserving graceful fallbacks when audio is disabled
+   - MusicVideoChoreographer playback now routes imported tracks through the advanced analyzer, keeping reactive + choreographed modes in sync with spectral features
+
+2. **Color System Integration** ✅
+   - ✅ Implemented `ColorSystem.js` with palettes, gradients, and audio-reactive blending
+   - ✅ Advanced audio engine now publishes `window.colorState` for every frame
+   - ✅ Feed palette uniforms + gradient data into shaders and UI controls (faceted, quantum, holographic) with live UI selectors
+
+3. **Unified System Architecture (in progress)**:
+   - ✅ BaseSystem + BaseVisualizer scaffolding created under `src/systems/shared`
+   - ✅ SystemRegistry orchestrates switching + lifecycle teardown
+   - ✅ Faceted, Quantum, and Holographic engines now run through BaseSystem adapters
+   - ✅ ParameterManager, timeline bridge, and export tooling resolve engines via SystemAccess helpers
+   - 🔜 Port remaining consumers (timeline bridge, export tools, gallery) to query registry instead of globals
+   - ✅ Added Polychora adapter powered by BaseSystem + SystemRegistry (`src/polychora/PolychoraEngine.js`, `src/systems/polychora/PolychoraSystem.js`)
+   - ✅ New Polychora visualizer consumes shared ColorSystem + audio analyzer for 4D palette + rotation reactivity
+
+4. **Finally Consolidation**:
+   - New unified `index.html`
+   - Move old versions to archive
+   - Polish and optimize
+
+---
+
+**TIMELINE**: 6 weeks for complete refactoring
+**PRIORITY**: Audio system first (can integrate with current architecture immediately)
+
+**Next Command**: Begin consolidating `ParameterManager` + timeline/export hooks to read from the SystemRegistry adapters.

--- a/index.html
+++ b/index.html
@@ -161,6 +161,52 @@
             cursor: not-allowed;
         }
 
+        select,
+        input[type="range"] {
+            background: rgba(0, 0, 0, 0.7);
+            border: 1px solid rgba(0, 255, 255, 0.6);
+            color: #0ff;
+            font-family: 'Orbitron', monospace;
+            padding: 8px 12px;
+            border-radius: 8px;
+            appearance: none;
+        }
+
+        .control-value {
+            min-width: 48px;
+            text-align: right;
+            font-size: 12px;
+            color: #0ff;
+        }
+
+        .color-controls {
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .color-controls label {
+            font-size: 11px;
+            text-transform: uppercase;
+            opacity: 0.75;
+            letter-spacing: 0.05em;
+        }
+
+        .color-controls select {
+            min-width: 140px;
+        }
+
+        .color-controls input[type="range"] {
+            flex: 1;
+        }
+
+        .gradient-preview {
+            width: 140px;
+            height: 22px;
+            border-radius: 8px;
+            border: 1px solid rgba(0, 255, 255, 0.4);
+            background: linear-gradient(90deg, #0ff, #f0f);
+        }
+
         .file-input-label {
             background: linear-gradient(135deg, #4a0a68, #f0f);
             padding: 12px 24px;
@@ -434,12 +480,34 @@
             <button class="system-btn active" data-system="faceted">🔷 FACETED</button>
             <button class="system-btn" data-system="quantum">🌌 QUANTUM</button>
             <button class="system-btn" data-system="holographic">✨ HOLOGRAPHIC</button>
+            <button class="system-btn" data-system="polychora">🔮 POLYCHORA</button>
+        </div>
+
+        <div class="control-row color-controls">
+            <label for="colorModeControl">Color Mode</label>
+            <select id="colorModeControl"></select>
+            <label for="colorPaletteControl">Palette</label>
+            <select id="colorPaletteControl"></select>
+            <div class="gradient-preview" id="gradientPreview"></div>
+        </div>
+
+        <div class="control-row color-controls">
+            <label for="gradientTypeControl">Gradient</label>
+            <select id="gradientTypeControl"></select>
+            <label for="gradientSpeedControl">Speed</label>
+            <input type="range" id="gradientSpeedControl" min="0" max="2" step="0.01" value="0.25">
+            <span class="control-value" id="gradientSpeedValue">0.25x</span>
+            <label for="colorReactivityControl">Reactivity</label>
+            <input type="range" id="colorReactivityControl" min="0" max="1" step="0.05" value="0.65">
+            <span class="control-value" id="colorReactivityValue">65%</span>
         </div>
 
         <div id="status">Select a mode to begin</div>
     </div>
 
     <script type="module">
+        import './js/audio/audio-engine.js';
+        import './js/controls/ui-handlers.js';
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
@@ -464,6 +532,10 @@
 
             // Initialize choreographer with selected mode
             initChoreographer(mode);
+
+            if (window.refreshColorControls) {
+                window.refreshColorControls();
+            }
         };
 
         window.toggleMode = function() {

--- a/js/audio/audio-engine.js
+++ b/js/audio/audio-engine.js
@@ -1,139 +1,685 @@
 /**
  * VIB34D Audio Engine Module
- * Mobile-safe audio reactivity system with global window integration
- * Extracted from monolithic index.html for clean architecture
+ * Advanced audio reactivity hub that feeds all visualization systems
+ * Built on the unified AudioAnalyzer / ParameterMapper toolkit
  */
+
+import { AudioAnalyzer } from '../../src/audio/AudioAnalyzer.js';
+import { ParameterMapper } from '../../src/audio/ParameterMapper.js';
+import { ADSREnvelope } from '../../src/audio/ADSREnvelope.js';
+import { ColorSystem } from '../../src/color/ColorSystem.js';
+
+const MEDIA_ELEMENT_SOURCE = Symbol('AdvancedAudioEngineMediaElementSource');
 
 // Global audio state flags - CRITICAL for system integration
 window.audioEnabled = false; // Global audio flag (will auto-enable on interaction)
 
-/**
- * Simple Audio Engine - Mobile-safe and actually works
- * Provides real-time audio analysis for all visualization systems
- */
-export class SimpleAudioEngine {
-    constructor() {
-        this.context = null;
-        this.analyser = null;
-        this.dataArray = null;
-        this.isActive = false;
-        
-        // Mobile-safe: Initialize with defaults
-        window.audioReactive = {
+const clamp01 = value => Math.min(Math.max(value, 0), 1);
+
+function createDefaultReactiveState(colorState = null) {
+    return {
+        bass: 0,
+        mid: 0,
+        high: 0,
+        sparkle: 0,
+        energy: 0,
+        motion: 0,
+        onset: 0,
+        hueShift: 0,
+        intensity: 0,
+        spectralCentroid: 0,
+        spectralRolloff: 0,
+        spectralFlux: 0,
+        rms: 0,
+        bpm: 0,
+        bands: {
+            subBass: 0,
             bass: 0,
-            mid: 0, 
+            lowMid: 0,
+            mid: 0,
+            highMid: 0,
             high: 0,
-            energy: 0
+            air: 0
+        },
+        color: colorState
+    };
+}
+
+/**
+ * Advanced Audio Engine - Unified analysis + parameter routing
+ */
+export class AdvancedAudioEngine {
+    constructor(options = {}) {
+        this.context = null;
+        this.mediaStream = null;
+        this.analyserNode = null;
+        this.audioAnalyzer = null;
+        this.parameterMapper = null;
+        this.colorSystem = new ColorSystem(options.colorSystem || {});
+        this.listeners = new Set();
+
+        this.mediaElementSource = null;
+        this.externalMediaElement = null;
+        this.analyserConnectedToDestination = false;
+
+        this.isActive = false;
+        this.isEnabled = false;
+        this.processingHandle = null;
+        this.frameScheduler = 'raf';
+
+        this.options = {
+            fftSize: options.fftSize || 2048,
+            smoothingTimeConstant: options.smoothingTimeConstant ?? 0.7,
+            energySmoothing: options.energySmoothing ?? 0.75,
+            onsetThreshold: options.onsetThreshold ?? 0.18,
+            minimumOnsetInterval: options.minimumOnsetInterval ?? 110
         };
-        
-        console.log('🎵 Audio Engine: Initialized with default values');
+
+        this.sensitivity = {
+            bass: options.bassGain ?? 1,
+            mid: options.midGain ?? 1,
+            high: options.highGain ?? 1,
+            energy: options.energyGain ?? 1,
+            sparkle: options.sparkleGain ?? 1,
+            motion: options.motionGain ?? 1
+        };
+
+        const initialColorState = this.colorSystem.getState();
+        window.colorState = initialColorState;
+        window.audioReactive = createDefaultReactiveState(initialColorState);
+
+        this.#emitColorEvent(initialColorState);
+
+        console.log('🎵 Audio Engine: Advanced analyzer initialized with default values');
     }
-    
-    async init() {
-        if (this.isActive) return true;
-        
+
+    async init(options = {}) {
+        if (options?.mediaElement) {
+            return this.#initWithMediaElement(options.mediaElement, options);
+        }
+
+        if (this.isActive) {
+            if (this.context?.state === 'suspended') {
+                await this.context.resume();
+            }
+            this.setEnabled(true);
+            return true;
+        }
+
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            console.warn('⚠️ Audio Analyzer: getUserMedia not available.');
+            return false;
+        }
+
         try {
-            console.log('🎵 Simple Audio Engine: Starting...');
-            
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            console.log('🎵 Advanced Audio Engine: Requesting microphone access…');
+            this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
             this.context = new (window.AudioContext || window.webkitAudioContext)();
-            
+
             if (this.context.state === 'suspended') {
                 await this.context.resume();
             }
-            
-            this.analyser = this.context.createAnalyser();
-            this.analyser.fftSize = 256;
-            this.analyser.smoothingTimeConstant = 0.8;
-            
-            const source = this.context.createMediaStreamSource(stream);
-            source.connect(this.analyser);
-            
-            this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+
+            this.analyserNode = this.context.createAnalyser();
+            this.analyserNode.fftSize = this.options.fftSize;
+            this.analyserNode.smoothingTimeConstant = this.options.smoothingTimeConstant;
+
+            const source = this.context.createMediaStreamSource(this.mediaStream);
+            source.connect(this.analyserNode);
+
+            this.audioAnalyzer = new AudioAnalyzer(this.analyserNode, {
+                fftSize: this.options.fftSize,
+                frequencySmoothing: this.options.smoothingTimeConstant,
+                energySmoothing: this.options.energySmoothing,
+                onsetThreshold: this.options.onsetThreshold,
+                minimumOnsetInterval: this.options.minimumOnsetInterval
+            });
+
+            this.parameterMapper = this.#createDefaultMapper();
+
             this.isActive = true;
-            
-            // CRITICAL FIX: Enable global audio flag so visualizers will use the data
-            window.audioEnabled = true;
-            
-            this.startProcessing();
-            console.log('✅ Audio Engine: Active - window.audioEnabled = true');
+            this.setEnabled(true);
+            this.#startProcessing();
+
+            console.log('✅ Audio Engine: Advanced analyzer active');
             return true;
-            
         } catch (error) {
-            console.log('⚠️ Audio denied - silent mode');
-            window.audioEnabled = false; // Keep audio disabled if permission denied
+            console.warn('⚠️ Audio Analyzer: Permission denied or device unavailable', error);
+            this.isActive = false;
+            this.setEnabled(false);
             return false;
         }
     }
-    
-    startProcessing() {
-        const process = () => {
-            if (!this.isActive || !this.analyser) {
-                requestAnimationFrame(process);
-                return;
-            }
-            
-            this.analyser.getByteFrequencyData(this.dataArray);
-            
-            // Simple frequency analysis
-            const len = this.dataArray.length;
-            const bassRange = Math.floor(len * 0.1);
-            const midRange = Math.floor(len * 0.3);
-            
-            let bass = 0, mid = 0, high = 0;
-            
-            for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
-            for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
-            for (let i = midRange; i < len; i++) high += this.dataArray[i];
-            
-            bass = (bass / bassRange) / 255;
-            mid = (mid / (midRange - bassRange)) / 255;
-            high = (high / (len - midRange)) / 255;
-            
-            const smoothing = 0.7;
-            window.audioReactive.bass = bass * smoothing + window.audioReactive.bass * (1 - smoothing);
-            window.audioReactive.mid = mid * smoothing + window.audioReactive.mid * (1 - smoothing);
-            window.audioReactive.high = high * smoothing + window.audioReactive.high * (1 - smoothing);
-            window.audioReactive.energy = (window.audioReactive.bass + window.audioReactive.mid + window.audioReactive.high) / 3;
-            
-            // Debug logging every 5 seconds to verify audio processing
-            if (Date.now() % 5000 < 16) {
-                console.log(`🎵 Audio levels: Bass=${window.audioReactive.bass.toFixed(2)} Mid=${window.audioReactive.mid.toFixed(2)} High=${window.audioReactive.high.toFixed(2)} Energy=${window.audioReactive.energy.toFixed(2)}`);
-            }
-            
-            requestAnimationFrame(process);
-        };
-        
-        process();
+
+    async useMediaElement(mediaElement, options = {}) {
+        return this.init({ ...options, mediaElement });
     }
-    
-    /**
-     * Check if audio is currently active and processing
-     */
+
     isAudioActive() {
-        return this.isActive && window.audioEnabled;
+        return this.isActive && this.isEnabled && window.audioEnabled;
     }
-    
-    /**
-     * Get current audio reactive values
-     */
+
+    setEnabled(enabled) {
+        this.isEnabled = Boolean(enabled);
+        window.audioEnabled = this.isEnabled;
+
+        if (!this.isEnabled) {
+            this.#resetReactiveState();
+            this.#stopProcessingLoop();
+        }
+
+        if (!this.processingHandle && this.isActive && this.isEnabled) {
+            this.#startProcessing();
+        }
+    }
+
+    updateSensitivity(settings = {}) {
+        if (typeof settings.bassGain === 'number') {
+            this.sensitivity.bass = Math.max(0, settings.bassGain);
+        }
+        if (typeof settings.midGain === 'number') {
+            this.sensitivity.mid = Math.max(0, settings.midGain);
+        }
+        if (typeof settings.highGain === 'number') {
+            this.sensitivity.high = Math.max(0, settings.highGain);
+        }
+        if (typeof settings.energyGain === 'number') {
+            this.sensitivity.energy = Math.max(0, settings.energyGain);
+        }
+        if (typeof settings.sparkleGain === 'number') {
+            this.sensitivity.sparkle = Math.max(0, settings.sparkleGain);
+        }
+        if (typeof settings.motionGain === 'number') {
+            this.sensitivity.motion = Math.max(0, settings.motionGain);
+        }
+    }
+
+    registerMappings(parameterMappings = {}) {
+        if (!this.parameterMapper) {
+            this.parameterMapper = new ParameterMapper(parameterMappings);
+            return;
+        }
+
+        Object.entries(parameterMappings).forEach(([parameter, config]) => {
+            this.parameterMapper.registerMapping(parameter, config);
+        });
+    }
+
+    getColorConfiguration() {
+        if (this.colorSystem && typeof this.colorSystem.getConfig === 'function') {
+            return this.colorSystem.getConfig();
+        }
+        return {};
+    }
+
+    getAvailableColorModes() {
+        if (this.colorSystem && typeof this.colorSystem.getAvailableModes === 'function') {
+            return this.colorSystem.getAvailableModes();
+        }
+        return [];
+    }
+
+    getAvailablePalettes() {
+        if (this.colorSystem && typeof this.colorSystem.getAvailablePalettes === 'function') {
+            return this.colorSystem.getAvailablePalettes();
+        }
+        return [];
+    }
+
+    getAvailableGradients() {
+        if (this.colorSystem && typeof this.colorSystem.getAvailableGradients === 'function') {
+            return this.colorSystem.getAvailableGradients();
+        }
+        return [];
+    }
+
+    updateColorSettings(settings = {}) {
+        if (!this.colorSystem || !settings || typeof settings !== 'object') {
+            return this.getColorState();
+        }
+
+        const state = this.colorSystem.updateConfig(settings);
+        window.colorState = state;
+        if (window.audioReactive) {
+            window.audioReactive.color = state;
+        }
+
+        this.#emitColorEvent(state);
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(window.audioReactive, null);
+            } catch (error) {
+                console.warn('Audio Engine listener error during color update', error);
+            }
+        });
+
+        return state;
+    }
+
+    setColorMode(mode) {
+        if (typeof mode !== 'string') {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ colorMode: mode });
+    }
+
+    setColorPalette(name) {
+        if (typeof name !== 'string') {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ colorPalette: name });
+    }
+
+    setGradientType(type) {
+        if (typeof type !== 'string') {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ gradientType: type });
+    }
+
+    setGradientSpeed(speed) {
+        const numeric = Number(speed);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ gradientSpeed: numeric });
+    }
+
+    setColorReactivity(amount) {
+        const numeric = Number(amount);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ colorReactivity: numeric });
+    }
+
+    setBaseHue(hue) {
+        const numeric = Number(hue);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ baseHue: numeric });
+    }
+
+    setBaseSaturation(saturation) {
+        const numeric = Number(saturation);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ baseSaturation: numeric });
+    }
+
+    setBaseIntensity(intensity) {
+        const numeric = Number(intensity);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ baseIntensity: numeric });
+    }
+
+    subscribe(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
     getAudioLevels() {
         return window.audioReactive;
     }
-    
-    /**
-     * Stop audio processing and clean up resources
-     */
+
+    getColorState() {
+        return this.colorSystem?.getState() ?? window.colorState ?? null;
+    }
+
     stop() {
-        this.isActive = false;
+        this.isEnabled = false;
         window.audioEnabled = false;
-        
+
+        this.#stopProcessingLoop();
+
+        if (this.mediaElementSource) {
+            try {
+                this.mediaElementSource.disconnect();
+            } catch (error) {
+                console.warn('Audio Engine: failed to disconnect media element source', error);
+            }
+            this.mediaElementSource = null;
+        }
+
+        if (this.externalMediaElement) {
+            delete this.externalMediaElement[MEDIA_ELEMENT_SOURCE];
+            this.externalMediaElement = null;
+        }
+
+        if (this.analyserNode) {
+            try {
+                this.analyserNode.disconnect();
+            } catch (error) {
+                console.warn('Audio Engine: failed to disconnect analyser node', error);
+            }
+            this.analyserConnectedToDestination = false;
+            this.analyserNode = null;
+        }
+
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach(track => track.stop());
+            this.mediaStream = null;
+        }
+
         if (this.context) {
             this.context.close();
             this.context = null;
         }
-        
-        console.log('🎵 Audio Engine: Stopped');
+
+        this.isActive = false;
+        this.#resetReactiveState();
+
+        console.log('🎵 Audio Engine: Stopped and cleaned up');
+    }
+
+    #startProcessing() {
+        if (!this.isActive || !this.isEnabled || !this.audioAnalyzer || this.processingHandle != null) {
+            return;
+        }
+
+        const useRaf = typeof requestAnimationFrame === 'function';
+        this.frameScheduler = useRaf ? 'raf' : 'timeout';
+
+        const step = () => {
+            if (!this.isActive) {
+                this.#stopProcessingLoop();
+                return;
+            }
+
+            if (this.isEnabled) {
+                this.#processFrame();
+            }
+
+            if (this.frameScheduler === 'raf') {
+                this.processingHandle = requestAnimationFrame(step);
+            } else {
+                this.processingHandle = setTimeout(step, 16);
+            }
+        };
+
+        if (this.frameScheduler === 'raf') {
+            this.processingHandle = requestAnimationFrame(step);
+        } else {
+            this.processingHandle = setTimeout(step, 16);
+        }
+    }
+
+    #processFrame() {
+        if (!this.audioAnalyzer || !this.parameterMapper) {
+            return;
+        }
+
+        const audioData = this.audioAnalyzer.analyze();
+        const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const mapped = this.parameterMapper.map(audioData, now);
+
+        const combinedBands = {
+            subBass: clamp01(audioData.bands?.subBass ?? 0),
+            bass: clamp01(audioData.bands?.bass ?? 0),
+            lowMid: clamp01(audioData.bands?.lowMid ?? 0),
+            mid: clamp01(audioData.bands?.mid ?? 0),
+            highMid: clamp01(audioData.bands?.highMid ?? 0),
+            high: clamp01(audioData.bands?.high ?? 0),
+            air: clamp01(audioData.bands?.air ?? 0)
+        };
+
+        const reactive = {
+            bass: clamp01((mapped.bass ?? 0) * this.sensitivity.bass),
+            mid: clamp01((mapped.mid ?? 0) * this.sensitivity.mid),
+            high: clamp01((mapped.high ?? 0) * this.sensitivity.high),
+            sparkle: clamp01((mapped.sparkle ?? combinedBands.air) * this.sensitivity.sparkle),
+            energy: clamp01((mapped.energy ?? audioData.rms ?? 0) * this.sensitivity.energy),
+            motion: clamp01((mapped.motion ?? audioData.spectralFlux ?? 0) * this.sensitivity.motion),
+            onset: audioData.onset ? 1 : 0,
+            hueShift: clamp01(mapped.hueShift ?? audioData.spectralCentroid ?? 0),
+            intensity: clamp01(mapped.intensity ?? audioData.rms ?? 0),
+            spectralCentroid: clamp01(audioData.spectralCentroid ?? 0),
+            spectralRolloff: clamp01(audioData.spectralRolloff ?? 0),
+            spectralFlux: clamp01(audioData.spectralFlux ?? 0),
+            rms: clamp01(audioData.rms ?? 0),
+            bpm: audioData.bpm || 0,
+            bands: combinedBands
+        };
+
+        reactive.energy = Math.max(reactive.energy, (reactive.bass + reactive.mid + reactive.high) / 3);
+
+        if (this.colorSystem) {
+            const colorState = this.colorSystem.update(now, audioData, reactive);
+            reactive.color = colorState;
+            window.colorState = colorState;
+        }
+
+        window.audioReactive = reactive;
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(reactive, audioData);
+            } catch (error) {
+                console.warn('Audio Engine listener error', error);
+            }
+        });
+
+        if (Math.floor(now) % 5000 < 32) {
+            console.log(
+                `🎵 Audio levels: Bass=${reactive.bass.toFixed(2)} Mid=${reactive.mid.toFixed(2)} High=${reactive.high.toFixed(2)} Energy=${reactive.energy.toFixed(2)} BPM=${Math.round(reactive.bpm)}`
+            );
+        }
+    }
+
+    #stopProcessingLoop() {
+        if (this.processingHandle == null) {
+            return;
+        }
+
+        if (this.frameScheduler === 'raf') {
+            if (typeof cancelAnimationFrame === 'function') {
+                cancelAnimationFrame(this.processingHandle);
+            }
+        } else if (this.frameScheduler === 'timeout') {
+            clearTimeout(this.processingHandle);
+        }
+
+        this.processingHandle = null;
+    }
+
+    #createDefaultMapper() {
+        return new ParameterMapper({
+            bass: {
+                source: data => ((data.bands.subBass + data.bands.bass) / 2) || 0,
+                curve: 'exponential',
+                range: [0, 1],
+                envelope: new ADSREnvelope(60, 140, 0.65, 220),
+                envelopeTrigger: 0.05,
+                envelopeRelease: 0.03
+            },
+            mid: {
+                source: data => ((data.bands.lowMid + data.bands.mid) / 2) || 0,
+                curve: 's-curve',
+                intensity: 0.8,
+                range: [0, 1],
+                envelope: new ADSREnvelope(50, 100, 0.7, 200),
+                envelopeTrigger: 0.05,
+                envelopeRelease: 0.03
+            },
+            high: {
+                source: data => ((data.bands.highMid + data.bands.high) / 2) || 0,
+                curve: 'power',
+                power: 1.4,
+                range: [0, 1],
+                envelope: new ADSREnvelope(35, 90, 0.6, 160),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.025
+            },
+            sparkle: {
+                source: data => data.bands.air || 0,
+                curve: 'power',
+                power: 1.6,
+                range: [0, 1],
+                envelope: new ADSREnvelope(25, 80, 0.5, 140),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            },
+            energy: {
+                source: data => data.rms || 0,
+                curve: 'logarithmic',
+                range: [0.1, 1],
+                envelope: new ADSREnvelope(30, 120, 0.75, 260),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            },
+            motion: {
+                source: data => data.spectralFlux || 0,
+                curve: 'exponential',
+                range: [0, 1],
+                envelope: new ADSREnvelope(20, 80, 0.5, 180),
+                envelopeTrigger: 0.03,
+                envelopeRelease: 0.015
+            },
+            hueShift: {
+                source: data => data.spectralCentroid || 0,
+                curve: 'linear',
+                range: [0, 1]
+            },
+            intensity: {
+                source: data => data.rms || 0,
+                curve: 's-curve',
+                intensity: 0.6,
+                range: [0.2, 1],
+                envelope: new ADSREnvelope(25, 70, 0.8, 160),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            }
+        });
+    }
+
+    #resetReactiveState() {
+        const colorState = this.colorSystem ? this.colorSystem.reset() : null;
+        window.colorState = colorState;
+        window.audioReactive = createDefaultReactiveState(colorState);
+        this.#emitColorEvent(colorState);
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(window.audioReactive, null);
+            } catch (error) {
+                console.warn('Audio Engine listener error during reset', error);
+            }
+        });
+    }
+
+    #emitColorEvent(state) {
+        if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+            return;
+        }
+
+        try {
+            const detail = {
+                state: state || this.getColorState(),
+                config: this.getColorConfiguration()
+            };
+            window.dispatchEvent(new CustomEvent('vib34d:color-state', { detail }));
+        } catch (error) {
+            console.warn('Audio Engine color event dispatch failed', error);
+        }
+    }
+
+    async #initWithMediaElement(mediaElement, options = {}) {
+        if (!mediaElement) {
+            console.warn('Audio Engine: media element not provided for analysis');
+            return false;
+        }
+
+        if (!this.context) {
+            this.context = new (window.AudioContext || window.webkitAudioContext)();
+        }
+
+        if (this.context.state === 'suspended') {
+            await this.context.resume();
+        }
+
+        if (!this.analyserNode) {
+            this.analyserNode = this.context.createAnalyser();
+            this.analyserNode.fftSize = this.options.fftSize;
+            this.analyserNode.smoothingTimeConstant = this.options.smoothingTimeConstant;
+        }
+
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach(track => track.stop());
+            this.mediaStream = null;
+        }
+
+        if (this.mediaElementSource && this.externalMediaElement !== mediaElement) {
+            try {
+                this.mediaElementSource.disconnect();
+            } catch (error) {
+                console.warn('Audio Engine: failed to detach previous media element source', error);
+            }
+            this.mediaElementSource = null;
+        }
+
+        if (this.externalMediaElement && this.externalMediaElement !== mediaElement) {
+            delete this.externalMediaElement[MEDIA_ELEMENT_SOURCE];
+        }
+
+        this.externalMediaElement = mediaElement;
+
+        if (mediaElement[MEDIA_ELEMENT_SOURCE]) {
+            this.mediaElementSource = mediaElement[MEDIA_ELEMENT_SOURCE];
+        } else {
+            this.mediaElementSource = this.context.createMediaElementSource(mediaElement);
+            mediaElement[MEDIA_ELEMENT_SOURCE] = this.mediaElementSource;
+        }
+
+        try {
+            this.mediaElementSource.disconnect();
+        } catch (error) {
+            // Disconnect errors are safe to ignore; the source might not be connected yet
+        }
+
+        this.mediaElementSource.connect(this.analyserNode);
+
+        try {
+            this.analyserNode.disconnect();
+        } catch (error) {
+            // Ignore disconnect errors
+        }
+
+        this.analyserNode.connect(this.context.destination);
+        this.analyserConnectedToDestination = true;
+
+        if (!this.audioAnalyzer) {
+            this.audioAnalyzer = new AudioAnalyzer(this.analyserNode, {
+                fftSize: this.options.fftSize,
+                frequencySmoothing: this.options.smoothingTimeConstant,
+                energySmoothing: this.options.energySmoothing,
+                onsetThreshold: this.options.onsetThreshold,
+                minimumOnsetInterval: this.options.minimumOnsetInterval
+            });
+        }
+
+        if (!this.parameterMapper) {
+            this.parameterMapper = this.#createDefaultMapper();
+        }
+
+        this.isActive = true;
+
+        if (options.autoEnable !== false) {
+            this.setEnabled(true);
+        }
+
+        this.#startProcessing();
+
+        console.log('🎵 Audio Engine: attached to media element for analysis');
+        return true;
     }
 }
 
@@ -142,56 +688,45 @@ export class SimpleAudioEngine {
  * Toggles audio reactivity and updates UI state
  */
 export function setupAudioToggle() {
-    window.toggleAudio = function() {
+    window.toggleAudio = async function toggleAudio() {
         const audioBtn = document.getElementById('audioToggle') || document.querySelector('[onclick="toggleAudio()"]');
-        
-        if (!window.audioEngine.isActive) {
-            // Try to start audio
-            window.audioEngine.init().then(success => {
-                if (success) {
-                    if (audioBtn) {
-                        audioBtn.classList.add('active');
-                        audioBtn.title = 'Audio Reactivity: ON';
-                    }
-                    console.log('🎵 Audio Reactivity: ON');
-                } else {
-                    console.log('⚠️ Audio permission denied or not available');
-                }
-            });
-        } else {
-            // Toggle audio processing
-            let audioEnabled = !window.audioEnabled;
-            window.audioEnabled = audioEnabled; // Update global flag
-            
-            if (audioBtn) {
-                // Update button visual state
-                if (audioEnabled) {
-                    audioBtn.classList.add('active');
-                } else {
-                    audioBtn.classList.remove('active');
-                }
-                audioBtn.title = `Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`;
-            }
-            
-            // Audio permission check for mobile
-            if (audioEnabled) {
-                navigator.mediaDevices.getUserMedia({ audio: true }).catch(e => {
-                    audioEnabled = false;
-                    window.audioEnabled = false;
-                    console.log('⚠️ Audio permission denied:', e.message);
-                });
-            }
-            
-            console.log(`🎵 Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`);
+
+        if (!window.audioEngine) {
+            console.warn('⚠️ No audio engine instance available');
+            return;
         }
+
+        if (!window.audioEngine.isActive) {
+            const success = await window.audioEngine.init();
+            if (!success) {
+                console.warn('⚠️ Audio Reactivity: Permission denied or unavailable');
+                return;
+            }
+            if (audioBtn) {
+                audioBtn.classList.add('active');
+                audioBtn.title = 'Audio Reactivity: ON';
+            }
+            console.log('🎵 Audio Reactivity: ON');
+            return;
+        }
+
+        const nextEnabled = !window.audioEnabled;
+        window.audioEngine.setEnabled(nextEnabled);
+
+        if (audioBtn) {
+            audioBtn.classList.toggle('active', nextEnabled);
+            audioBtn.title = `Audio Reactivity: ${nextEnabled ? 'ON' : 'OFF'}`;
+        }
+
+        console.log(`🎵 Audio Reactivity: ${nextEnabled ? 'ON' : 'OFF'}`);
     };
 }
 
 // Create and initialize the global audio engine instance
-const audioEngine = new SimpleAudioEngine();
+const audioEngine = new AdvancedAudioEngine();
 window.audioEngine = audioEngine;
 
 // Set up global audio toggle function
 setupAudioToggle();
 
-console.log('🎵 Audio Engine Module: Loaded');
+console.log('🎵 Audio Engine Module: Advanced analyzer loaded');

--- a/js/controls/ui-handlers.js
+++ b/js/controls/ui-handlers.js
@@ -5,6 +5,13 @@
  */
 
 import { GeometryLibrary } from '../../src/geometry/GeometryLibrary.js';
+import { COLOR_MODES, GRADIENT_TYPES, COLOR_PALETTES } from '../../src/color/ColorSystem.js';
+import {
+    getActiveEngine,
+    getActiveParameterManager,
+    getActiveSystemKey,
+    onRegistryChange
+} from '../../src/systems/shared/SystemAccess.js';
 
 // Global state variables
 let audioEnabled = window.audioEnabled || false;
@@ -15,7 +22,24 @@ const LEGACY_SYSTEM_KEYS = ['faceted', 'quantum', 'holographic', 'polychora'];
 let cachedGeometryNames = sanitizeGeometryList(GeometryLibrary.getGeometryNames());
 let geometrySubscriptionCleanup = null;
 let geometryGridElement = null;
-let geometryGridSystem = 'faceted';
+let geometryGridSystem = getActiveSystemKey() || 'faceted';
+
+const COLOR_MODE_OPTIONS = Array.from(COLOR_MODES);
+const GRADIENT_TYPE_OPTIONS = Array.from(GRADIENT_TYPES);
+const COLOR_PALETTE_OPTIONS = Object.keys(COLOR_PALETTES);
+const getSystemKeyFallback = () => getActiveSystemKey() || window.currentSystem || 'faceted';
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+let colorControlsInitialized = false;
+let gradientPreviewElement = null;
+let gradientPreviewLoopActive = false;
+let colorModeSelect = null;
+let colorPaletteSelect = null;
+let gradientTypeSelect = null;
+let gradientSpeedInput = null;
+let gradientSpeedValueLabel = null;
+let colorReactivityInput = null;
+let colorReactivityValueLabel = null;
 
 function sanitizeGeometryList(names = []) {
     const seen = new Set();
@@ -113,7 +137,7 @@ function ensureGeometrySubscription() {
     }, { once: true });
 }
 
-function getGeometryNamesForSystem(system = window.currentSystem || 'faceted') {
+function getGeometryNamesForSystem(system = getSystemKeyFallback()) {
     const fallback = cachedGeometryNames.length ? cachedGeometryNames : sanitizeGeometryList(GeometryLibrary.getGeometryNames());
     const manual = window.geometries?.[system];
     if (!Array.isArray(manual) || !manual.length) {
@@ -153,22 +177,268 @@ function renderGeometryGrid() {
 syncLegacyGeometryState(cachedGeometryNames);
 ensureGeometrySubscription();
 
+onRegistryChange(({ key }) => {
+    if (!key) {
+        return;
+    }
+    if (geometryGridSystem !== key) {
+        geometryGridSystem = key;
+        if (geometryGridElement) {
+            renderGeometryGrid();
+        }
+    }
+});
+
+function formatColorLabel(key) {
+    if (!key) {
+        return 'Default';
+    }
+    return key.replace(/[-_]/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function ensureSelectOptions(select, options) {
+    if (!select || !Array.isArray(options)) {
+        return;
+    }
+
+    const existing = Array.from(select.options).map(option => option.value);
+    const needsUpdate = existing.length !== options.length || existing.some((value, index) => value !== options[index]);
+
+    if (!needsUpdate) {
+        return;
+    }
+
+    select.innerHTML = options.map(option => `<option value="${option}">${formatColorLabel(option)}</option>`).join('');
+}
+
+function startGradientPreviewLoop() {
+    if (gradientPreviewLoopActive || !gradientPreviewElement) {
+        return;
+    }
+
+    gradientPreviewLoopActive = true;
+
+    const update = () => {
+        if (!gradientPreviewElement) {
+            gradientPreviewLoopActive = false;
+            return;
+        }
+
+        const gradientState = window.colorState?.gradient;
+        if (gradientState?.css && gradientPreviewElement.dataset.currentCss !== gradientState.css) {
+            gradientPreviewElement.style.background = gradientState.css;
+            gradientPreviewElement.dataset.currentCss = gradientState.css;
+        }
+
+        requestAnimationFrame(update);
+    };
+
+    requestAnimationFrame(update);
+}
+
+function syncColorControls(config, state) {
+    if (!colorControlsInitialized) {
+        return;
+    }
+
+    const audioEngine = window.audioEngine;
+    const activeConfig = config || audioEngine?.getColorConfiguration?.() || {};
+    const activeState = state || audioEngine?.getColorState?.() || window.colorState || {};
+
+    if (colorModeSelect) {
+        const modeValue = activeConfig.colorMode || 'single';
+        if (colorModeSelect.value !== modeValue) {
+            colorModeSelect.value = modeValue;
+        }
+    }
+
+    if (colorPaletteSelect) {
+        const paletteValue = activeConfig.colorPalette || '';
+        if (paletteValue && !Array.from(colorPaletteSelect.options).some(option => option.value === paletteValue)) {
+            const option = document.createElement('option');
+            option.value = paletteValue;
+            option.textContent = formatColorLabel(paletteValue);
+            colorPaletteSelect.appendChild(option);
+        }
+        if (paletteValue && colorPaletteSelect.value !== paletteValue) {
+            colorPaletteSelect.value = paletteValue;
+        }
+    }
+
+    if (gradientTypeSelect) {
+        const gradientValue = activeConfig.gradientType || 'horizontal';
+        if (gradientTypeSelect.value !== gradientValue) {
+            gradientTypeSelect.value = gradientValue;
+        }
+    }
+
+    if (gradientSpeedInput) {
+        const speedValue = typeof activeConfig.gradientSpeed === 'number' ? activeConfig.gradientSpeed : 0.25;
+        if (gradientSpeedInput.value !== String(speedValue)) {
+            gradientSpeedInput.value = String(speedValue);
+        }
+        if (gradientSpeedValueLabel) {
+            gradientSpeedValueLabel.textContent = `${speedValue.toFixed(2)}x`;
+        }
+    }
+
+    if (colorReactivityInput) {
+        const reactivityValue = typeof activeConfig.colorReactivity === 'number' ? activeConfig.colorReactivity : 0.65;
+        if (colorReactivityInput.value !== String(reactivityValue)) {
+            colorReactivityInput.value = String(reactivityValue);
+        }
+        if (colorReactivityValueLabel) {
+            colorReactivityValueLabel.textContent = `${Math.round(clamp(reactivityValue, 0, 1) * 100)}%`;
+        }
+    }
+
+    if (gradientPreviewElement && activeState?.gradient?.css) {
+        gradientPreviewElement.style.background = activeState.gradient.css;
+        gradientPreviewElement.dataset.currentCss = activeState.gradient.css;
+    }
+}
+
+function initializeColorControls(force = false) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    if (!force && colorControlsInitialized) {
+        syncColorControls();
+        return;
+    }
+
+    if (!window.audioEngine) {
+        setTimeout(() => initializeColorControls(force), 150);
+        return;
+    }
+
+    colorModeSelect = document.getElementById('colorModeControl');
+    colorPaletteSelect = document.getElementById('colorPaletteControl');
+    gradientTypeSelect = document.getElementById('gradientTypeControl');
+    gradientSpeedInput = document.getElementById('gradientSpeedControl');
+    gradientSpeedValueLabel = document.getElementById('gradientSpeedValue');
+    colorReactivityInput = document.getElementById('colorReactivityControl');
+    colorReactivityValueLabel = document.getElementById('colorReactivityValue');
+    gradientPreviewElement = document.getElementById('gradientPreview');
+
+    if (!colorModeSelect || !colorPaletteSelect || !gradientTypeSelect || !gradientSpeedInput || !colorReactivityInput) {
+        return;
+    }
+
+    const audioEngine = window.audioEngine;
+    const availableModes = audioEngine?.getAvailableColorModes?.() ?? COLOR_MODE_OPTIONS;
+    const availablePalettes = audioEngine?.getAvailablePalettes?.() ?? COLOR_PALETTE_OPTIONS;
+    const availableGradients = audioEngine?.getAvailableGradients?.() ?? GRADIENT_TYPE_OPTIONS;
+
+    ensureSelectOptions(colorModeSelect, availableModes);
+    ensureSelectOptions(colorPaletteSelect, availablePalettes.length ? availablePalettes : COLOR_PALETTE_OPTIONS);
+    ensureSelectOptions(gradientTypeSelect, availableGradients);
+
+    colorModeSelect.addEventListener('change', event => {
+        audioEngine?.setColorMode?.(event.target.value);
+    });
+
+    colorPaletteSelect.addEventListener('change', event => {
+        audioEngine?.setColorPalette?.(event.target.value);
+    });
+
+    gradientTypeSelect.addEventListener('change', event => {
+        audioEngine?.setGradientType?.(event.target.value);
+    });
+
+    gradientSpeedInput.addEventListener('input', event => {
+        const value = parseFloat(event.target.value);
+        if (gradientSpeedValueLabel) {
+            gradientSpeedValueLabel.textContent = `${(Number.isFinite(value) ? value : 0).toFixed(2)}x`;
+        }
+        audioEngine?.setGradientSpeed?.(value);
+    });
+
+    colorReactivityInput.addEventListener('input', event => {
+        const value = parseFloat(event.target.value);
+        if (colorReactivityValueLabel) {
+            colorReactivityValueLabel.textContent = `${Math.round(clamp(value, 0, 1) * 100)}%`;
+        }
+        audioEngine?.setColorReactivity?.(value);
+    });
+
+    colorControlsInitialized = true;
+    syncColorControls();
+
+    if (gradientPreviewElement) {
+        startGradientPreviewLoop();
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('vib34d:color-state', event => {
+        syncColorControls(event.detail?.config, event.detail?.state);
+    });
+
+    window.refreshColorControls = (force = false) => {
+        initializeColorControls(force);
+    };
+}
+
+if (typeof document !== 'undefined') {
+    const initControls = () => initializeColorControls();
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initControls, { once: true });
+    } else {
+        setTimeout(initControls, 0);
+    }
+}
+
 /**
  * Main parameter update function - CRITICAL for all visualizers
  * Routes parameters to appropriate engine based on current system
  */
 window.updateParameter = function(param, value) {
-    // CRITICAL: Store user's parameter choice for persistence
-    window.userParameterState[param] = parseFloat(value);
-    
-    // GALLERY PERFORMANCE FIX: Reduce parameter logging spam in gallery context
-    if (!window.isGalleryPreview) {
-        console.log(`💾 User parameter: ${param} = ${value}`);
+    if (!window.userParameterState) {
+        window.userParameterState = {};
     }
-    
+
+    const systemKey = getSystemKeyFallback();
+    const manager = getActiveParameterManager();
+    const definition = manager?.getParameterDefinition?.(param) || manager?.parameterDefs?.[param] || null;
+
+    let numericValue = Number(value);
+    const isNumeric = Number.isFinite(numericValue);
+    let processedValue = value;
+
+    if (definition) {
+        if (definition.type === 'enum') {
+            processedValue = typeof value === 'string' ? value : (value === null || value === undefined ? '' : String(value));
+        } else if (definition.type === 'bool' || definition.type === 'boolean') {
+            processedValue = Boolean(value);
+        } else {
+            processedValue = isNumeric ? numericValue : Number(definition.default ?? manager?.params?.[param] ?? value);
+            numericValue = Number(processedValue);
+        }
+    } else if (isNumeric) {
+        processedValue = numericValue;
+    }
+
+    window.userParameterState[param] = processedValue;
+
+    if (!window.isGalleryPreview) {
+        console.log(`💾 User parameter: ${param} = ${processedValue}`);
+    }
+
+    if (window.audioEngine && isNumeric) {
+        if (param === 'hue') {
+            window.audioEngine.setBaseHue?.(numericValue);
+        } else if (param === 'saturation') {
+            window.audioEngine.setBaseSaturation?.(numericValue);
+        } else if (param === 'intensity') {
+            window.audioEngine.setBaseIntensity?.(numericValue);
+        }
+    }
+
     const displays = {
         rot4dXW: 'xwValue',
-        rot4dYW: 'ywValue', 
+        rot4dYW: 'ywValue',
         rot4dZW: 'zwValue',
         gridDensity: 'densityValue',
         morphFactor: 'morphValue',
@@ -178,72 +448,50 @@ window.updateParameter = function(param, value) {
         intensity: 'intensityValue',
         saturation: 'saturationValue'
     };
-    
+
     const display = document.getElementById(displays[param]);
     if (display) {
-        if (param === 'hue') {
-            display.textContent = value + '°';
-        } else if (param.startsWith('rot4d')) {
-            display.textContent = parseFloat(value).toFixed(2);
-        } else {
-            display.textContent = parseFloat(value).toFixed(1);
+        if (definition?.type === 'enum') {
+            display.textContent = String(processedValue);
+        } else if (param === 'hue' && isNumeric) {
+            display.textContent = `${Math.round(numericValue)}°`;
+        } else if (param.startsWith('rot4d') && isNumeric) {
+            display.textContent = numericValue.toFixed(2);
+        } else if (isNumeric) {
+            display.textContent = numericValue.toFixed(1);
         }
     }
-    
-    // SURGICAL FIX: Unified parameter router - eliminates scope confusion
+
     try {
-        const activeSystem = window.currentSystem || 'faceted';
-        const engines = {
-            faceted: window.engine,
-            quantum: window.quantumEngine,
-            holographic: window.holographicSystem,
-            polychora: window.polychoraSystem
-        };
-        
-        const engine = engines[activeSystem];
+        let handled = false;
+        if (manager?.setParameter) {
+            handled = manager.setParameter(param, processedValue) || handled;
+        }
+
+        const engine = getActiveEngine();
         if (!engine) {
-            console.warn(`⚠️ System ${activeSystem} not available - engines:`, Object.keys(engines).map(k => `${k}:${!!engines[k]}`).join(', '));
-            
-            // CRITICAL FIX: Track retry count to prevent infinite loops
-            if (!window.parameterRetryCount) window.parameterRetryCount = {};
-            const retryKey = `${param}_${value}_${activeSystem}`;
-            const currentRetries = window.parameterRetryCount[retryKey] || 0;
-            
-            // Only retry once, then give up to prevent infinite loops
-            if (currentRetries < 1) {
-                window.parameterRetryCount[retryKey] = currentRetries + 1;
-                console.log(`🔄 Retrying parameter ${param} = ${value} for ${activeSystem} (attempt ${currentRetries + 2})`);
-                setTimeout(() => {
-                    window.updateParameter(param, value);
-                }, 100);
-            } else {
-                console.warn(`❌ Parameter ${param} = ${value} failed for ${activeSystem} - system not available, giving up after 2 attempts`);
-                // Clean up retry tracking for this parameter
-                delete window.parameterRetryCount[retryKey];
-            }
+            console.warn(`[UIHandlers] No active engine available for ${systemKey}`);
             return;
         }
-        
-        // Route to appropriate engine method
-        if (activeSystem === 'faceted') {
-            engine.parameterManager.setParameter(param, parseFloat(value));
-            engine.updateVisualizers();
-        } else if (activeSystem === 'quantum') {
-            engine.updateParameter(param, parseFloat(value));
-        } else if (activeSystem === 'holographic') {
-            engine.updateParameter(param, parseFloat(value));
-        } else if (activeSystem === 'polychora') {
-            engine.updateParameters({ [param]: parseFloat(value) });
+
+        if (systemKey === 'faceted') {
+            if (!handled && engine.parameterManager && engine.parameterManager !== manager) {
+                engine.parameterManager.setParameter?.(param, processedValue);
+            }
+            engine.updateVisualizers?.();
+        } else if (!handled) {
+            if (typeof engine.updateParameter === 'function') {
+                engine.updateParameter(param, processedValue);
+            } else if (typeof engine.updateParameters === 'function') {
+                engine.updateParameters({ [param]: processedValue });
+            }
         }
-        
-        // GALLERY PERFORMANCE FIX: Reduce engine parameter logging spam in gallery context
+
         if (!window.isGalleryPreview) {
-            console.log(`📊 ${activeSystem.toUpperCase()}: ${param} = ${value}`);
+            console.log(`📊 ${systemKey.toUpperCase()}: ${param} = ${processedValue}`);
         }
-        
     } catch (error) {
-        console.error(`❌ Parameter update error in ${window.currentSystem || 'unknown'} for ${param}:`, error);
-        // Don't break the UI, just log the error
+        console.error(`❌ Parameter update error in ${systemKey} for ${param}:`, error);
     }
 };
 
@@ -290,8 +538,9 @@ function randomizeParameters() {
  */
 function randomizeGeometryAndHue() {
     // Randomize geometry selection
-    if (window.currentSystem !== 'holographic') {
-        const geometryNames = getGeometryNamesForSystem(window.currentSystem);
+    const systemKey = getSystemKeyFallback();
+    if (systemKey !== 'holographic') {
+        const geometryNames = getGeometryNamesForSystem(systemKey);
         if (geometryNames.length) {
             const randomGeometry = Math.floor(Math.random() * geometryNames.length);
             if (window.selectGeometry) {
@@ -409,7 +658,7 @@ window.openViewer = function() {
     console.log('👁️ Navigating to viewer...');
     // Save current parameters for viewer
     const currentState = {
-        system: window.currentSystem || 'faceted',
+        system: getSystemKeyFallback(),
         parameters: window.userParameterState || {},
         toggleStates: {
             audioEnabled: window.audioEnabled || false,
@@ -743,49 +992,41 @@ document.addEventListener('keydown', (e) => {
 
 // Listen for mouse events from gallery iframe for visualizer interactivity
 window.addEventListener('message', (event) => {
-    if (event.data && event.data.type) {
-        if (event.data.type === 'mouseMove') {
-            // Update all visualizers with mouse position
-            const updateMouseForSystem = (system) => {
-                if (system && system.visualizers) {
-                    system.visualizers.forEach(vis => {
-                        if (vis) {
-                            vis.mouseX = event.data.x;
-                            vis.mouseY = event.data.y;
-                            vis.mouseIntensity = event.data.intensity || 0.5;
-                        }
-                    });
-                }
-            };
-            
-            // Update the active system's visualizers
-            if (window.currentSystem === 'faceted' && window.engine) {
-                updateMouseForSystem(window.engine);
-            } else if (window.currentSystem === 'quantum' && window.quantumEngine) {
-                updateMouseForSystem(window.quantumEngine);
-            } else if (window.currentSystem === 'holographic' && window.holographicSystem) {
-                updateMouseForSystem(window.holographicSystem);
+    if (!event.data || !event.data.type) {
+        return;
+    }
+
+    if (event.data.type === 'mouseMove') {
+        const updateMouseForSystem = (system) => {
+            if (system && system.visualizers) {
+                system.visualizers.forEach(vis => {
+                    if (vis) {
+                        vis.mouseX = event.data.x;
+                        vis.mouseY = event.data.y;
+                        vis.mouseIntensity = event.data.intensity || 0.5;
+                    }
+                });
             }
-        } else if (event.data.type === 'mouseClick') {
-            // Trigger click effects on all visualizers
-            const triggerClickForSystem = (system) => {
-                if (system && system.visualizers) {
-                    system.visualizers.forEach(vis => {
-                        if (vis) {
-                            vis.clickIntensity = event.data.intensity || 1.0;
-                        }
-                    });
-                }
-            };
-            
-            // Trigger click on active system
-            if (window.currentSystem === 'faceted' && window.engine) {
-                triggerClickForSystem(window.engine);
-            } else if (window.currentSystem === 'quantum' && window.quantumEngine) {
-                triggerClickForSystem(window.quantumEngine);
-            } else if (window.currentSystem === 'holographic' && window.holographicSystem) {
-                triggerClickForSystem(window.holographicSystem);
+        };
+
+        const engine = getActiveEngine();
+        if (engine) {
+            updateMouseForSystem(engine);
+        }
+    } else if (event.data.type === 'mouseClick') {
+        const triggerClickForSystem = (system) => {
+            if (system && system.visualizers) {
+                system.visualizers.forEach(vis => {
+                    if (vis) {
+                        vis.clickIntensity = event.data.intensity || 1.0;
+                    }
+                });
             }
+        };
+
+        const engine = getActiveEngine();
+        if (engine) {
+            triggerClickForSystem(engine);
         }
     }
 });
@@ -798,7 +1039,7 @@ window.setupGeometry = function(system) {
     if (!grid) return;
 
     geometryGridElement = grid;
-    geometryGridSystem = system || window.currentSystem || 'faceted';
+    geometryGridSystem = system || getSystemKeyFallback();
 
     if (!geometrySubscriptionCleanup) {
         ensureGeometrySubscription();

--- a/src/audio/ADSREnvelope.js
+++ b/src/audio/ADSREnvelope.js
@@ -1,0 +1,121 @@
+export class ADSREnvelope {
+    constructor(attackMs = 100, decayMs = 200, sustainLevel = 0.7, releaseMs = 200) {
+        this.attack = Math.max(0, attackMs);
+        this.decay = Math.max(0, decayMs);
+        this.sustain = Math.min(Math.max(sustainLevel, 0), 1);
+        this.release = Math.max(0, releaseMs);
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = this.#now();
+        this.startValue = 0;
+    }
+
+    reset() {
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.startValue = 0;
+        this.phaseStartTime = this.#now();
+    }
+
+    trigger(level = 1, time = this.#now()) {
+        const clamped = Math.min(Math.max(level, 0), 1);
+        this.targetValue = clamped;
+        this.phaseStartTime = time;
+
+        if (this.attack <= 0) {
+            this.value = clamped;
+            this.startValue = this.value;
+
+            if (this.decay <= 0) {
+                this.phase = 'sustain';
+            } else {
+                this.phase = 'decay';
+            }
+        } else {
+            this.phase = 'attack';
+            this.startValue = this.value;
+        }
+    }
+
+    releasePhase(time = this.#now()) {
+        if (this.phase === 'idle' || this.release === 0) {
+            this.reset();
+            return;
+        }
+
+        if (this.phase === 'release') {
+            return;
+        }
+
+        this.phase = 'release';
+        this.phaseStartTime = time;
+        this.startValue = this.value;
+    }
+
+    update(time = this.#now()) {
+        const now = time;
+        switch (this.phase) {
+            case 'attack':
+                this.value = this.#interpolate(this.startValue, this.targetValue, this.attack, now);
+                if (now - this.phaseStartTime >= this.attack) {
+                    this.phase = this.decay === 0 ? 'sustain' : 'decay';
+                    this.phaseStartTime = now;
+                    this.startValue = this.value;
+                }
+                break;
+            case 'decay':
+                {
+                    const target = this.targetValue * this.sustain;
+                    this.value = this.#interpolate(this.startValue, target, this.decay, now);
+                    if (now - this.phaseStartTime >= this.decay) {
+                        this.phase = 'sustain';
+                        this.phaseStartTime = now;
+                        this.startValue = this.value;
+                    }
+                }
+                break;
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+            case 'release':
+                this.value = this.#interpolate(this.startValue, 0, this.release, now);
+                if (now - this.phaseStartTime >= this.release) {
+                    this.reset();
+                }
+                break;
+            default:
+                this.value = 0;
+                break;
+        }
+
+        return this.value;
+    }
+
+    isActive() {
+        return this.phase !== 'idle';
+    }
+
+    clone() {
+        return new ADSREnvelope(this.attack, this.decay, this.sustain, this.release);
+    }
+
+    #interpolate(start, end, duration, now) {
+        if (duration <= 0) {
+            return end;
+        }
+        const progress = Math.min((now - this.phaseStartTime) / duration, 1);
+        return start + (end - start) * progress;
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default ADSREnvelope;

--- a/src/audio/AudioAnalyzer.js
+++ b/src/audio/AudioAnalyzer.js
@@ -1,0 +1,261 @@
+const DEFAULT_BANDS = [
+    { key: 'subBass', low: 20, high: 60 },
+    { key: 'bass', low: 60, high: 250 },
+    { key: 'lowMid', low: 250, high: 500 },
+    { key: 'mid', low: 500, high: 2000 },
+    { key: 'highMid', low: 2000, high: 4000 },
+    { key: 'high', low: 4000, high: 8000 },
+    { key: 'air', low: 8000, high: 20000 }
+];
+
+const DB_FLOOR = -100;
+
+export class AudioAnalyzer {
+    constructor(analyserNode, options = {}) {
+        if (!analyserNode) {
+            throw new Error('AudioAnalyzer requires an AnalyserNode instance.');
+        }
+
+        this.analyser = analyserNode;
+        this.context = analyserNode.context || null;
+
+        this.fftSize = options.fftSize || 2048;
+        this.minDecibels = options.minDecibels ?? -100;
+        this.maxDecibels = options.maxDecibels ?? -20;
+        this.smoothingConstant = options.frequencySmoothing ?? 0.7;
+        this.energySmoothing = options.energySmoothing ?? 0.8;
+        this.onsetThreshold = options.onsetThreshold ?? 0.15;
+        this.minimumOnsetInterval = options.minimumOnsetInterval ?? 120;
+        this.bandDefinitions = options.bands || DEFAULT_BANDS;
+
+        this.analyser.fftSize = this.fftSize;
+        this.analyser.minDecibels = this.minDecibels;
+        this.analyser.maxDecibels = this.maxDecibels;
+        this.analyser.smoothingTimeConstant = this.smoothingConstant;
+
+        this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
+        this.timeDomainData = new Float32Array(this.analyser.fftSize);
+        this.previousSpectrum = new Float32Array(this.analyser.frequencyBinCount);
+
+        this.sampleRate = options.sampleRate || this.context?.sampleRate || 44100;
+
+        this.bandValues = this.bandDefinitions.reduce((acc, band) => {
+            acc[band.key] = 0;
+            return acc;
+        }, {});
+        this.smoothedBands = { ...this.bandValues };
+
+        this.spectralCentroid = 0;
+        this.spectralRolloff = 0;
+        this.spectralFlux = 0;
+        this.rms = 0;
+        this.estimatedBPM = options.initialBPM || 120;
+
+        this.onsetHistory = [];
+        this.lastOnsetTime = 0;
+    }
+
+    analyze() {
+        this.#captureFrequencyData();
+        this.#captureTimeDomainData();
+
+        this.#analyzeBands();
+        this.#calculateSpectralCentroid();
+        this.#calculateSpectralRolloff();
+        this.#calculateSpectralFlux();
+        this.#calculateRMS();
+
+        const now = this.#now();
+        const onset = this.#detectOnset(now);
+        if (onset) {
+            this.#recordOnset(now);
+            this.#estimateBPM();
+        }
+
+        return {
+            bands: { ...this.smoothedBands },
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset,
+            bpm: this.estimatedBPM
+        };
+    }
+
+    #captureFrequencyData() {
+        if (typeof this.analyser.getFloatFrequencyData === 'function') {
+            this.analyser.getFloatFrequencyData(this.frequencyData);
+        } else {
+            const byteData = new Uint8Array(this.analyser.frequencyBinCount);
+            this.analyser.getByteFrequencyData(byteData);
+            for (let i = 0; i < byteData.length; i += 1) {
+                this.frequencyData[i] = (byteData[i] / 255) * (this.maxDecibels - this.minDecibels) + this.minDecibels;
+            }
+        }
+    }
+
+    #captureTimeDomainData() {
+        if (typeof this.analyser.getFloatTimeDomainData === 'function') {
+            this.analyser.getFloatTimeDomainData(this.timeDomainData);
+        } else {
+            const byteData = new Uint8Array(this.analyser.fftSize);
+            this.analyser.getByteTimeDomainData(byteData);
+            for (let i = 0; i < byteData.length; i += 1) {
+                this.timeDomainData[i] = (byteData[i] - 128) / 128;
+            }
+        }
+    }
+
+    #analyzeBands() {
+        const binSize = this.sampleRate / this.analyser.fftSize;
+        const smoothing = this.energySmoothing;
+
+        this.bandDefinitions.forEach((band) => {
+            const startBin = Math.max(0, Math.floor(band.low / binSize));
+            const endBin = Math.min(this.frequencyData.length - 1, Math.ceil(band.high / binSize));
+
+            if (endBin <= startBin) {
+                this.smoothedBands[band.key] *= smoothing;
+                return;
+            }
+
+            let sum = 0;
+            let count = 0;
+            for (let i = startBin; i <= endBin; i += 1) {
+                const amplitude = this.#dbToNormalized(this.frequencyData[i]);
+                sum += amplitude;
+                count += 1;
+            }
+
+            const average = count > 0 ? sum / count : 0;
+            this.smoothedBands[band.key] = (smoothing * this.smoothedBands[band.key]) + ((1 - smoothing) * average);
+        });
+    }
+
+    #calculateSpectralCentroid() {
+        let weightedSum = 0;
+        let total = 0;
+        const binSize = this.sampleRate / this.analyser.fftSize;
+
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.#dbToNormalized(this.frequencyData[i]);
+            const frequency = i * binSize;
+            weightedSum += frequency * magnitude;
+            total += magnitude;
+        }
+
+        const centroid = total > 0 ? weightedSum / total : 0;
+        this.spectralCentroid = centroid / (this.sampleRate / 2);
+    }
+
+    #calculateSpectralRolloff() {
+        const threshold = 0.85;
+        const binSize = this.sampleRate / this.analyser.fftSize;
+        let totalEnergy = 0;
+        const magnitudes = new Array(this.frequencyData.length);
+
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.#dbToNormalized(this.frequencyData[i]);
+            magnitudes[i] = magnitude;
+            totalEnergy += magnitude;
+        }
+
+        const targetEnergy = totalEnergy * threshold;
+        let cumulative = 0;
+        let rolloffBin = 0;
+        for (let i = 0; i < magnitudes.length; i += 1) {
+            cumulative += magnitudes[i];
+            if (cumulative >= targetEnergy) {
+                rolloffBin = i;
+                break;
+            }
+        }
+
+        const rolloffFrequency = rolloffBin * binSize;
+        this.spectralRolloff = Math.min(rolloffFrequency / (this.sampleRate / 2), 1);
+    }
+
+    #calculateSpectralFlux() {
+        let flux = 0;
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const current = Math.max(0, this.#dbToNormalized(this.frequencyData[i]));
+            const previous = Math.max(0, this.previousSpectrum[i]);
+            const diff = current - previous;
+            if (diff > 0) {
+                flux += diff;
+            }
+            this.previousSpectrum[i] = current;
+        }
+
+        this.spectralFlux = flux / this.frequencyData.length;
+    }
+
+    #calculateRMS() {
+        let sumSquares = 0;
+        for (let i = 0; i < this.timeDomainData.length; i += 1) {
+            const sample = this.timeDomainData[i];
+            sumSquares += sample * sample;
+        }
+
+        const meanSquare = sumSquares / this.timeDomainData.length;
+        this.rms = Math.sqrt(meanSquare);
+    }
+
+    #detectOnset(now) {
+        const flux = this.spectralFlux;
+        const timeSinceLast = now - this.lastOnsetTime;
+
+        if (flux > this.onsetThreshold && timeSinceLast > this.minimumOnsetInterval) {
+            this.lastOnsetTime = now;
+            return true;
+        }
+
+        return false;
+    }
+
+    #recordOnset(timestamp) {
+        this.onsetHistory.push(timestamp);
+        const windowMs = 6000;
+        const cutoff = timestamp - windowMs;
+        this.onsetHistory = this.onsetHistory.filter((time) => time >= cutoff);
+    }
+
+    #estimateBPM() {
+        if (this.onsetHistory.length < 2) {
+            return;
+        }
+
+        const intervals = [];
+        for (let i = 1; i < this.onsetHistory.length; i += 1) {
+            intervals.push(this.onsetHistory[i] - this.onsetHistory[i - 1]);
+        }
+
+        if (intervals.length === 0) {
+            return;
+        }
+
+        const avgInterval = intervals.reduce((sum, value) => sum + value, 0) / intervals.length;
+        if (avgInterval === 0) {
+            return;
+        }
+
+        const bpm = 60000 / avgInterval;
+        const clampedBpm = Math.min(Math.max(bpm, 60), 200);
+        this.estimatedBPM = (this.estimatedBPM * 0.8) + (clampedBpm * 0.2);
+    }
+
+    #dbToNormalized(db) {
+        const normalized = (db - (this.minDecibels ?? DB_FLOOR)) / ((this.maxDecibels ?? -30) - (this.minDecibels ?? DB_FLOOR));
+        return Math.min(Math.max(normalized, 0), 1);
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default AudioAnalyzer;

--- a/src/audio/ParameterMapper.js
+++ b/src/audio/ParameterMapper.js
@@ -1,0 +1,141 @@
+import { ADSREnvelope } from './ADSREnvelope.js';
+
+const clamp01 = (value) => Math.min(Math.max(value, 0), 1);
+
+export class ParameterMapper {
+    constructor(mappings = {}) {
+        this.mappings = {};
+        this.envelopes = new Map();
+        this.lastValues = new Map();
+
+        Object.entries(mappings).forEach(([parameter, config]) => {
+            this.registerMapping(parameter, config);
+        });
+    }
+
+    registerMapping(parameter, config) {
+        if (!config) {
+            return;
+        }
+
+        const mapping = {
+            source: config.source,
+            curve: config.curve || 'linear',
+            range: config.range || [0, 1],
+            scale: config.scale || 1,
+            offset: config.offset || 0,
+            threshold: config.threshold ?? 0,
+            envelopeTrigger: config.envelopeTrigger ?? config.threshold ?? 0,
+            envelopeRelease: config.envelopeRelease ?? config.threshold ?? 0,
+            envelope: null
+        };
+
+        if (config.envelope instanceof ADSREnvelope) {
+            mapping.envelope = config.envelope.clone();
+            this.envelopes.set(parameter, mapping.envelope);
+        }
+
+        this.mappings[parameter] = mapping;
+        this.lastValues.set(parameter, 0);
+    }
+
+    removeMapping(parameter) {
+        delete this.mappings[parameter];
+        this.envelopes.delete(parameter);
+        this.lastValues.delete(parameter);
+    }
+
+    map(audioData, time = this.#now()) {
+        const result = {};
+        Object.entries(this.mappings).forEach(([parameter, config]) => {
+            const rawValue = clamp01(this.#resolveSource(config.source, audioData));
+            const curvedValue = clamp01(this.#applyCurve(rawValue, config));
+            let value = this.#applyRange(curvedValue, config);
+
+            const envelope = this.envelopes.get(parameter);
+            if (envelope) {
+                if (curvedValue >= config.envelopeTrigger) {
+                    envelope.trigger(curvedValue, time);
+                } else if (curvedValue <= config.envelopeRelease) {
+                    envelope.releasePhase(time);
+                }
+                const envelopeValue = envelope.update(time);
+                value = this.#applyRange(envelopeValue, config);
+            }
+
+            value = (value * config.scale) + config.offset;
+            result[parameter] = value;
+            this.lastValues.set(parameter, value);
+        });
+
+        return result;
+    }
+
+    #resolveSource(source, audioData) {
+        if (typeof source === 'function') {
+            try {
+                const resolved = source(audioData);
+                return typeof resolved === 'number' ? resolved : 0;
+            } catch (error) {
+                console.warn('ParameterMapper source function failed:', error);
+                return 0;
+            }
+        }
+
+        if (typeof source === 'string') {
+            const path = source.split('.');
+            let value = audioData;
+            for (let i = 0; i < path.length; i += 1) {
+                if (value == null) {
+                    return 0;
+                }
+                value = value[path[i]];
+            }
+
+            if (typeof value === 'number') {
+                return value;
+            }
+
+            if (value && typeof value.value === 'number') {
+                return value.value;
+            }
+        }
+
+        return 0;
+    }
+
+    #applyCurve(value, config) {
+        const curve = config.curve;
+        switch (curve) {
+            case 'exponential':
+                return Math.pow(value, config.exponent ?? 2);
+            case 'logarithmic':
+                return Math.log10(1 + value * 9) / Math.log10(10);
+            case 's-curve': {
+                const intensity = config.intensity ?? 1;
+                const x = (value - 0.5) * (1 + intensity * 4);
+                return 1 / (1 + Math.exp(-x * 5));
+            }
+            case 'threshold':
+                return value >= (config.threshold ?? 0.5) ? 1 : 0;
+            case 'power':
+                return Math.pow(value, config.power ?? 1.5);
+            default:
+                return value;
+        }
+    }
+
+    #applyRange(value, config) {
+        const [min, max] = config.range;
+        return min + (clamp01(value) * (max - min));
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default ParameterMapper;

--- a/src/color/ColorSystem.js
+++ b/src/color/ColorSystem.js
@@ -1,0 +1,535 @@
+/**
+ * VIB34D Advanced Color System
+ * Provides palette, gradient, and audio-reactive color generation utilities.
+ */
+
+const clamp01 = value => Math.min(Math.max(value, 0), 1);
+const mod360 = value => {
+    const wrapped = value % 360;
+    return wrapped < 0 ? wrapped + 360 : wrapped;
+};
+
+export const COLOR_MODES = Object.freeze([
+    'single',
+    'dual',
+    'triad',
+    'complementary',
+    'analogous',
+    'palette',
+    'gradient',
+    'reactive'
+]);
+
+export const GRADIENT_TYPES = Object.freeze([
+    'horizontal',
+    'vertical',
+    'radial',
+    'spiral',
+    'wave'
+]);
+
+export const DEFAULT_COLOR_CONFIG = {
+    colorMode: 'single',
+    baseHue: 210,
+    baseSaturation: 0.75,
+    baseIntensity: 0.65,
+    colorPalette: 'synthwave',
+    gradientType: 'horizontal',
+    gradientSpeed: 0.25,
+    colorReactivity: 0.65,
+    dualOffset: 180,
+    triadSpacing: 120,
+    analogousSpread: 30
+};
+
+export const COLOR_PALETTES = Object.freeze({
+    vaporwave: ['#ff71ce', '#01cdfe', '#05ffa1', '#b967ff'],
+    cyberpunk: ['#ff006e', '#fb5607', '#ffbe0b', '#8338ec'],
+    synthwave: ['#f72585', '#7209b7', '#3a0ca3', '#4361ee'],
+    holographic: ['#ff00ff', '#00ffff', '#ff00aa', '#00aaff'],
+    neon: ['#fe00fe', '#00fefe', '#fefe00', '#00fe00'],
+    fire: ['#ff0000', '#ff4400', '#ff8800', '#ffcc00'],
+    ocean: ['#001eff', '#0088ff', '#00ccff', '#00ffee'],
+    forest: ['#004d00', '#008800', '#00cc00', '#88ff00']
+});
+
+function hexToRgb(hex) {
+    const clean = hex.replace('#', '');
+    const value = parseInt(clean, 16);
+    return {
+        r: ((value >> 16) & 255) / 255,
+        g: ((value >> 8) & 255) / 255,
+        b: (value & 255) / 255
+    };
+}
+
+function rgbToHex({ r, g, b }) {
+    const toHex = component => {
+        const clamped = Math.round(clamp01(component) * 255);
+        return clamped.toString(16).padStart(2, '0');
+    };
+
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hsvToRgb(h, s, v) {
+    const hue = (mod360(h) / 60);
+    const c = v * s;
+    const x = c * (1 - Math.abs((hue % 2) - 1));
+    const m = v - c;
+    const sector = Math.floor(hue);
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    switch (sector) {
+        case 0:
+            r = c; g = x; b = 0;
+            break;
+        case 1:
+            r = x; g = c; b = 0;
+            break;
+        case 2:
+            r = 0; g = c; b = x;
+            break;
+        case 3:
+            r = 0; g = x; b = c;
+            break;
+        case 4:
+            r = x; g = 0; b = c;
+            break;
+        default:
+            r = c; g = 0; b = x;
+    }
+
+    return {
+        r: r + m,
+        g: g + m,
+        b: b + m
+    };
+}
+
+function rgbToHsl({ r, g, b }) {
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    let s = 0;
+    const l = (max + min) / 2;
+
+    if (delta !== 0) {
+        if (max === r) {
+            h = ((g - b) / delta) % 6;
+        } else if (max === g) {
+            h = (b - r) / delta + 2;
+        } else {
+            h = (r - g) / delta + 4;
+        }
+
+        s = delta / (1 - Math.abs(2 * l - 1));
+    }
+
+    h = (h * 60 + 360) % 360;
+
+    return { h, s, l };
+}
+
+function makeColorObject(h, s, v) {
+    const rgb = hsvToRgb(h, s, v);
+    const hsl = rgbToHsl(rgb);
+
+    return {
+        h: mod360(h),
+        s: clamp01(s),
+        v: clamp01(v),
+        rgb,
+        hex: rgbToHex(rgb),
+        hsl,
+        css: `hsl(${Math.round(hsl.h)}, ${Math.round(hsl.s * 100)}%, ${Math.round(hsl.l * 100)}%)`
+    };
+}
+
+function clonePalette(palette) {
+    return palette.map(color => ({ ...color, rgb: { ...color.rgb }, hsl: { ...color.hsl } }));
+}
+
+export class ColorSystem {
+    constructor(config = {}) {
+        this.config = { ...DEFAULT_COLOR_CONFIG, ...config };
+        this.gradientPhase = 0;
+        this.lastUpdateTime = null;
+
+        this.#paletteCache = new Map();
+
+        // Prime initial state so consumers have data immediately
+        const initialState = this.#computeColorState({});
+        this.lastState = { ...initialState, gradient: this.#buildGradient(initialState.palette) };
+    }
+
+    updateConfig(partial = {}) {
+        if (!partial || typeof partial !== 'object') {
+            return this.getState();
+        }
+
+        const nextConfig = { ...this.config, ...partial };
+
+        if (typeof partial.colorMode === 'string') {
+            nextConfig.colorMode = COLOR_MODES.includes(partial.colorMode)
+                ? partial.colorMode
+                : this.config.colorMode;
+        }
+
+        if (typeof partial.colorPalette === 'string') {
+            nextConfig.colorPalette = COLOR_PALETTES[partial.colorPalette]
+                ? partial.colorPalette
+                : this.config.colorPalette;
+        }
+
+        if (typeof partial.gradientType === 'string') {
+            nextConfig.gradientType = GRADIENT_TYPES.includes(partial.gradientType)
+                ? partial.gradientType
+                : this.config.gradientType;
+        }
+
+        if (partial.gradientSpeed !== undefined) {
+            const parsed = Number(partial.gradientSpeed);
+            nextConfig.gradientSpeed = Number.isFinite(parsed)
+                ? Math.min(Math.max(parsed, 0), 5)
+                : this.config.gradientSpeed;
+        }
+
+        if (partial.colorReactivity !== undefined) {
+            const parsed = Number(partial.colorReactivity);
+            nextConfig.colorReactivity = Number.isFinite(parsed)
+                ? clamp01(parsed)
+                : this.config.colorReactivity;
+        }
+
+        if (partial.baseHue !== undefined) {
+            const parsed = Number(partial.baseHue);
+            nextConfig.baseHue = Number.isFinite(parsed)
+                ? mod360(parsed)
+                : this.config.baseHue;
+        }
+
+        if (partial.baseSaturation !== undefined) {
+            const parsed = Number(partial.baseSaturation);
+            nextConfig.baseSaturation = Number.isFinite(parsed)
+                ? clamp01(parsed)
+                : this.config.baseSaturation;
+        }
+
+        if (partial.baseIntensity !== undefined) {
+            const parsed = Number(partial.baseIntensity);
+            nextConfig.baseIntensity = Number.isFinite(parsed)
+                ? clamp01(parsed)
+                : this.config.baseIntensity;
+        }
+
+        if (partial.dualOffset !== undefined) {
+            const parsed = Number(partial.dualOffset);
+            nextConfig.dualOffset = Number.isFinite(parsed) ? parsed : this.config.dualOffset;
+        }
+
+        if (partial.triadSpacing !== undefined) {
+            const parsed = Number(partial.triadSpacing);
+            nextConfig.triadSpacing = Number.isFinite(parsed) ? parsed : this.config.triadSpacing;
+        }
+
+        if (partial.analogousSpread !== undefined) {
+            const parsed = Number(partial.analogousSpread);
+            nextConfig.analogousSpread = Number.isFinite(parsed) ? parsed : this.config.analogousSpread;
+        }
+
+        this.config = nextConfig;
+
+        return this.update(Date.now(), {});
+    }
+
+    setMode(mode) {
+        if (typeof mode === 'string') {
+            this.updateConfig({ colorMode: mode });
+        }
+    }
+
+    setPalette(name) {
+        if (typeof name === 'string' && COLOR_PALETTES[name]) {
+            this.updateConfig({ colorPalette: name });
+        }
+    }
+
+    getAvailablePalettes() {
+        return Object.keys(COLOR_PALETTES);
+    }
+
+    getAvailableModes() {
+        return [...COLOR_MODES];
+    }
+
+    getAvailableGradients() {
+        return [...GRADIENT_TYPES];
+    }
+
+    getConfig() {
+        return { ...this.config };
+    }
+
+    /**
+     * Update the color system using the latest audio frame.
+     * @param {number} now - timestamp in milliseconds
+     * @param {object} audioData - analyzer output
+     * @param {object} reactive - mapped audio data
+     */
+    update(now = Date.now(), audioData = {}, reactive = {}) {
+        if (typeof now !== 'number') {
+            now = Date.now();
+        }
+
+        if (this.lastUpdateTime == null) {
+            this.lastUpdateTime = now;
+        }
+
+        const delta = Math.max(0, (now - this.lastUpdateTime) / 1000);
+        this.lastUpdateTime = now;
+
+        const modulation = (audioData?.spectralFlux ?? reactive.motion ?? 0) * this.config.colorReactivity;
+        const speed = this.config.gradientSpeed * (1 + modulation * 1.5);
+        this.gradientPhase = (this.gradientPhase + delta * speed) % 1;
+
+        const paletteInfo = this.#computeColorState(audioData, reactive);
+        const gradient = this.#buildGradient(paletteInfo.palette);
+
+        this.lastState = {
+            ...paletteInfo,
+            gradient: {
+                ...gradient,
+                phase: this.gradientPhase
+            }
+        };
+
+        return this.lastState;
+    }
+
+    reset() {
+        this.lastUpdateTime = null;
+        this.gradientPhase = 0;
+        return this.update(Date.now(), {});
+    }
+
+    getState() {
+        return this.lastState;
+    }
+
+    /**
+     * Build a normalized palette given the current configuration.
+     */
+    #computeColorState(audioData = {}, reactive = {}) {
+        const mode = this.config.colorMode;
+        const baseHue = this.#computeBaseHue(audioData, reactive);
+        const baseSaturation = this.#computeBaseSaturation(audioData, reactive);
+        const baseIntensity = this.#computeBaseIntensity(audioData, reactive);
+
+        const palette = this.#generatePalette(mode, baseHue, baseSaturation, baseIntensity, audioData, reactive);
+        const primary = palette[0];
+        const accent = palette[Math.min(1, palette.length - 1)];
+
+        const uniforms = {
+            palette: palette.slice(0, 4).map(color => [color.rgb.r, color.rgb.g, color.rgb.b]),
+            size: Math.min(palette.length, 4)
+        };
+
+        return {
+            mode,
+            baseHue,
+            palette,
+            primary,
+            accent,
+            uniforms,
+            saturation: baseSaturation,
+            intensity: baseIntensity,
+            paletteName: this.config.colorPalette
+        };
+    }
+
+    #computeBaseHue(audioData = {}, reactive = {}) {
+        const centroid = audioData?.spectralCentroid ?? 0;
+        const motion = reactive.motion ?? audioData?.spectralFlux ?? 0;
+        const onsetBoost = audioData?.onset ? 25 : 0;
+
+        const reactiveShift = (centroid * 220 + motion * 110 + onsetBoost) * this.config.colorReactivity;
+        return mod360(this.config.baseHue + reactiveShift);
+    }
+
+    #computeBaseSaturation(audioData = {}, reactive = {}) {
+        const sparkle = reactive.sparkle ?? audioData?.bands?.air ?? 0;
+        const flux = audioData?.spectralFlux ?? 0;
+        const adjustment = (sparkle * 0.35 + flux * 0.4) * this.config.colorReactivity;
+        return clamp01(this.config.baseSaturation + adjustment);
+    }
+
+    #computeBaseIntensity(audioData = {}, reactive = {}) {
+        const rms = audioData?.rms ?? 0;
+        const energy = reactive.energy ?? rms;
+        const adjustment = (energy * 0.55) * this.config.colorReactivity;
+        return clamp01(this.config.baseIntensity + adjustment);
+    }
+
+    #generatePalette(mode, baseHue, saturation, intensity, audioData = {}, reactive = {}) {
+        switch (mode) {
+            case 'dual':
+                return this.#buildHueSet([baseHue, baseHue + this.config.dualOffset], saturation, intensity, audioData, reactive);
+            case 'triad':
+                return this.#buildHueSet([
+                    baseHue,
+                    baseHue + this.config.triadSpacing,
+                    baseHue + this.config.triadSpacing * 2
+                ], saturation, intensity, audioData, reactive);
+            case 'complementary':
+                return this.#buildHueSet([baseHue, baseHue + 180], saturation, intensity, audioData, reactive);
+            case 'analogous':
+                return this.#buildHueSet([
+                    baseHue - this.config.analogousSpread,
+                    baseHue,
+                    baseHue + this.config.analogousSpread
+                ], saturation, intensity, audioData, reactive);
+            case 'palette':
+                return this.#buildPaletteMode(saturation, intensity, audioData, reactive);
+            case 'gradient':
+                return this.#buildGradientMode(baseHue, saturation, intensity, audioData, reactive);
+            case 'reactive':
+                return this.#buildReactivePalette(saturation, intensity, audioData, reactive);
+            case 'single':
+            default:
+                return this.#buildHueSet([baseHue], saturation, intensity, audioData, reactive);
+        }
+    }
+
+    #buildHueSet(hues, saturation, intensity, audioData, reactive) {
+        return hues.map(hue => this.#applyAudioModulation(hue, saturation, intensity, audioData, reactive));
+    }
+
+    #applyAudioModulation(h, s, v, audioData = {}, reactive = {}) {
+        const centroid = audioData?.spectralCentroid ?? 0;
+        const sparkle = reactive.sparkle ?? audioData?.bands?.air ?? 0;
+        const energy = reactive.energy ?? audioData?.rms ?? 0;
+
+        const hueShift = centroid * 45 * this.config.colorReactivity;
+        const saturationBoost = sparkle * 0.45 * this.config.colorReactivity;
+        const intensityBoost = energy * 0.55 * this.config.colorReactivity;
+
+        const hue = mod360(h + hueShift);
+        const saturation = clamp01(s + saturationBoost);
+        const intensityValue = clamp01(v + intensityBoost);
+
+        return makeColorObject(hue, saturation, intensityValue);
+    }
+
+    #buildPaletteMode(saturation, intensity, audioData, reactive) {
+        const paletteName = this.config.colorPalette;
+        const key = `${paletteName}|${Math.round(saturation * 100)}|${Math.round(intensity * 100)}`;
+
+        if (this.#paletteCache.has(key)) {
+            const cached = this.#paletteCache.get(key);
+            return clonePalette(cached);
+        }
+
+        const source = COLOR_PALETTES[paletteName] || COLOR_PALETTES.synthwave;
+        const palette = source.map(hex => {
+            const { r, g, b } = hexToRgb(hex);
+            const max = Math.max(r, g, b);
+            const min = Math.min(r, g, b);
+            const delta = max - min;
+
+            let hue = 0;
+            if (delta > 0) {
+                if (max === r) {
+                    hue = ((g - b) / delta) % 6;
+                } else if (max === g) {
+                    hue = (b - r) / delta + 2;
+                } else {
+                    hue = (r - g) / delta + 4;
+                }
+            }
+
+            hue = (hue * 60 + 360) % 360;
+            return makeColorObject(hue, saturation, intensity);
+        });
+
+        this.#paletteCache.set(key, palette);
+        return clonePalette(palette).map(color => this.#applyAudioModulation(color.h, color.s, color.v, audioData, reactive));
+    }
+
+    #buildGradientMode(baseHue, saturation, intensity, audioData, reactive) {
+        const hues = [baseHue, baseHue + 60, baseHue + 180];
+        return this.#buildHueSet(hues, saturation, intensity, audioData, reactive);
+    }
+
+    #buildReactivePalette(saturation, intensity, audioData = {}, reactive = {}) {
+        const bass = reactive.bass ?? audioData?.bands?.bass ?? 0;
+        const mid = reactive.mid ?? audioData?.bands?.mid ?? 0;
+        const high = reactive.high ?? audioData?.bands?.high ?? 0;
+
+        const bassHue = 20 + bass * 60;
+        const midHue = 160 + mid * 80;
+        const highHue = 260 + high * 80;
+
+        return this.#buildHueSet([bassHue, midHue, highHue], saturation, intensity, audioData, reactive);
+    }
+
+    #buildGradient(palette) {
+        if (!palette || palette.length === 0) {
+            return {
+                type: this.config.gradientType,
+                css: 'linear-gradient(90deg, #ffffff, #000000)',
+                stops: []
+            };
+        }
+
+        const stops = palette.map((color, index) => ({
+            offset: palette.length === 1 ? 0 : index / (palette.length - 1),
+            color
+        }));
+
+        const stopString = stops
+            .map(({ offset, color }) => `${color.css} ${(offset * 100).toFixed(1)}%`)
+            .join(', ');
+
+        const angle = Math.round(this.gradientPhase * 360);
+
+        switch (this.config.gradientType) {
+            case 'vertical':
+                return {
+                    type: 'vertical',
+                    css: `linear-gradient(180deg, ${stopString})`,
+                    stops
+                };
+            case 'radial':
+                return {
+                    type: 'radial',
+                    css: `radial-gradient(circle, ${stopString})`,
+                    stops
+                };
+            case 'spiral':
+                return {
+                    type: 'spiral',
+                    css: `conic-gradient(from ${angle}deg, ${stopString})`,
+                    stops
+                };
+            case 'wave':
+                return {
+                    type: 'wave',
+                    css: `linear-gradient(${angle}deg, ${stopString})`,
+                    stops
+                };
+            case 'horizontal':
+            default:
+                return {
+                    type: 'horizontal',
+                    css: `linear-gradient(90deg, ${stopString})`,
+                    stops
+                };
+        }
+    }
+}

--- a/src/core/Visualizer.js
+++ b/src/core/Visualizer.js
@@ -5,6 +5,28 @@
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
 
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const lerp = (current, target, factor) => current + (target - current) * factor;
+
+const COLOR_MODE_MAP = Object.freeze({
+    single: 0,
+    dual: 1,
+    triad: 2,
+    complementary: 3,
+    analogous: 4,
+    palette: 5,
+    gradient: 6,
+    reactive: 7
+});
+
+const GRADIENT_TYPE_MAP = Object.freeze({
+    horizontal: 0,
+    vertical: 1,
+    radial: 2,
+    spiral: 3,
+    wave: 4
+});
+
 export class IntegratedHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
         this.canvas = document.getElementById(canvasId);
@@ -55,7 +77,30 @@ export class IntegratedHolographicVisualizer {
             rot4dYW: 0.0,
             rot4dZW: 0.0
         };
-        
+
+        this.audioResponse = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hueShift: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+        this.onsetPulse = 0;
+
+        this.colorUniformBuffer = new Float32Array(12);
+        this.colorUniformState = {
+            mode: COLOR_MODE_MAP.single,
+            paletteSize: 0,
+            gradientType: GRADIENT_TYPE_MAP.horizontal,
+            gradientPhase: 0
+        };
+
         // Initialization now happens in ensureCanvasSizedThenInitWebGL after sizing
         // this.init(); // MOVED
     }
@@ -183,6 +228,74 @@ uniform float u_rot4dZW;
 uniform float u_mouseIntensity;
 uniform float u_clickIntensity;
 uniform float u_roleIntensity;
+uniform int u_colorMode;
+uniform int u_paletteSize;
+uniform vec3 u_palette[4];
+uniform int u_gradientType;
+uniform float u_gradientPhase;
+
+const int COLOR_MODE_SINGLE = 0;
+const int COLOR_MODE_DUAL = 1;
+const int COLOR_MODE_TRIAD = 2;
+const int COLOR_MODE_COMPLEMENTARY = 3;
+const int COLOR_MODE_ANALOGOUS = 4;
+const int COLOR_MODE_PALETTE = 5;
+const int COLOR_MODE_GRADIENT = 6;
+const int COLOR_MODE_REACTIVE = 7;
+
+const int GRADIENT_HORIZONTAL = 0;
+const int GRADIENT_VERTICAL = 1;
+const int GRADIENT_RADIAL = 2;
+const int GRADIENT_SPIRAL = 3;
+const int GRADIENT_WAVE = 4;
+
+float clamp01(float value) {
+    return clamp(value, 0.0, 1.0);
+}
+
+vec3 samplePaletteColor(float position) {
+    if (u_paletteSize <= 0) {
+        return vec3(1.0);
+    }
+
+    if (u_paletteSize == 1) {
+        return u_palette[0];
+    }
+
+    float clamped = clamp(position, 0.0, 0.9999);
+    float scaled = clamped * float(u_paletteSize - 1);
+    int index = int(floor(scaled));
+    int nextIndex = min(index + 1, u_paletteSize - 1);
+    float mixAmount = fract(scaled);
+    vec3 a = u_palette[index];
+    vec3 b = u_palette[nextIndex];
+    return mix(a, b, mixAmount);
+}
+
+float computeGradientPosition(vec2 uv, float geometryValue) {
+    vec2 normalized = uv * 0.5 + 0.5;
+    float base = fract(u_gradientPhase + geometryValue * 0.25);
+
+    if (u_colorMode == COLOR_MODE_GRADIENT) {
+        if (u_gradientType == GRADIENT_HORIZONTAL) {
+            base = clamp01(normalized.x);
+        } else if (u_gradientType == GRADIENT_VERTICAL) {
+            base = clamp01(normalized.y);
+        } else if (u_gradientType == GRADIENT_RADIAL) {
+            float dist = length(normalized - 0.5);
+            base = clamp(dist * 1.4142, 0.0, 1.0);
+        } else if (u_gradientType == GRADIENT_SPIRAL) {
+            float angle = atan(normalized.y - 0.5, normalized.x - 0.5) / (6.28318);
+            base = fract(angle + u_gradientPhase);
+        } else if (u_gradientType == GRADIENT_WAVE) {
+            base = fract(normalized.x + sin((normalized.y + u_gradientPhase) * 6.28318) * 0.2 + u_gradientPhase);
+        }
+    } else {
+        base = fract(u_gradientPhase + geometryValue * 0.3 + normalized.x * 0.25);
+    }
+
+    return clamp01(base);
+}
 
 // 4D rotation matrices
 mat4 rotateXW(float theta) {
@@ -308,18 +421,25 @@ void main() {
     float finalIntensity = geometryIntensity * u_intensity;
     
     float hue = u_hue / 360.0 + value * 0.1;
-    
+
     // Create color with saturation control
     vec3 baseColor = vec3(
         sin(hue * 6.28318 + 0.0) * 0.5 + 0.5,
         sin(hue * 6.28318 + 2.0943) * 0.5 + 0.5,
         sin(hue * 6.28318 + 4.1887) * 0.5 + 0.5
     );
-    
+
+    float palettePosition = computeGradientPosition(uv, value);
+    vec3 paletteColor = samplePaletteColor(palettePosition);
+    if (u_paletteSize > 0) {
+        float blendStrength = (u_colorMode == COLOR_MODE_SINGLE) ? 0.7 : 1.0;
+        baseColor = mix(baseColor, paletteColor, blendStrength);
+    }
+
     // Apply saturation (mix with grayscale)
     float gray = (baseColor.r + baseColor.g + baseColor.b) / 3.0;
     vec3 color = mix(vec3(gray), baseColor, u_saturation) * finalIntensity;
-    
+
     gl_FragColor = vec4(color, finalIntensity * u_roleIntensity);
 }`;
         
@@ -342,7 +462,12 @@ void main() {
             rot4dZW: this.gl.getUniformLocation(this.program, 'u_rot4dZW'),
             mouseIntensity: this.gl.getUniformLocation(this.program, 'u_mouseIntensity'),
             clickIntensity: this.gl.getUniformLocation(this.program, 'u_clickIntensity'),
-            roleIntensity: this.gl.getUniformLocation(this.program, 'u_roleIntensity')
+            roleIntensity: this.gl.getUniformLocation(this.program, 'u_roleIntensity'),
+            colorMode: this.gl.getUniformLocation(this.program, 'u_colorMode'),
+            palette: this.gl.getUniformLocation(this.program, 'u_palette[0]'),
+            paletteSize: this.gl.getUniformLocation(this.program, 'u_paletteSize'),
+            gradientType: this.gl.getUniformLocation(this.program, 'u_gradientType'),
+            gradientPhase: this.gl.getUniformLocation(this.program, 'u_gradientPhase')
         };
     }
     
@@ -537,12 +662,156 @@ void main() {
             this.mouseIntensity = 0.0;
             return;
         }
-        
+
         this.mouseX = x;
         this.mouseY = y;
         this.mouseIntensity = intensity;
     }
-    
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined' || !window.audioEnabled) {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels() || null;
+        }
+
+        return window.audioReactive || null;
+    }
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    prepareColorUniforms(colorState) {
+        const buffer = this.colorUniformBuffer;
+        buffer.fill(0);
+
+        let paletteSize = 0;
+        if (colorState?.uniforms?.palette && Array.isArray(colorState.uniforms.palette)) {
+            const palette = colorState.uniforms.palette;
+            paletteSize = Math.min(palette.length, 4);
+            for (let i = 0; i < paletteSize; i += 1) {
+                const color = palette[i] || [0, 0, 0];
+                const offset = i * 3;
+                buffer[offset] = color[0] ?? 0;
+                buffer[offset + 1] = color[1] ?? 0;
+                buffer[offset + 2] = color[2] ?? 0;
+            }
+        }
+
+        const gradientTypeKey = colorState?.gradient?.type || 'horizontal';
+        const gradientType = GRADIENT_TYPE_MAP[gradientTypeKey] ?? GRADIENT_TYPE_MAP.horizontal;
+        const gradientPhase = typeof colorState?.gradient?.phase === 'number'
+            ? colorState.gradient.phase
+            : 0;
+        const modeKey = colorState?.mode || 'single';
+        const mode = COLOR_MODE_MAP[modeKey] ?? COLOR_MODE_MAP.single;
+
+        this.colorUniformState.mode = mode;
+        this.colorUniformState.paletteSize = paletteSize;
+        this.colorUniformState.gradientType = gradientType;
+        this.colorUniformState.gradientPhase = gradientPhase;
+
+        return this.colorUniformState;
+    }
+
+    applyColorUniforms(uniformState) {
+        if (!this.gl || !this.uniforms) {
+            return;
+        }
+
+        if (this.uniforms.colorMode) {
+            this.gl.uniform1i(this.uniforms.colorMode, uniformState.mode);
+        }
+        if (this.uniforms.palette) {
+            this.gl.uniform3fv(this.uniforms.palette, this.colorUniformBuffer);
+        }
+        if (this.uniforms.paletteSize) {
+            this.gl.uniform1i(this.uniforms.paletteSize, uniformState.paletteSize);
+        }
+        if (this.uniforms.gradientType) {
+            this.gl.uniform1i(this.uniforms.gradientType, uniformState.gradientType);
+        }
+        if (this.uniforms.gradientPhase) {
+            this.gl.uniform1f(this.uniforms.gradientPhase, uniformState.gradientPhase);
+        }
+    }
+
+    updateAudioResponse(audioState) {
+        const smoothing = 0.18;
+        const target = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hueShift: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.onsetPulse = (this.onsetPulse || 0) * 0.82;
+
+        if (audioState) {
+            const bass = clamp(audioState.bass ?? 0, 0, 1);
+            const mid = clamp(audioState.mid ?? 0, 0, 1);
+            const high = clamp(audioState.high ?? 0, 0, 1);
+            const sparkle = clamp(audioState.sparkle ?? audioState.bands?.air ?? 0, 0, 1);
+            const energy = clamp(audioState.energy ?? audioState.rms ?? 0, 0, 1);
+            const motion = clamp(audioState.motion ?? audioState.spectralFlux ?? 0, 0, 1);
+            const hueShiftNorm = clamp(audioState.hueShift ?? audioState.spectralCentroid ?? 0, 0, 1);
+            const intensityBoost = clamp(audioState.intensity ?? audioState.rms ?? 0, 0, 1);
+
+            if (audioState.onset) {
+                this.onsetPulse = 1;
+            }
+
+            target.gridDensity = (bass * 32) + (motion * 14);
+            target.morph = (motion * 0.9) + (energy * 0.4);
+            target.chaos = (motion * 0.6) + (energy * 0.45);
+            target.speed = (energy * 0.45) + (motion * 0.3);
+            target.hueShift = (hueShiftNorm * 240) + (sparkle * 60);
+            target.intensity = (intensityBoost * 0.6) + (sparkle * 0.4);
+            target.saturation = sparkle * 0.35;
+            target.dimension = (energy * 0.35) + (bass * 0.25);
+            target.rot4dXW = bass * 0.4;
+            target.rot4dYW = mid * 0.3;
+            target.rot4dZW = high * 0.25;
+        }
+
+        target.speed += this.onsetPulse * 0.45;
+
+        this.audioResponse.gridDensity = lerp(this.audioResponse.gridDensity, target.gridDensity, smoothing);
+        this.audioResponse.morph = lerp(this.audioResponse.morph, target.morph, smoothing);
+        this.audioResponse.chaos = lerp(this.audioResponse.chaos, target.chaos, smoothing);
+        this.audioResponse.speed = lerp(this.audioResponse.speed, target.speed, smoothing);
+        this.audioResponse.hueShift = lerp(this.audioResponse.hueShift, target.hueShift, smoothing);
+        this.audioResponse.intensity = lerp(this.audioResponse.intensity, target.intensity, smoothing);
+        this.audioResponse.saturation = lerp(this.audioResponse.saturation, target.saturation, smoothing);
+        this.audioResponse.dimension = lerp(this.audioResponse.dimension, target.dimension, smoothing);
+        this.audioResponse.rot4dXW = lerp(this.audioResponse.rot4dXW, target.rot4dXW, smoothing);
+        this.audioResponse.rot4dYW = lerp(this.audioResponse.rot4dYW, target.rot4dYW, smoothing);
+        this.audioResponse.rot4dZW = lerp(this.audioResponse.rot4dZW, target.rot4dZW, smoothing);
+
+        return this.audioResponse;
+    }
+
     /**
      * Render frame
      */
@@ -591,33 +860,61 @@ void main() {
         this.gl.uniform1f(this.uniforms.time, time);
         this.gl.uniform2f(this.uniforms.mouse, this.mouseX, this.mouseY);
         this.gl.uniform1f(this.uniforms.geometry, this.params.geometry);
-        // 🎵 DIRECT AUDIO REACTIVITY - Simple and works
-        let gridDensity = this.params.gridDensity;
-        let hue = this.params.hue;
-        let intensity = this.params.intensity;
-        
-        if (window.audioEnabled && window.audioReactive) {
-            // Faceted audio mapping: Bass affects grid density, Mid affects hue, High affects intensity
-            gridDensity += window.audioReactive.bass * 30;  // Bass makes patterns denser
-            hue += window.audioReactive.mid * 60;           // Mid frequencies shift colors
-            intensity += window.audioReactive.high * 0.4;   // High frequencies brighten
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+        const colorUniforms = this.prepareColorUniforms(colorState);
+
+        let gridDensity = this.params.gridDensity + audioResponse.gridDensity;
+        let morphFactor = this.params.morphFactor + audioResponse.morph;
+        let chaos = this.params.chaos + audioResponse.chaos;
+        let speed = this.params.speed + audioResponse.speed;
+        let hue = (this.params.hue + audioResponse.hueShift) % 360;
+        let intensity = this.params.intensity + audioResponse.intensity;
+        let saturation = this.params.saturation + audioResponse.saturation;
+        let dimension = this.params.dimension + audioResponse.dimension;
+        let rot4dXW = this.params.rot4dXW + audioResponse.rot4dXW;
+        let rot4dYW = this.params.rot4dYW + audioResponse.rot4dYW;
+        let rot4dZW = this.params.rot4dZW + audioResponse.rot4dZW;
+
+        if (colorState?.primary) {
+            hue = colorState.primary.h;
+            saturation = clamp(Math.max(saturation, colorState.primary.s), 0, 1);
+            intensity = clamp(intensity + (colorState.primary.v - 0.5) * 0.8, 0, 2);
         }
-        
-        this.gl.uniform1f(this.uniforms.gridDensity, Math.min(100, gridDensity));
-        this.gl.uniform1f(this.uniforms.morphFactor, this.params.morphFactor);
-        this.gl.uniform1f(this.uniforms.chaos, this.params.chaos);
-        this.gl.uniform1f(this.uniforms.speed, this.params.speed);
-        this.gl.uniform1f(this.uniforms.hue, hue % 360);
+
+        if (colorState?.accent && colorState.accent !== colorState.primary) {
+            saturation = clamp(Math.max(saturation, colorState.accent.s * 0.9), 0, 1);
+        }
+
+        gridDensity = clamp(gridDensity, 0, 120);
+        morphFactor = clamp(morphFactor, 0, 2.5);
+        chaos = clamp(chaos, 0, 1.4);
+        speed = clamp(speed, 0, 3.5);
+        intensity = clamp(intensity, 0, 1.4);
+        saturation = clamp(saturation, 0, 1);
+        dimension = clamp(dimension, 0, 6);
+        rot4dXW = clamp(rot4dXW, -4, 4);
+        rot4dYW = clamp(rot4dYW, -4, 4);
+        rot4dZW = clamp(rot4dZW, -4, 4);
+
+        this.gl.uniform1f(this.uniforms.gridDensity, gridDensity);
+        this.gl.uniform1f(this.uniforms.morphFactor, morphFactor);
+        this.gl.uniform1f(this.uniforms.chaos, chaos);
+        this.gl.uniform1f(this.uniforms.speed, speed);
+        this.gl.uniform1f(this.uniforms.hue, hue);
         this.gl.uniform1f(this.uniforms.intensity, Math.min(1, intensity));
-        this.gl.uniform1f(this.uniforms.saturation, this.params.saturation);
-        this.gl.uniform1f(this.uniforms.dimension, this.params.dimension);
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.params.rot4dXW);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.params.rot4dYW);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.params.rot4dZW);
+        this.gl.uniform1f(this.uniforms.saturation, saturation);
+        this.gl.uniform1f(this.uniforms.dimension, dimension);
+        this.gl.uniform1f(this.uniforms.rot4dXW, rot4dXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, rot4dYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, rot4dZW);
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.roleIntensity, roleIntensities[this.role] || 1.0);
-        
+
+        this.applyColorUniforms(colorUniforms);
+
         try {
             this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
             

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -6,6 +6,28 @@ import {
     buildVariantParams
 } from './VariantCatalog.js';
 
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const lerp = (current, target, factor) => current + (target - current) * factor;
+
+const COLOR_MODE_MAP = Object.freeze({
+    single: 0,
+    dual: 1,
+    triad: 2,
+    complementary: 3,
+    analogous: 4,
+    palette: 5,
+    gradient: 6,
+    reactive: 7
+});
+
+const GRADIENT_TYPE_MAP = Object.freeze({
+    horizontal: 0,
+    vertical: 1,
+    radial: 2,
+    spiral: 3,
+    wave: 4
+});
+
 /**
  * Core Holographic Visualizer - Clean WebGL rendering engine
  * Extracted from working system, no debugging mess
@@ -96,7 +118,28 @@ export class HolographicVisualizer {
         this.audioSpeedBoost = 0.0;
         this.audioChaosBoost = 0.0;
         this.audioColorShift = 0.0;
-        
+
+        this.audioResponse = {
+            density: 0,
+            morph: 0,
+            speed: 0,
+            chaos: 0,
+            colorShift: 0,
+            intensity: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+        this.onsetPulse = 0;
+
+        this.colorUniformBuffer = new Float32Array(12);
+        this.colorUniformState = {
+            mode: COLOR_MODE_MAP.single,
+            paletteSize: 0,
+            gradientType: GRADIENT_TYPE_MAP.horizontal,
+            gradientPhase: 0
+        };
+
         this.startTime = Date.now();
         this.initShaders();
         this.initBuffers();
@@ -213,7 +256,75 @@ export class HolographicVisualizer {
             uniform float u_rot4dXW;
             uniform float u_rot4dYW;
             uniform float u_rot4dZW;
-            
+            uniform int u_colorMode;
+            uniform int u_paletteSize;
+            uniform vec3 u_palette[4];
+            uniform int u_gradientType;
+            uniform float u_gradientPhase;
+
+            const int COLOR_MODE_SINGLE = 0;
+            const int COLOR_MODE_DUAL = 1;
+            const int COLOR_MODE_TRIAD = 2;
+            const int COLOR_MODE_COMPLEMENTARY = 3;
+            const int COLOR_MODE_ANALOGOUS = 4;
+            const int COLOR_MODE_PALETTE = 5;
+            const int COLOR_MODE_GRADIENT = 6;
+            const int COLOR_MODE_REACTIVE = 7;
+
+            const int GRADIENT_HORIZONTAL = 0;
+            const int GRADIENT_VERTICAL = 1;
+            const int GRADIENT_RADIAL = 2;
+            const int GRADIENT_SPIRAL = 3;
+            const int GRADIENT_WAVE = 4;
+
+            float clamp01(float value) {
+                return clamp(value, 0.0, 1.0);
+            }
+
+            vec3 samplePaletteColor(float position) {
+                if (u_paletteSize <= 0) {
+                    return vec3(1.0);
+                }
+
+                if (u_paletteSize == 1) {
+                    return u_palette[0];
+                }
+
+                float clamped = clamp(position, 0.0, 0.9999);
+                float scaled = clamped * float(u_paletteSize - 1);
+                int index = int(floor(scaled));
+                int nextIndex = min(index + 1, u_paletteSize - 1);
+                float mixAmount = fract(scaled);
+                vec3 a = u_palette[index];
+                vec3 b = u_palette[nextIndex];
+                return mix(a, b, mixAmount);
+            }
+
+            float computePalettePosition(vec2 uv, float geometryValue) {
+                vec2 normalized = uv * 0.5 + 0.5;
+                float base = fract(u_gradientPhase + geometryValue * 0.25);
+
+                if (u_colorMode == COLOR_MODE_GRADIENT) {
+                    if (u_gradientType == GRADIENT_HORIZONTAL) {
+                        base = clamp01(normalized.x);
+                    } else if (u_gradientType == GRADIENT_VERTICAL) {
+                        base = clamp01(normalized.y);
+                    } else if (u_gradientType == GRADIENT_RADIAL) {
+                        float dist = length(normalized - 0.5);
+                        base = clamp(dist * 1.4142, 0.0, 1.0);
+                    } else if (u_gradientType == GRADIENT_SPIRAL) {
+                        float angle = atan(normalized.y - 0.5, normalized.x - 0.5) / (6.28318);
+                        base = fract(angle + u_gradientPhase);
+                    } else if (u_gradientType == GRADIENT_WAVE) {
+                        base = fract(normalized.x + sin((normalized.y + u_gradientPhase) * 6.28318) * 0.2 + u_gradientPhase);
+                    }
+                } else {
+                    base = fract(u_gradientPhase + geometryValue * 0.3 + normalized.x * 0.25);
+                }
+
+                return clamp01(base);
+            }
+
             // 4D rotation matrices
             mat4 rotateXW(float theta) {
                 float c = cos(theta);
@@ -438,7 +549,14 @@ export class HolographicVisualizer {
                 // Enhanced holographic color processing
                 vec3 baseColor = u_color;
                 float latticeIntensity = lattice * u_intensity;
-                
+
+                if (u_paletteSize > 0) {
+                    float palettePosition = computePalettePosition(uv, lattice);
+                    vec3 paletteColor = samplePaletteColor(palettePosition);
+                    float blendStrength = (u_colorMode == COLOR_MODE_SINGLE) ? 0.65 : 1.0;
+                    baseColor = mix(baseColor, paletteColor, blendStrength);
+                }
+
                 // Multi-layer color composition for higher fidelity
                 vec3 color = baseColor * (0.2 + latticeIntensity * 0.8);
                 
@@ -520,7 +638,12 @@ export class HolographicVisualizer {
             audioColorShift: this.gl.getUniformLocation(this.program, 'u_audioColorShift'),
             rot4dXW: this.gl.getUniformLocation(this.program, 'u_rot4dXW'),
             rot4dYW: this.gl.getUniformLocation(this.program, 'u_rot4dYW'),
-            rot4dZW: this.gl.getUniformLocation(this.program, 'u_rot4dZW')
+            rot4dZW: this.gl.getUniformLocation(this.program, 'u_rot4dZW'),
+            colorMode: this.gl.getUniformLocation(this.program, 'u_colorMode'),
+            palette: this.gl.getUniformLocation(this.program, 'u_palette[0]'),
+            paletteSize: this.gl.getUniformLocation(this.program, 'u_paletteSize'),
+            gradientType: this.gl.getUniformLocation(this.program, 'u_gradientType'),
+            gradientPhase: this.gl.getUniformLocation(this.program, 'u_gradientPhase')
         };
     }
     
@@ -655,56 +778,152 @@ export class HolographicVisualizer {
         this.scrollVelocity += deltaY * 0.001;
         this.scrollVelocity = Math.max(-2.0, Math.min(2.0, this.scrollVelocity));
     }
-    
-    // Audio reactivity now handled directly in render() loop
-    updateAudio_DISABLED() {
-        return; // No longer used - audio handled in render()
-        
-        // Musical visualization approach - responsive but controlled
-        const smoothing = 0.6; // Less smoothing for more reactivity
-        
-        // Initialize if needed
-        if (!this.audioSmooth) {
-            this.audioSmooth = {
-                density: 0, morph: 0, speed: 0, chaos: 0, color: 0, beat: 0
-            };
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined' || !window.audioEnabled) {
+            return null;
         }
-        
-        // Speed: More responsive to rhythm and bass
-        const targetSpeed = audioData.rhythm > 0 ? audioData.rhythm * 0.8 : 
-                           audioData.bass > 0.3 ? audioData.bass * 0.6 : 0;
-        this.audioSmooth.speed = this.audioSmooth.speed * smoothing + targetSpeed * (1 - smoothing);
-        this.audioSpeedBoost = this.audioSmooth.speed;
-        
-        // Density: More reactive to energy
-        const targetDensity = audioData.energy * 1.2 + audioData.bass * 0.8;
-        this.audioSmooth.density = this.audioSmooth.density * smoothing + targetDensity * (1 - smoothing);
-        this.audioDensityBoost = this.audioSmooth.density;
-        
-        // Morph: More flowing with melody and mid frequencies
-        const targetMorph = audioData.melody * 1.2 + audioData.mid * 0.8;
-        this.audioSmooth.morph = this.audioSmooth.morph * smoothing + targetMorph * (1 - smoothing);
-        this.audioMorphBoost = this.audioSmooth.morph;
-        
-        // Chaos: More responsive to bass and high frequencies
-        const targetChaos = audioData.bass > 0.4 ? audioData.bass * 0.8 : 
-                           audioData.high > 0.6 ? audioData.high * 0.6 : 0;
-        this.audioSmooth.chaos = this.audioSmooth.chaos * smoothing + targetChaos * (1 - smoothing);
-        this.audioChaosBoost = this.audioSmooth.chaos;
-        
-        // Color: More dynamic color shifting
-        const targetColor = (audioData.melody + audioData.high + audioData.mid) * 0.6;
-        this.audioSmooth.color = this.audioSmooth.color * smoothing + targetColor * (1 - smoothing);
-        this.audioColorShift = this.audioSmooth.color * Math.PI;
-        
-        // Beat detection creates sharp visual pulses
-        if (audioData.rhythm > 0.5) { // Lower threshold for beat detection
-            this.clickIntensity = Math.max(this.clickIntensity, 1.0);
-            this.audioSmooth.beat = 1.0;
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels() || null;
         }
-        this.audioSmooth.beat *= 0.8; // Faster beat decay for more responsive pulses
+
+        return window.audioReactive || null;
     }
-    
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    prepareColorUniforms(colorState) {
+        const buffer = this.colorUniformBuffer;
+        buffer.fill(0);
+
+        let paletteSize = 0;
+        if (colorState?.uniforms?.palette && Array.isArray(colorState.uniforms.palette)) {
+            const palette = colorState.uniforms.palette;
+            paletteSize = Math.min(palette.length, 4);
+            for (let i = 0; i < paletteSize; i += 1) {
+                const color = palette[i] || [0, 0, 0];
+                const offset = i * 3;
+                buffer[offset] = color[0] ?? 0;
+                buffer[offset + 1] = color[1] ?? 0;
+                buffer[offset + 2] = color[2] ?? 0;
+            }
+        }
+
+        const gradientTypeKey = colorState?.gradient?.type || 'horizontal';
+        const gradientType = GRADIENT_TYPE_MAP[gradientTypeKey] ?? GRADIENT_TYPE_MAP.horizontal;
+        const gradientPhase = typeof colorState?.gradient?.phase === 'number'
+            ? colorState.gradient.phase
+            : 0;
+        const modeKey = colorState?.mode || 'single';
+        const mode = COLOR_MODE_MAP[modeKey] ?? COLOR_MODE_MAP.single;
+
+        this.colorUniformState.mode = mode;
+        this.colorUniformState.paletteSize = paletteSize;
+        this.colorUniformState.gradientType = gradientType;
+        this.colorUniformState.gradientPhase = gradientPhase;
+
+        return this.colorUniformState;
+    }
+
+    applyColorUniforms(uniformState) {
+        if (!this.gl || !this.uniforms) {
+            return;
+        }
+
+        if (this.uniforms.colorMode) {
+            this.gl.uniform1i(this.uniforms.colorMode, uniformState.mode);
+        }
+        if (this.uniforms.palette) {
+            this.gl.uniform3fv(this.uniforms.palette, this.colorUniformBuffer);
+        }
+        if (this.uniforms.paletteSize) {
+            this.gl.uniform1i(this.uniforms.paletteSize, uniformState.paletteSize);
+        }
+        if (this.uniforms.gradientType) {
+            this.gl.uniform1i(this.uniforms.gradientType, uniformState.gradientType);
+        }
+        if (this.uniforms.gradientPhase) {
+            this.gl.uniform1f(this.uniforms.gradientPhase, uniformState.gradientPhase);
+        }
+    }
+
+    updateAudioResponse(audioState) {
+        const smoothing = 0.2;
+        const target = {
+            density: 0,
+            morph: 0,
+            speed: 0,
+            chaos: 0,
+            colorShift: 0,
+            intensity: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.onsetPulse = (this.onsetPulse || 0) * 0.82;
+
+        if (audioState) {
+            const bass = clamp(audioState.bass ?? 0, 0, 1);
+            const mid = clamp(audioState.mid ?? 0, 0, 1);
+            const high = clamp(audioState.high ?? 0, 0, 1);
+            const sparkle = clamp(audioState.sparkle ?? audioState.bands?.air ?? 0, 0, 1);
+            const energy = clamp(audioState.energy ?? audioState.rms ?? 0, 0, 1);
+            const motion = clamp(audioState.motion ?? audioState.spectralFlux ?? 0, 0, 1);
+            const centroid = clamp(audioState.hueShift ?? audioState.spectralCentroid ?? 0, 0, 1);
+            const intensityBoost = clamp(audioState.intensity ?? audioState.rms ?? 0, 0, 1);
+
+            if (audioState.onset) {
+                this.onsetPulse = 1;
+                this.clickIntensity = Math.min(1.0, this.clickIntensity + 0.35);
+            }
+
+            target.density = clamp((bass * 1.8) + (energy * 0.6), 0, 2.5);
+            target.morph = clamp((mid * 1.4) + (motion * 0.8), 0, 2.2);
+            target.speed = clamp((high * 1.1) + (energy * 0.5), 0, 2.8);
+            target.chaos = clamp((motion * 0.7) + (sparkle * 0.4) + (energy * 0.3), 0, 2.4);
+            target.colorShift = clamp((centroid * 240) + (sparkle * 90), 0, 360);
+            target.intensity = clamp((intensityBoost * 0.7) + (energy * 0.4), 0, 1.5);
+            target.rot4dXW = clamp(bass * 0.5, 0, 1.6);
+            target.rot4dYW = clamp(mid * 0.35, 0, 1.4);
+            target.rot4dZW = clamp(high * 0.3, 0, 1.2);
+        }
+
+        target.speed += this.onsetPulse * 1.1;
+
+        this.audioResponse.density = lerp(this.audioResponse.density, target.density, smoothing);
+        this.audioResponse.morph = lerp(this.audioResponse.morph, target.morph, smoothing);
+        this.audioResponse.speed = lerp(this.audioResponse.speed, target.speed, smoothing);
+        this.audioResponse.chaos = lerp(this.audioResponse.chaos, target.chaos, smoothing);
+        this.audioResponse.colorShift = lerp(this.audioResponse.colorShift, target.colorShift, smoothing);
+        this.audioResponse.intensity = lerp(this.audioResponse.intensity, target.intensity, smoothing);
+        this.audioResponse.rot4dXW = lerp(this.audioResponse.rot4dXW, target.rot4dXW, smoothing);
+        this.audioResponse.rot4dYW = lerp(this.audioResponse.rot4dYW, target.rot4dYW, smoothing);
+        this.audioResponse.rot4dZW = lerp(this.audioResponse.rot4dZW, target.rot4dZW, smoothing);
+
+        this.audioDensityBoost = this.audioResponse.density;
+        this.audioMorphBoost = this.audioResponse.morph;
+        this.audioSpeedBoost = this.audioResponse.speed;
+        this.audioChaosBoost = this.audioResponse.chaos;
+        this.audioColorShift = this.audioResponse.colorShift;
+
+        return this.audioResponse;
+    }
+
     updateScrollPhysics() {
         this.scrollPosition += this.scrollVelocity;
         this.scrollVelocity *= this.scrollDecay;
@@ -718,17 +937,35 @@ export class HolographicVisualizer {
         
         this.resize();
         this.gl.useProgram(this.program);
-        
+
         this.densityVariation += (this.densityTarget - this.densityVariation) * 0.05;
         this.clickIntensity *= this.clickDecay;
         this.updateScrollPhysics();
-        
+
         const time = Date.now() - this.startTime;
-        
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+        const colorUniforms = this.prepareColorUniforms(colorState);
+
         // Convert HSL to RGB for color uniform
-        const hue = (this.variantParams.hue || 0) / 360; // Convert to 0-1 range
-        const saturation = this.variantParams.saturation || 0.8;
-        const lightness = Math.max(0.2, Math.min(0.8, this.variantParams.intensity || 0.5)); // Use intensity for lightness
+        let hueDegrees = this.variantParams.hue || 0;
+        let saturation = this.variantParams.saturation ?? 0.8;
+        let lightness = Math.max(0.2, Math.min(0.8, this.variantParams.intensity || 0.5));
+
+        if (colorState?.primary) {
+            hueDegrees = colorState.primary.h;
+            saturation = Math.max(saturation, colorState.primary.s);
+            lightness = Math.min(0.85, Math.max(0.2, colorState.primary.v * 0.8 + 0.15));
+        }
+
+        if (colorState?.accent && colorState.accent !== colorState.primary) {
+            saturation = Math.max(saturation, colorState.accent.s * 0.85);
+        }
+
+        const hue = (hueDegrees % 360) / 360;
+        saturation = clamp(saturation, 0, 1);
+        lightness = clamp(lightness, 0, 1);
         
         // HSL to RGB conversion
         const hslToRgb = (h, s, l) => {
@@ -763,55 +1000,60 @@ export class HolographicVisualizer {
         this.gl.uniform1f(this.uniforms.density, this.variantParams.density || 1.0);
         // FIX: Controlled speed calculation - base speed controls main movement, audio provides subtle boost
         const baseSpeed = (this.variantParams.speed || 0.5) * 0.2; // Much slower base speed
-        const audioBoost = (this.audioSpeedBoost || 0.0) * 0.1; // Subtle audio boost only
+        const audioBoost = (audioResponse.speed || 0.0) * 0.12; // Subtle audio boost only
         this.gl.uniform1f(this.uniforms.speed, baseSpeed + audioBoost);
         this.gl.uniform3fv(this.uniforms.color, new Float32Array(rgbColor));
-        this.gl.uniform1f(this.uniforms.intensity, (this.variantParams.intensity || 0.5) * this.roleParams.intensity);
+        const baseIntensity = (this.variantParams.intensity || 0.5) * this.roleParams.intensity;
+        const colorIntensityBoost = colorState?.primary ? colorState.primary.v * 0.8 : 0;
+        const reactiveIntensity = clamp(baseIntensity * (1 + audioResponse.intensity) + colorIntensityBoost, 0, 3);
+        this.gl.uniform1f(this.uniforms.intensity, reactiveIntensity);
         this.gl.uniform1f(this.uniforms.roleDensity, this.roleParams.densityMult);
         this.gl.uniform1f(this.uniforms.roleSpeed, this.roleParams.speedMult);
-        this.gl.uniform1f(this.uniforms.colorShift, this.roleParams.colorShift + (this.variantParams.hue || 0) / 360);
-        this.gl.uniform1f(this.uniforms.chaosIntensity, this.variantParams.chaos || 0.0);
+        const baseColorShiftDegrees = (this.roleParams.colorShift || 0) + hueDegrees;
+        const gradientShift = colorState?.gradient ? colorState.gradient.phase * 180 : 0;
+        const totalColorShift = (baseColorShiftDegrees + (audioResponse.colorShift || 0) + gradientShift) % 360;
+        this.gl.uniform1f(this.uniforms.colorShift, totalColorShift / 360);
+        const chaosReactive = clamp((this.variantParams.chaos || 0.0) + audioResponse.chaos * 0.6, 0, 3);
+        this.gl.uniform1f(this.uniforms.chaosIntensity, chaosReactive);
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.densityVariation, this.densityVariation);
         this.gl.uniform1f(this.uniforms.geometryType, this.variantParams.geometryType !== undefined ? this.variantParams.geometryType : this.variant || 0);
-        this.gl.uniform1f(this.uniforms.chaos, this.variantParams.chaos || 0.0);
+        this.gl.uniform1f(this.uniforms.chaos, chaosReactive);
         this.gl.uniform1f(this.uniforms.morph, this.variantParams.morph || 0.0);
-        
+
         // Touch and scroll uniforms
         this.gl.uniform1f(this.uniforms.touchMorph, this.touchMorph);
         this.gl.uniform1f(this.uniforms.touchChaos, this.touchChaos);
         this.gl.uniform1f(this.uniforms.scrollParallax, this.parallaxDepth);
         this.gl.uniform1f(this.uniforms.gridDensityShift, this.gridDensityShift);
         this.gl.uniform1f(this.uniforms.colorScrollShift, this.colorScrollShift);
-        
-        // 🎵 HOLOGRAPHIC AUDIO REACTIVITY - Direct and beautiful
-        let audioDensity = 0, audioMorph = 0, audioSpeed = 0, audioChaos = 0, audioColor = 0;
-        
-        if (window.audioEnabled && window.audioReactive) {
-            // Holographic audio mapping: Rich volumetric effects
-            audioDensity = window.audioReactive.bass * 1.5;     // Bass creates density in holographic layers
-            audioMorph = window.audioReactive.mid * 1.2;        // Mid frequencies morph the hologram
-            audioSpeed = window.audioReactive.high * 0.8;       // High frequencies speed up animation
-            audioChaos = window.audioReactive.energy * 0.6;     // Energy creates chaotic holographic distortion
-            audioColor = window.audioReactive.bass * 45;        // Bass affects holographic color shifts
-            
-            // Debug logging every 10 seconds to verify holographic audio reactivity
-            if (Date.now() % 10000 < 16) {
-                console.log(`✨ Holographic audio reactivity: Density+${audioDensity.toFixed(2)} Morph+${audioMorph.toFixed(2)} Speed+${audioSpeed.toFixed(2)} Chaos+${audioChaos.toFixed(2)} Color+${audioColor.toFixed(1)}`);
-            }
+
+        this.applyColorUniforms(colorUniforms);
+
+        // 🎵 HOLOGRAPHIC AUDIO REACTIVITY - powered by advanced analyzer
+        const audioDensity = audioResponse.density || 0;
+        const audioMorph = audioResponse.morph || 0;
+        const audioSpeed = audioResponse.speed || 0;
+        const audioChaos = audioResponse.chaos || 0;
+        const audioColor = audioResponse.colorShift || 0;
+
+        if (audioState && Date.now() % 10000 < 16) {
+            console.log(
+                `✨ Holographic audio reactivity: Density+${audioDensity.toFixed(2)} Morph+${audioMorph.toFixed(2)} Speed+${audioSpeed.toFixed(2)} Chaos+${audioChaos.toFixed(2)} Color+${audioColor.toFixed(1)}`
+            );
         }
-        
+
         this.gl.uniform1f(this.uniforms.audioDensityBoost, audioDensity);
         this.gl.uniform1f(this.uniforms.audioMorphBoost, audioMorph);
         this.gl.uniform1f(this.uniforms.audioSpeedBoost, audioSpeed);
         this.gl.uniform1f(this.uniforms.audioChaosBoost, audioChaos);
         this.gl.uniform1f(this.uniforms.audioColorShift, audioColor);
-        
+
         // 4D rotation uniforms
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.variantParams.rot4dXW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.variantParams.rot4dYW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.variantParams.rot4dZW || 0.0);
+        this.gl.uniform1f(this.uniforms.rot4dXW, (this.variantParams.rot4dXW || 0.0) + audioResponse.rot4dXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, (this.variantParams.rot4dYW || 0.0) + audioResponse.rot4dYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, (this.variantParams.rot4dZW || 0.0) + audioResponse.rot4dZW);
         
         this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
     }

--- a/src/polychora/PolychoraEngine.js
+++ b/src/polychora/PolychoraEngine.js
@@ -1,0 +1,157 @@
+import { ParameterManager } from '../core/Parameters.js';
+import { PolychoraVisualizer } from './PolychoraVisualizer.js';
+
+const LAYERS = [
+    { id: 'polychora-background-canvas', role: 'background' },
+    { id: 'polychora-shadow-canvas', role: 'shadow' },
+    { id: 'polychora-content-canvas', role: 'content' },
+    { id: 'polychora-highlight-canvas', role: 'highlight' },
+    { id: 'polychora-accent-canvas', role: 'accent' }
+];
+
+export class PolychoraEngine {
+    constructor() {
+        this.parameterManager = new ParameterManager();
+        this.parameters = this.parameterManager; // Legacy compatibility
+        this.visualizers = [];
+        this.isActive = false;
+        this.animationId = null;
+        this.clickPulse = 0;
+        this.audioSettings = {
+            bassToRotation: 2.0,
+            midToMorph: 1.2,
+            highToColor: 1.0
+        };
+
+        this.createVisualizers();
+        this.applyParametersToVisualizers();
+    }
+
+    createVisualizers() {
+        this.visualizers = [];
+        const params = this.parameterManager.getAllParameters();
+
+        LAYERS.forEach(layer => {
+            const visualizer = new PolychoraVisualizer(layer.id, layer.role, 1.0);
+            if (visualizer && visualizer.gl) {
+                visualizer.updateParameters(params);
+                this.visualizers.push(visualizer);
+            }
+        });
+    }
+
+    applyParametersToVisualizers() {
+        const snapshot = this.parameterManager.getAllParameters();
+        this.visualizers.forEach(visualizer => visualizer.updateParameters(snapshot));
+    }
+
+    startRenderLoop() {
+        if (this.animationId) {
+            cancelAnimationFrame(this.animationId);
+            this.animationId = null;
+        }
+
+        const render = () => {
+            if (!this.isActive) {
+                this.animationId = null;
+                return;
+            }
+
+            if (this.clickPulse > 0.001) {
+                const boost = this.clickPulse * 0.2;
+                const baseIntensity = this.parameterManager.getParameter('intensity') ?? 0.7;
+                const boosted = Math.min(1.5, baseIntensity + boost);
+                this.visualizers.forEach(visualizer => {
+                    visualizer.updateParameters({ intensity: boosted });
+                });
+                this.clickPulse *= 0.92;
+                if (this.clickPulse < 0.001) {
+                    this.applyParametersToVisualizers();
+                }
+            }
+
+            this.visualizers.forEach(visualizer => visualizer.render());
+            this.animationId = requestAnimationFrame(render);
+        };
+
+        this.animationId = requestAnimationFrame(render);
+    }
+
+    stopRenderLoop() {
+        if (this.animationId) {
+            cancelAnimationFrame(this.animationId);
+            this.animationId = null;
+        }
+    }
+
+    setActive(active) {
+        if (this.isActive === active) {
+            return;
+        }
+
+        this.isActive = active;
+        if (active) {
+            this.applyParametersToVisualizers();
+            this.startRenderLoop();
+        } else {
+            this.stopRenderLoop();
+        }
+    }
+
+    updateParameter(name, value) {
+        const result = this.parameterManager.setParameter(name, value);
+        if (result !== false) {
+            this.applyParametersToVisualizers();
+        }
+        return result;
+    }
+
+    updateParameters(params = {}) {
+        Object.entries(params).forEach(([key, value]) => {
+            this.parameterManager.setParameter(key, value);
+        });
+        this.applyParametersToVisualizers();
+    }
+
+    getParameters() {
+        return this.parameterManager.getAllParameters();
+    }
+
+    setParameters(params = {}) {
+        if (!params) return;
+        this.parameterManager.loadParameters?.(params);
+        Object.entries(params).forEach(([key, value]) => {
+            this.parameterManager.setParameter(key, value);
+        });
+        this.applyParametersToVisualizers();
+    }
+
+    triggerClick(strength = 1) {
+        this.clickPulse = Math.min(1.5, this.clickPulse + Math.max(0, strength));
+    }
+
+    updateAudioReactivity(settings = {}) {
+        if (settings && typeof settings === 'object') {
+            this.audioSettings = { ...this.audioSettings, ...settings };
+        }
+        return this.audioSettings;
+    }
+
+    start() {
+        this.setActive(true);
+    }
+
+    stop() {
+        this.setActive(false);
+    }
+
+    getParameter(name) {
+        return this.parameterManager.getParameter(name);
+    }
+
+    destroy() {
+        this.stopRenderLoop();
+        this.visualizers.forEach(visualizer => visualizer.cleanup());
+        this.visualizers = [];
+    }
+}

--- a/src/polychora/PolychoraVisualizer.js
+++ b/src/polychora/PolychoraVisualizer.js
@@ -1,0 +1,500 @@
+import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+
+const COLOR_MODE_MAP = Object.freeze({
+    single: 0,
+    dual: 1,
+    triad: 2,
+    complementary: 3,
+    analogous: 4,
+    palette: 5,
+    gradient: 6,
+    reactive: 7
+});
+
+const GRADIENT_TYPE_MAP = Object.freeze({
+    horizontal: 0,
+    vertical: 1,
+    radial: 2,
+    spiral: 3,
+    wave: 4
+});
+
+const ROLE_CONFIG = Object.freeze({
+    background: { intensity: 0.18, scale: 1.15, color: [0.08, 0.05, 0.16] },
+    shadow: { intensity: 0.32, scale: 1.08, color: [0.04, 0.05, 0.12] },
+    content: { intensity: 0.95, scale: 1.0, color: [0.42, 0.25, 0.72] },
+    highlight: { intensity: 0.72, scale: 0.94, color: [0.86, 0.65, 1.0] },
+    accent: { intensity: 0.55, scale: 0.88, color: [0.35, 0.78, 0.92] }
+});
+
+const DEFAULT_PARAMS = Object.freeze({
+    geometry: 1,
+    rot4dXW: 0,
+    rot4dYW: 0,
+    rot4dZW: 0,
+    gridDensity: 18,
+    morphFactor: 1.0,
+    chaos: 0.15,
+    speed: 1.0,
+    hue: 280,
+    intensity: 0.75,
+    saturation: 0.85,
+    colorMode: 'single',
+    colorPalette: 'holographic',
+    gradientType: 'horizontal',
+    gradientSpeed: 0.3,
+    colorReactivity: 0.65
+});
+
+export class PolychoraVisualizer {
+    constructor(canvasId, role = 'content', reactivity = 1.0) {
+        this.canvas = typeof document !== 'undefined' ? document.getElementById(canvasId) : null;
+        if (!this.canvas) {
+            console.warn(`[PolychoraVisualizer] Canvas not found: ${canvasId}`);
+            return;
+        }
+
+        this.role = role;
+        this.reactivity = reactivity;
+        this.contextOptions = {
+            alpha: true,
+            depth: false,
+            stencil: false,
+            antialias: false,
+            premultipliedAlpha: true,
+            preserveDrawingBuffer: false,
+            powerPreference: 'high-performance'
+        };
+
+        const roleConfig = ROLE_CONFIG[role] || ROLE_CONFIG.content;
+        this.layerIntensity = roleConfig.intensity;
+        this.layerScale = roleConfig.scale;
+        this.layerColor = roleConfig.color.slice();
+
+        this.params = { ...DEFAULT_PARAMS };
+        this.audioResponse = { bass: 0, mid: 0, high: 0, energy: 0 };
+        this.audioSmoothing = 0.18;
+
+        this.colorUniformBuffer = new Float32Array(12);
+        this.colorUniformState = {
+            mode: COLOR_MODE_MAP.single,
+            paletteSize: 0,
+            gradientType: GRADIENT_TYPE_MAP.horizontal,
+            gradientPhase: 0
+        };
+
+        this.time = 0;
+        this.startTime = Date.now();
+        this.handleResize = this.resize.bind(this);
+
+        this.initContext();
+        if (!this.gl) {
+            return;
+        }
+
+        if (!this.initShaders()) {
+            console.error('[PolychoraVisualizer] Failed to initialize shaders');
+            this.disposeContext();
+            return;
+        }
+
+        this.initBuffers();
+        this.cacheUniformLocations();
+        this.resize();
+
+        window.addEventListener('resize', this.handleResize);
+        GeometryLibrary.subscribe(() => {
+            if (this.params.geometry >= GeometryLibrary.getGeometryNames().length) {
+                this.params.geometry = Math.max(0, GeometryLibrary.getGeometryNames().length - 1);
+            }
+        });
+    }
+
+    initContext() {
+        this.gl = this.canvas.getContext('webgl2', this.contextOptions) ||
+                  this.canvas.getContext('webgl', this.contextOptions) ||
+                  this.canvas.getContext('experimental-webgl', this.contextOptions);
+
+        if (!this.gl) {
+            console.error('[PolychoraVisualizer] WebGL not supported');
+        }
+    }
+
+    disposeContext() {
+        this.gl = null;
+    }
+
+    initShaders() {
+        const vertexShaderSource = `attribute vec2 a_position;\nvarying vec2 v_uv;\n\nvoid main() {\n    v_uv = a_position * 0.5 + 0.5;\n    gl_Position = vec4(a_position, 0.0, 1.0);\n}`;
+
+        const fragmentShaderSource = `#ifdef GL_FRAGMENT_PRECISION_HIGH\n    precision highp float;\n#else\n    precision mediump float;\n#endif\n\nvarying vec2 v_uv;\n\nuniform float u_time;\nuniform vec2 u_resolution;\nuniform float u_geometry;\nuniform float u_rot4dXW;\nuniform float u_rot4dYW;\nuniform float u_rot4dZW;\nuniform float u_gridDensity;\nuniform float u_morphFactor;\nuniform float u_chaos;\nuniform float u_speed;\nuniform float u_hue;\nuniform float u_intensity;\nuniform float u_saturation;\nuniform float u_layerIntensity;\nuniform float u_layerScale;\nuniform vec3 u_layerColor;\nuniform float u_colorReactivity;\nuniform int u_colorMode;\nuniform int u_paletteSize;\nuniform vec3 u_palette[4];\nuniform int u_gradientType;\nuniform float u_gradientPhase;\nuniform float u_bass;\nuniform float u_mid;\nuniform float u_high;\n\nconst int COLOR_MODE_SINGLE = 0;\nconst int COLOR_MODE_DUAL = 1;\nconst int COLOR_MODE_TRIAD = 2;\nconst int COLOR_MODE_COMPLEMENTARY = 3;\nconst int COLOR_MODE_ANALOGOUS = 4;\nconst int COLOR_MODE_PALETTE = 5;\nconst int COLOR_MODE_GRADIENT = 6;\nconst int COLOR_MODE_REACTIVE = 7;\n\nconst int GRADIENT_HORIZONTAL = 0;\nconst int GRADIENT_VERTICAL = 1;\nconst int GRADIENT_RADIAL = 2;\nconst int GRADIENT_SPIRAL = 3;\nconst int GRADIENT_WAVE = 4;\n\nfloat clamp01(float value) {\n    return clamp(value, 0.0, 1.0);\n}\n\nmat4 rotateXW(float angle) {\n    float c = cos(angle);\n    float s = sin(angle);\n    return mat4(\n        c, 0.0, 0.0, -s,\n        0.0, 1.0, 0.0, 0.0,\n        0.0, 0.0, 1.0, 0.0,\n        s, 0.0, 0.0, c\n    );\n}\n\nmat4 rotateYW(float angle) {\n    float c = cos(angle);\n    float s = sin(angle);\n    return mat4(\n        1.0, 0.0, 0.0, 0.0,\n        0.0, c, 0.0, -s,\n        0.0, 0.0, 1.0, 0.0,\n        0.0, s, 0.0, c\n    );\n}\n\nmat4 rotateZW(float angle) {\n    float c = cos(angle);\n    float s = sin(angle);\n    return mat4(\n        1.0, 0.0, 0.0, 0.0,\n        0.0, 1.0, 0.0, 0.0,\n        0.0, 0.0, c, -s,\n        0.0, 0.0, s, c\n    );\n}\n\nfloat hash(vec4 p) {\n    vec4 h = vec4(37.0, 57.0, 113.0, 147.0);\n    return fract(sin(dot(p, h)) * 43758.5453);\n}\n\nvec3 hsv2rgb(vec3 c) {\n    vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);\n    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);\n    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);\n}\n\nvec3 samplePaletteColor(float position) {\n    if (u_paletteSize <= 0) {\n        return vec3(1.0);\n    }\n\n    if (u_paletteSize == 1) {\n        return u_palette[0];\n    }\n\n    float clamped = clamp(position, 0.0, 0.9999);\n    float scaled = clamped * float(u_paletteSize - 1);\n    int index = int(floor(scaled));\n    int nextIndex = min(index + 1, u_paletteSize - 1);\n    float mixAmount = fract(scaled);\n    vec3 a = u_palette[index];\n    vec3 b = u_palette[nextIndex];\n    return mix(a, b, mixAmount);\n}\n\nfloat computePalettePosition(vec2 uv, float geometryValue) {\n    vec2 normalized = uv * 0.5 + 0.5;\n    float base = fract(u_gradientPhase + geometryValue * 0.25);\n\n    if (u_colorMode == COLOR_MODE_GRADIENT) {\n        if (u_gradientType == GRADIENT_HORIZONTAL) {\n            base = clamp01(normalized.x);\n        } else if (u_gradientType == GRADIENT_VERTICAL) {\n            base = clamp01(normalized.y);\n        } else if (u_gradientType == GRADIENT_RADIAL) {\n            float dist = length(normalized - 0.5);\n            base = clamp(dist * 1.4142, 0.0, 1.0);\n        } else if (u_gradientType == GRADIENT_SPIRAL) {\n            float angle = atan(normalized.y - 0.5, normalized.x - 0.5) / (6.28318);\n            base = fract(angle + u_gradientPhase);\n        } else if (u_gradientType == GRADIENT_WAVE) {\n            base = fract(normalized.x + sin((normalized.y + u_gradientPhase) * 6.28318) * 0.2 + u_gradientPhase);\n        }\n    } else {\n        base = fract(u_gradientPhase + geometryValue * 0.3 + normalized.x * 0.25);\n    }\n\n    return clamp01(base);\n}\n\nfloat polytope5Cell(vec4 p) {\n    vec4 corners[5];\n    corners[0] = vec4(1, 1, 1, -1) / sqrt(4.0);\n    corners[1] = vec4(1, -1, -1, -1) / sqrt(4.0);\n    corners[2] = vec4(-1, 1, -1, -1) / sqrt(4.0);\n    corners[3] = vec4(-1, -1, 1, -1) / sqrt(4.0);\n    corners[4] = vec4(0, 0, 0, 1);\n\n    float dist = 1e9;\n    for (int i = 0; i < 5; i++) {\n        float d = length(p - corners[i]);\n        dist = min(dist, d);\n    }\n    return dist - 0.8;\n}\n\nfloat polytopeTesseract(vec4 p) {\n    vec4 q = abs(p);\n    return max(max(q.x, max(q.y, max(q.z, q.w))) - 1.0, 0.0);\n}\n\nfloat polytope16Cell(vec4 p) {\n    return (abs(p.x) + abs(p.y) + abs(p.z) + abs(p.w)) - 1.5;\n}\n\nfloat polytope24Cell(vec4 p) {\n    vec4 q = abs(p);\n    float max1 = max(q.x, max(q.y, q.z));\n    float min1 = min(q.x, min(q.y, q.z));\n    float s = q.x + q.y + q.z + q.w;\n    return max(max1 + q.w - 1.3, s * 0.5 - 1.5);\n}\n\nfloat polytope600Cell(vec4 p) {\n    vec4 q = abs(p);\n    float sum = q.x + q.y + q.z + q.w;\n    return sum * 0.57735 - 1.2;\n}\n\nfloat polytope120Cell(vec4 p) {\n    float phi = 1.618033988749895;\n    vec4 q = abs(p);\n    float d1 = length(q) - 2.0;\n    float d2 = max(max(max(q.x/phi, q.y*phi), q.z/phi), q.w*phi) - 1.5;\n    return max(d1, d2);\n}\n\nfloat polytopeHypersphere(vec4 p) {\n    return length(p) - 1.5;\n}\n\nfloat polytopeDuocylinder(vec4 p) {\n    float r1 = length(p.xy) - 1.0;\n    float r2 = length(p.zw) - 1.0;\n    return sqrt(r1*r1 + r2*r2) - 0.5;\n}\n\nfloat true4DGeometryFunction(vec4 p) {\n    int geomType = int(u_geometry);\n    float gridSize = max(0.0001, u_gridDensity * 0.1);\n\n    mat4 rotation = rotateXW(u_rot4dXW) * rotateYW(u_rot4dYW) * rotateZW(u_rot4dZW);\n    vec4 rotatedP = rotation * p;\n    vec4 tiledP = fract(rotatedP * gridSize) - 0.5;\n\n    float dist = 0.0;\n    if (geomType == 0) {\n        dist = polytope5Cell(tiledP);\n    } else if (geomType == 1) {\n        dist = polytopeTesseract(tiledP);\n    } else if (geomType == 2) {\n        dist = polytopeHypersphere(tiledP);\n    } else if (geomType == 3) {\n        dist = polytopeDuocylinder(tiledP);\n    } else if (geomType == 4) {\n        dist = polytope16Cell(tiledP);\n    } else if (geomType == 5) {\n        dist = polytope24Cell(tiledP);\n    } else if (geomType == 6) {\n        dist = polytope600Cell(tiledP);\n    } else {\n        dist = polytope120Cell(tiledP);\n    }\n\n    dist *= u_morphFactor;\n    if (u_chaos > 0.0) {\n        float noise = hash(rotatedP * 7.3);\n        dist += (noise - 0.5) * u_chaos * 0.3;\n    }\n\n    return dist;\n}\n\nvec3 applyColorMode(vec3 baseColor, vec3 paletteColor, float paletteStrength, vec3 reactiveColor) {\n    if (u_colorMode == COLOR_MODE_REACTIVE) {\n        return mix(baseColor, reactiveColor, clamp01(paletteStrength));\n    }\n\n    if (u_paletteSize <= 0) {\n        return baseColor;\n    }\n\n    float blend = 0.6 + paletteStrength * 0.4;\n    if (u_colorMode == COLOR_MODE_SINGLE) {\n        return mix(baseColor, paletteColor, blend * 0.6);\n    }\n    if (u_colorMode == COLOR_MODE_PALETTE || u_colorMode == COLOR_MODE_GRADIENT) {\n        return mix(baseColor, paletteColor, blend);\n    }\n    if (u_colorMode == COLOR_MODE_DUAL || u_colorMode == COLOR_MODE_COMPLEMENTARY) {\n        vec3 complementary = vec3(paletteColor.b, paletteColor.r, paletteColor.g);
+        return mix(baseColor, mix(paletteColor, complementary, 0.5), blend);
+    }
+    if (u_colorMode == COLOR_MODE_TRIAD) {
+        vec3 triadA = vec3(paletteColor.g, paletteColor.b, paletteColor.r);
+        vec3 triadB = vec3(paletteColor.b, paletteColor.r, paletteColor.g);
+        vec3 triad = (paletteColor + triadA + triadB) / 3.0;
+        return mix(baseColor, triad, blend);
+    }
+    if (u_colorMode == COLOR_MODE_ANALOGOUS) {
+        vec3 shifted = paletteColor * vec3(1.1, 0.95, 1.05);
+        return mix(baseColor, shifted, blend * 0.8);
+    }
+
+    return mix(baseColor, paletteColor, blend);
+}
+
+void main() {
+    vec2 uv = (gl_FragCoord.xy - u_resolution.xy * 0.5) / min(u_resolution.x, u_resolution.y);
+    float time = u_time * 0.001 * max(0.1, u_speed);
+
+    vec4 rayDir = vec4(uv * u_layerScale, sin(time * 0.5), cos(time * 0.3));
+    vec4 audioOffset = vec4(u_bass * 0.35, u_mid * 0.25, u_high * 0.2, (u_bass + u_high) * 0.15);
+    rayDir += audioOffset;
+
+    float dist = true4DGeometryFunction(rayDir);
+
+    float alpha = 0.0;
+    if (dist < 0.08) {
+        alpha = 1.0 - (dist / 0.08);
+        alpha = pow(alpha, 2.0);
+    } else {
+        alpha = exp(-dist * 6.5) * 0.35;
+    }
+
+    alpha *= u_layerIntensity * u_intensity;
+
+    float hue = u_hue / 360.0;
+    vec3 baseColor = hsv2rgb(vec3(hue, u_saturation, 1.0));
+    baseColor = mix(baseColor, u_layerColor, 0.3);
+
+    vec3 reactiveColor = clamp(vec3(
+        baseColor.r + u_high * 0.8,
+        baseColor.g + u_mid * 0.6,
+        baseColor.b + u_bass * 0.7
+    ), 0.0, 1.5);
+
+    float palettePos = computePalettePosition(uv, u_geometry);
+    vec3 paletteColor = samplePaletteColor(palettePos);
+
+    float paletteStrength = float(u_paletteSize > 0) * clamp01(0.35 + u_colorReactivity * 0.65);
+    vec3 finalColor = applyColorMode(baseColor, paletteColor, paletteStrength, reactiveColor);
+
+    gl_FragColor = vec4(finalColor, clamp(alpha, 0.0, 1.0));
+}
+`;
+
+        this.vertexShader = this.compileShader(this.gl.VERTEX_SHADER, vertexShaderSource);
+        this.fragmentShader = this.compileShader(this.gl.FRAGMENT_SHADER, fragmentShaderSource);
+
+        if (!this.vertexShader || !this.fragmentShader) {
+            return false;
+        }
+
+        this.program = this.gl.createProgram();
+        this.gl.attachShader(this.program, this.vertexShader);
+        this.gl.attachShader(this.program, this.fragmentShader);
+        this.gl.linkProgram(this.program);
+
+        if (!this.gl.getProgramParameter(this.program, this.gl.LINK_STATUS)) {
+            console.error('[PolychoraVisualizer] Shader link error:', this.gl.getProgramInfoLog(this.program));
+            return false;
+        }
+
+        this.gl.useProgram(this.program);
+
+        const positionBuffer = this.gl.createBuffer();
+        this.vertexBuffer = positionBuffer;
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, positionBuffer);
+        const vertices = new Float32Array([
+            -1, -1,  1, -1,  -1,  1,
+            -1,  1,  1, -1,   1,  1
+        ]);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
+
+        const positionLocation = this.gl.getAttribLocation(this.program, 'a_position');
+        this.gl.enableVertexAttribArray(positionLocation);
+        this.gl.vertexAttribPointer(positionLocation, 2, this.gl.FLOAT, false, 0, 0);
+
+        return true;
+    }
+
+    compileShader(type, source) {
+        const shader = this.gl.createShader(type);
+        this.gl.shaderSource(shader, source);
+        this.gl.compileShader(shader);
+
+        if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
+            console.error('[PolychoraVisualizer] Shader compile error:', this.gl.getShaderInfoLog(shader));
+            return null;
+        }
+
+        return shader;
+    }
+
+    initBuffers() {
+        if (!this.vertexBuffer) {
+            this.vertexBuffer = this.gl.createBuffer();
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+            const vertices = new Float32Array([
+                -1, -1,
+                 1, -1,
+                -1,  1,
+                -1,  1,
+                 1, -1,
+                 1,  1
+            ]);
+            this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
+            const positionLocation = this.gl.getAttribLocation(this.program, 'a_position');
+            this.gl.enableVertexAttribArray(positionLocation);
+            this.gl.vertexAttribPointer(positionLocation, 2, this.gl.FLOAT, false, 0, 0);
+        } else {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        }
+    }
+
+    cacheUniformLocations() {
+        const fetch = name => this.gl.getUniformLocation(this.program, name);
+        this.uniforms = {
+            time: fetch('u_time'),
+            resolution: fetch('u_resolution'),
+            geometry: fetch('u_geometry'),
+            rot4dXW: fetch('u_rot4dXW'),
+            rot4dYW: fetch('u_rot4dYW'),
+            rot4dZW: fetch('u_rot4dZW'),
+            gridDensity: fetch('u_gridDensity'),
+            morphFactor: fetch('u_morphFactor'),
+            chaos: fetch('u_chaos'),
+            speed: fetch('u_speed'),
+            hue: fetch('u_hue'),
+            intensity: fetch('u_intensity'),
+            saturation: fetch('u_saturation'),
+            layerIntensity: fetch('u_layerIntensity'),
+            layerScale: fetch('u_layerScale'),
+            layerColor: fetch('u_layerColor'),
+            colorMode: fetch('u_colorMode'),
+            palette: fetch('u_palette'),
+            paletteSize: fetch('u_paletteSize'),
+            gradientType: fetch('u_gradientType'),
+            gradientPhase: fetch('u_gradientPhase'),
+            colorReactivity: fetch('u_colorReactivity'),
+            bass: fetch('u_bass'),
+            mid: fetch('u_mid'),
+            high: fetch('u_high')
+        };
+    }
+
+    resize() {
+        if (!this.canvas || !this.gl) return;
+        const dpr = window.devicePixelRatio || 1;
+        const width = this.canvas.clientWidth * dpr;
+        const height = this.canvas.clientHeight * dpr;
+
+        if (this.canvas.width !== width || this.canvas.height !== height) {
+            this.canvas.width = width;
+            this.canvas.height = height;
+        }
+
+        this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    updateParameters(params = {}) {
+        Object.assign(this.params, params);
+    }
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels();
+        }
+
+        return window.audioReactive || null;
+    }
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    prepareColorUniforms(colorState) {
+        const buffer = this.colorUniformBuffer;
+        buffer.fill(0);
+
+        let paletteSize = 0;
+        if (colorState?.uniforms?.palette && Array.isArray(colorState.uniforms.palette)) {
+            const palette = colorState.uniforms.palette;
+            paletteSize = Math.min(palette.length, 4);
+            for (let i = 0; i < paletteSize; i += 1) {
+                const color = palette[i] || [0, 0, 0];
+                const offset = i * 3;
+                buffer[offset] = color[0] ?? 0;
+                buffer[offset + 1] = color[1] ?? 0;
+                buffer[offset + 2] = color[2] ?? 0;
+            }
+        }
+
+        const gradientTypeKey = colorState?.gradient?.type || this.params.gradientType || 'horizontal';
+        const gradientType = GRADIENT_TYPE_MAP[gradientTypeKey] ?? GRADIENT_TYPE_MAP.horizontal;
+        const gradientPhase = typeof colorState?.gradient?.phase === 'number'
+            ? colorState.gradient.phase
+            : 0;
+        const modeKey = colorState?.mode || this.params.colorMode || 'single';
+        const mode = COLOR_MODE_MAP[modeKey] ?? COLOR_MODE_MAP.single;
+
+        this.colorUniformState.mode = mode;
+        this.colorUniformState.paletteSize = paletteSize;
+        this.colorUniformState.gradientType = gradientType;
+        this.colorUniformState.gradientPhase = gradientPhase;
+
+        return this.colorUniformState;
+    }
+
+    applyColorUniforms(uniformState) {
+        if (!this.gl || !this.uniforms) return;
+
+        if (this.uniforms.colorMode) {
+            this.gl.uniform1i(this.uniforms.colorMode, uniformState.mode);
+        }
+        if (this.uniforms.palette) {
+            this.gl.uniform3fv(this.uniforms.palette, this.colorUniformBuffer);
+        }
+        if (this.uniforms.paletteSize) {
+            this.gl.uniform1i(this.uniforms.paletteSize, uniformState.paletteSize);
+        }
+        if (this.uniforms.gradientType) {
+            this.gl.uniform1i(this.uniforms.gradientType, uniformState.gradientType);
+        }
+        if (this.uniforms.gradientPhase) {
+            this.gl.uniform1f(this.uniforms.gradientPhase, uniformState.gradientPhase);
+        }
+    }
+
+    updateAudioResponse(audioState) {
+        if (!audioState) {
+            this.audioResponse.bass *= 0.9;
+            this.audioResponse.mid *= 0.9;
+            this.audioResponse.high *= 0.9;
+            this.audioResponse.energy *= 0.9;
+            return this.audioResponse;
+        }
+
+        const bands = audioState.bands || audioState;
+        const targetBass = bands?.bass?.value ?? bands?.bass ?? 0;
+        const targetMid = bands?.mid?.value ?? bands?.mid ?? 0;
+        const targetHigh = bands?.high?.value ?? bands?.high ?? 0;
+        const targetEnergy = audioState.energy ?? audioState.rms ?? 0;
+
+        const smooth = this.audioSmoothing;
+        this.audioResponse.bass += (targetBass - this.audioResponse.bass) * smooth;
+        this.audioResponse.mid += (targetMid - this.audioResponse.mid) * smooth;
+        this.audioResponse.high += (targetHigh - this.audioResponse.high) * smooth;
+        this.audioResponse.energy += (targetEnergy - this.audioResponse.energy) * smooth;
+
+        return this.audioResponse;
+    }
+
+    render() {
+        if (!this.gl || !this.program) {
+            return;
+        }
+
+        this.resize();
+        this.gl.useProgram(this.program);
+        this.gl.enable(this.gl.BLEND);
+        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
+
+        this.time += 16;
+        const elapsed = Date.now() - this.startTime;
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+        const colorUniforms = this.prepareColorUniforms(colorState);
+
+        const params = this.params;
+        let hueDegrees = typeof params.hue === 'number' ? params.hue : DEFAULT_PARAMS.hue;
+        let saturation = params.saturation ?? DEFAULT_PARAMS.saturation;
+        let intensity = params.intensity ?? DEFAULT_PARAMS.intensity;
+
+        if (colorState?.primary) {
+            hueDegrees = colorState.primary.h;
+            saturation = Math.max(saturation, colorState.primary.s);
+            intensity = Math.max(intensity, colorState.primary.v);
+        }
+
+        if (colorState?.accent) {
+            saturation = Math.max(saturation, colorState.accent.s * 0.85);
+        }
+
+        const hue = (hueDegrees % 360 + 360) % 360;
+        const colorReactivity = typeof params.colorReactivity === 'number'
+            ? params.colorReactivity
+            : DEFAULT_PARAMS.colorReactivity;
+
+        this.gl.uniform2f(this.uniforms.resolution, this.canvas.width, this.canvas.height);
+        this.gl.uniform1f(this.uniforms.time, elapsed);
+        this.gl.uniform1f(this.uniforms.geometry, params.geometry ?? 0);
+        this.gl.uniform1f(this.uniforms.rot4dXW, params.rot4dXW ?? 0);
+        this.gl.uniform1f(this.uniforms.rot4dYW, params.rot4dYW ?? 0);
+        this.gl.uniform1f(this.uniforms.rot4dZW, params.rot4dZW ?? 0);
+        this.gl.uniform1f(this.uniforms.gridDensity, params.gridDensity ?? DEFAULT_PARAMS.gridDensity);
+        this.gl.uniform1f(this.uniforms.morphFactor, params.morphFactor ?? DEFAULT_PARAMS.morphFactor);
+        this.gl.uniform1f(this.uniforms.chaos, params.chaos ?? DEFAULT_PARAMS.chaos);
+        this.gl.uniform1f(this.uniforms.speed, params.speed ?? DEFAULT_PARAMS.speed);
+        this.gl.uniform1f(this.uniforms.hue, hue);
+        this.gl.uniform1f(this.uniforms.intensity, intensity);
+        this.gl.uniform1f(this.uniforms.saturation, saturation);
+        this.gl.uniform1f(this.uniforms.layerIntensity, this.layerIntensity);
+        this.gl.uniform1f(this.uniforms.layerScale, this.layerScale);
+        this.gl.uniform3fv(this.uniforms.layerColor, this.layerColor);
+        this.gl.uniform1f(this.uniforms.colorReactivity, colorReactivity);
+        this.gl.uniform1f(this.uniforms.bass, audioResponse.bass || 0);
+        this.gl.uniform1f(this.uniforms.mid, audioResponse.mid || 0);
+        this.gl.uniform1f(this.uniforms.high, audioResponse.high || 0);
+
+        this.applyColorUniforms(colorUniforms);
+
+        if (this.vertexBuffer) {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        }
+
+        this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
+    }
+
+    cleanup() {
+        window.removeEventListener('resize', this.handleResize);
+        if (!this.gl) return;
+
+        if (this.vertexBuffer) {
+            this.gl.deleteBuffer(this.vertexBuffer);
+            this.vertexBuffer = null;
+        }
+
+        if (this.program) {
+            this.gl.deleteProgram(this.program);
+            this.program = null;
+        }
+
+        if (this.vertexShader) {
+            this.gl.deleteShader(this.vertexShader);
+            this.vertexShader = null;
+        }
+
+        if (this.fragmentShader) {
+            this.gl.deleteShader(this.fragmentShader);
+            this.fragmentShader = null;
+        }
+    }
+}

--- a/src/systems/faceted/FacetedSystem.js
+++ b/src/systems/faceted/FacetedSystem.js
@@ -1,0 +1,80 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { VIB34DIntegratedEngine } from '../../core/Engine.js';
+
+const FACETED_LAYERS = [
+    { id: 'background-canvas', role: 'background' },
+    { id: 'shadow-canvas', role: 'shadow' },
+    { id: 'content-canvas', role: 'content' },
+    { id: 'highlight-canvas', role: 'highlight' },
+    { id: 'accent-canvas', role: 'accent' }
+];
+
+export class FacetedSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'faceted',
+            name: 'Faceted Holographic Grid',
+            description: 'Five-layer holographic renderer with polychora geometry',
+            canvas: FACETED_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new VIB34DIntegratedEngine();
+        if (typeof window !== 'undefined') {
+            window.engine = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.engine = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+
+        if (typeof this.engine.stopRenderLoop === 'function') {
+            try {
+                this.engine.stopRenderLoop();
+            } catch (error) {
+                console.warn('[FacetedSystem] Failed to stop render loop', error);
+            }
+        }
+
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.engine === this.engine) {
+                window.engine = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.engine === this.engine) {
+            window.engine = null;
+        }
+    }
+}

--- a/src/systems/holographic/HolographicSystem.js
+++ b/src/systems/holographic/HolographicSystem.js
@@ -1,0 +1,71 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { RealHolographicSystem } from '../../holograms/RealHolographicSystem.js';
+
+const HOLOGRAPHIC_LAYERS = [
+    { id: 'holo-background-canvas', role: 'background' },
+    { id: 'holo-shadow-canvas', role: 'shadow' },
+    { id: 'holo-content-canvas', role: 'content' },
+    { id: 'holo-highlight-canvas', role: 'highlight' },
+    { id: 'holo-accent-canvas', role: 'accent' }
+];
+
+export class HolographicSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'holographic',
+            name: 'Real Holographic System',
+            description: 'Multi-layer holographic renderer with active variant catalog',
+            canvas: HOLOGRAPHIC_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new RealHolographicSystem();
+        if (typeof window !== 'undefined') {
+            window.holographicSystem = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.holographicSystem = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.holographicSystem === this.engine) {
+                window.holographicSystem = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.holographicSystem === this.engine) {
+            window.holographicSystem = null;
+        }
+    }
+}

--- a/src/systems/polychora/PolychoraSystem.js
+++ b/src/systems/polychora/PolychoraSystem.js
@@ -1,0 +1,71 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { PolychoraEngine } from '../../polychora/PolychoraEngine.js';
+
+const POLYCHORA_LAYERS = [
+    { id: 'polychora-background-canvas', role: 'background' },
+    { id: 'polychora-shadow-canvas', role: 'shadow' },
+    { id: 'polychora-content-canvas', role: 'content' },
+    { id: 'polychora-highlight-canvas', role: 'highlight' },
+    { id: 'polychora-accent-canvas', role: 'accent' }
+];
+
+export class PolychoraSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'polychora',
+            name: 'Polychora 4D Engine',
+            description: 'True 4D polytope renderer with advanced color + audio integration',
+            canvas: POLYCHORA_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new PolychoraEngine();
+        if (typeof window !== 'undefined') {
+            window.polychoraSystem = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.polychoraSystem = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.polychoraSystem === this.engine) {
+                window.polychoraSystem = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.polychoraSystem === this.engine) {
+            window.polychoraSystem = null;
+        }
+    }
+}

--- a/src/systems/quantum/QuantumSystem.js
+++ b/src/systems/quantum/QuantumSystem.js
@@ -1,0 +1,71 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { QuantumEngine } from '../../quantum/QuantumEngine.js';
+
+const QUANTUM_LAYERS = [
+    { id: 'quantum-background-canvas', role: 'background' },
+    { id: 'quantum-shadow-canvas', role: 'shadow' },
+    { id: 'quantum-content-canvas', role: 'content' },
+    { id: 'quantum-highlight-canvas', role: 'highlight' },
+    { id: 'quantum-accent-canvas', role: 'accent' }
+];
+
+export class QuantumSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'quantum',
+            name: 'Quantum Lattice Engine',
+            description: 'Volumetric quantum renderer with lattice fields and higher dimensional rotations',
+            canvas: QUANTUM_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new QuantumEngine();
+        if (typeof window !== 'undefined') {
+            window.quantumEngine = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.quantumEngine = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.quantumEngine === this.engine) {
+                window.quantumEngine = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.quantumEngine === this.engine) {
+            window.quantumEngine = null;
+        }
+    }
+}

--- a/src/systems/shared/BaseSystem.js
+++ b/src/systems/shared/BaseSystem.js
@@ -1,0 +1,218 @@
+/**
+ * BaseSystem - foundational lifecycle for all visualization engines
+ * Handles canvas creation, engine initialization, activation, and teardown
+ */
+
+export class BaseSystem {
+    constructor(config = {}) {
+        if (!config.key) {
+            throw new Error('BaseSystem requires a unique `key` identifier');
+        }
+
+        this.key = config.key;
+        this.name = config.name || config.key;
+        this.description = config.description || '';
+        this.canvasConfig = Array.isArray(config.canvas) ? config.canvas : [];
+        this.autoResize = config.autoResize !== false;
+        this.containerId = config.containerId || null;
+        this.metadata = config.metadata || {};
+
+        this.container = null;
+        this.canvasElements = [];
+        this.engine = null;
+        this.canvasManager = null;
+        this.isActive = false;
+        this.isInitialized = false;
+    }
+
+    /**
+     * Initialize the system with a container. Subclasses can override onInitialize
+     */
+    async initialize(options = {}) {
+        if (this.isInitialized) {
+            return;
+        }
+
+        const container = this.#resolveContainer(options.container || options.containerId || this.containerId);
+        if (!container) {
+            throw new Error(`[BaseSystem:${this.key}] Visualization container not found`);
+        }
+
+        this.container = container;
+        if (typeof this.onInitialize === 'function') {
+            await this.onInitialize(options);
+        }
+
+        this.isInitialized = true;
+    }
+
+    /**
+     * Activate the system, creating canvases and booting the engine
+     */
+    async activate(options = {}) {
+        const container = this.#resolveContainer(options.container || options.containerId || this.containerId);
+        if (!container) {
+            throw new Error(`[BaseSystem:${this.key}] Cannot activate without a container element`);
+        }
+
+        this.container = container;
+
+        if (!this.isInitialized) {
+            await this.initialize({ ...options, container });
+        }
+
+        this.#createCanvasElements(options);
+
+        this.engine = await this.createEngine(options) || null;
+        if (this.engine && typeof this.engine === 'object') {
+            this.canvasManager = this.engine.canvasManager || null;
+        }
+
+        if (typeof this.onAfterEngineCreated === 'function') {
+            await this.onAfterEngineCreated(options);
+        }
+
+        if (typeof this.onActivate === 'function') {
+            await this.onActivate(options);
+        }
+
+        this.isActive = true;
+        return this;
+    }
+
+    /**
+     * Deactivate the system without discarding initialization metadata
+     */
+    async deactivate(options = {}) {
+        if (!this.isActive) {
+            return this;
+        }
+
+        if (typeof this.onDeactivate === 'function') {
+            await this.onDeactivate(options);
+        }
+
+        await this.destroyEngine();
+
+        this.isActive = false;
+        return this;
+    }
+
+    /**
+     * Fully destroy the system (engine + canvases)
+     */
+    async destroy(options = {}) {
+        await this.deactivate(options);
+
+        this.#removeCanvasElements();
+
+        if (typeof this.onDestroy === 'function') {
+            await this.onDestroy(options);
+        }
+
+        this.container = null;
+        this.isInitialized = false;
+        return this;
+    }
+
+    /**
+     * Subclasses override to create their engine instance
+     */
+    async createEngine(options = {}) {
+        if (typeof this.onCreateEngine === 'function') {
+            return this.onCreateEngine(options);
+        }
+        return null;
+    }
+
+    /**
+     * Destroy the engine instance safely
+     */
+    async destroyEngine() {
+        if (this.engine && typeof this.engine.destroy === 'function') {
+            try {
+                this.engine.destroy();
+            } catch (error) {
+                console.warn(`[BaseSystem:${this.key}] Failed to destroy engine`, error);
+            }
+        }
+
+        this.engine = null;
+        this.canvasManager = null;
+    }
+
+    /**
+     * Create canvas elements for each configured layer
+     */
+    #createCanvasElements(options = {}) {
+        if (!this.container) return;
+
+        const layerClass = options.layerClass || 'system-layer';
+        const canvases = [];
+        const width = this.container.clientWidth || window.innerWidth;
+        const height = this.container.clientHeight || window.innerHeight;
+
+        this.canvasConfig.forEach((layer, index) => {
+            const id = layer.id || `${this.key}-layer-${index}`;
+            const safeId = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function')
+                ? CSS.escape(id)
+                : id.replace(/[^a-zA-Z0-9_-]/g, '_');
+            const existing = this.container.querySelector(`#${safeId}`);
+            if (existing) {
+                existing.remove();
+            }
+
+            const element = document.createElement(layer.tag || 'canvas');
+            element.id = id;
+            element.className = layer.className || layerClass;
+            if (layer.role) {
+                element.dataset.role = layer.role;
+            }
+
+            this.container.appendChild(element);
+
+            if (this.autoResize && typeof HTMLCanvasElement !== 'undefined' && element instanceof HTMLCanvasElement) {
+                element.width = width;
+                element.height = height;
+            }
+
+            canvases.push(element);
+        });
+
+        this.canvasElements = canvases;
+    }
+
+    /**
+     * Remove managed canvas elements from the DOM
+     */
+    #removeCanvasElements() {
+        if (!Array.isArray(this.canvasElements)) return;
+
+        this.canvasElements.forEach(canvas => {
+            if (canvas && canvas.parentElement) {
+                canvas.parentElement.removeChild(canvas);
+            }
+        });
+
+        this.canvasElements = [];
+    }
+
+    /**
+     * Resolve container element from selector, element, or default id
+     */
+    #resolveContainer(target) {
+        if (!target) {
+            return this.container || (this.containerId ? document.getElementById(this.containerId) : null);
+        }
+
+        if (typeof target === 'string') {
+            return document.getElementById(target) || document.querySelector(target);
+        }
+
+        if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+            return target;
+        }
+
+        return null;
+    }
+}

--- a/src/systems/shared/BaseVisualizer.js
+++ b/src/systems/shared/BaseVisualizer.js
@@ -1,0 +1,49 @@
+/**
+ * BaseVisualizer - shared interface for WebGL / Canvas visualizers
+ */
+
+export class BaseVisualizer {
+    constructor(config = {}) {
+        this.id = config.id || null;
+        this.role = config.role || 'content';
+        this.reactivity = config.reactivity ?? 1.0;
+        this.canvas = null;
+        this.gl = null;
+        this.contextType = config.contextType || 'webgl2';
+        this.isInitialized = false;
+    }
+
+    /**
+     * Resolve canvas and acquire rendering context
+     */
+    initializeCanvas() {
+        if (!this.id) {
+            throw new Error('BaseVisualizer requires a canvas id');
+        }
+
+        const canvas = document.getElementById(this.id);
+        if (!canvas) {
+            throw new Error(`BaseVisualizer could not find canvas with id ${this.id}`);
+        }
+
+        this.canvas = canvas;
+        this.gl = canvas.getContext(this.contextType) || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+        this.isInitialized = true;
+        return this.gl;
+    }
+
+    /** Override in subclasses */
+    updateFromAudio(_audioState) {}
+
+    /** Override in subclasses */
+    updateParameters(_params) {}
+
+    /** Override in subclasses */
+    render(_time) {}
+
+    destroy() {
+        this.canvas = null;
+        this.gl = null;
+        this.isInitialized = false;
+    }
+}

--- a/src/systems/shared/SystemAccess.js
+++ b/src/systems/shared/SystemAccess.js
@@ -1,0 +1,208 @@
+/**
+ * SystemAccess - shared helpers for working with the global SystemRegistry.
+ * Provides a single source of truth for resolving the active system, engine,
+ * and parameter manager so UI/export/timeline layers stay in sync.
+ */
+
+let registryRef = null;
+let registryUnsubscribe = null;
+let activeDescriptor = {
+    key: null,
+    system: null,
+    metadata: null
+};
+
+function toEngine(systemInstance) {
+    if (!systemInstance || typeof systemInstance !== 'object') {
+        return null;
+    }
+    if (systemInstance.engine && typeof systemInstance.engine === 'object') {
+        return systemInstance.engine;
+    }
+    return null;
+}
+
+function updateActiveDescriptor({ key = null, system = null, metadata = null } = {}) {
+    activeDescriptor = {
+        key,
+        system,
+        metadata
+    };
+
+    const engine = toEngine(system);
+    if (typeof window !== 'undefined') {
+        if (key) {
+            window.currentSystem = key;
+        }
+        if (engine) {
+            window.currentSystemEngine = engine;
+        }
+        if (engine?.parameterManager) {
+            window.parameterManager = engine.parameterManager;
+            window.activeParameterManager = engine.parameterManager;
+        } else if (window.activeParameterManager && key === null) {
+            window.activeParameterManager = null;
+        }
+
+        window.getActiveSystemEngine = getActiveEngine;
+        window.getActiveParameterManager = getActiveParameterManager;
+        window.getActiveSystemKey = getActiveSystemKey;
+        window.getActiveParameterSnapshot = getActiveParameterSnapshot;
+    }
+}
+
+function ensureRegistryListeners(registry) {
+    if (!registry || typeof registry.onChange !== 'function') {
+        return;
+    }
+
+    if (typeof registryUnsubscribe === 'function') {
+        try {
+            registryUnsubscribe();
+        } catch (error) {
+            console.warn('[SystemAccess] Failed to remove previous registry listener', error);
+        }
+        registryUnsubscribe = null;
+    }
+
+    registryUnsubscribe = registry.onChange(({ key, system, metadata }) => {
+        updateActiveDescriptor({ key, system, metadata });
+    });
+
+    if (typeof registry.getActiveKey === 'function') {
+        const key = registry.getActiveKey();
+        const system = typeof registry.getActiveSystem === 'function'
+            ? registry.getActiveSystem()
+            : null;
+        updateActiveDescriptor({ key, system, metadata: null });
+    }
+}
+
+export function registerSystemRegistry(registry) {
+    if (!registry) {
+        return null;
+    }
+
+    registryRef = registry;
+
+    if (typeof window !== 'undefined') {
+        window.systemRegistry = registry;
+        window.getSystemRegistry = getSystemRegistry;
+    }
+
+    ensureRegistryListeners(registry);
+    return registry;
+}
+
+export function getSystemRegistry() {
+    return registryRef || (typeof window !== 'undefined' ? window.systemRegistry || null : null);
+}
+
+export function syncActiveSystemState() {
+    const registry = getSystemRegistry();
+    if (!registry) {
+        updateActiveDescriptor({ key: window?.currentSystem ?? null, system: null, metadata: null });
+        return;
+    }
+
+    const key = typeof registry.getActiveKey === 'function' ? registry.getActiveKey() : null;
+    const system = typeof registry.getActiveSystem === 'function' ? registry.getActiveSystem() : null;
+    updateActiveDescriptor({ key, system, metadata: null });
+}
+
+export function onRegistryChange(callback, { emitCurrent = true } = {}) {
+    const registry = getSystemRegistry();
+    if (!registry || typeof registry.onChange !== 'function' || typeof callback !== 'function') {
+        return () => {};
+    }
+
+    const unsubscribe = registry.onChange(callback);
+    if (emitCurrent) {
+        const key = getActiveSystemKey();
+        const system = getActiveSystem();
+        if (key || system) {
+            callback({ key, system, metadata: activeDescriptor.metadata });
+        }
+    }
+    return unsubscribe;
+}
+
+export function getActiveSystemKey() {
+    if (activeDescriptor.key) {
+        return activeDescriptor.key;
+    }
+    if (typeof window !== 'undefined' && typeof window.currentSystem === 'string') {
+        return window.currentSystem;
+    }
+    const registry = getSystemRegistry();
+    if (registry && typeof registry.getActiveKey === 'function') {
+        return registry.getActiveKey();
+    }
+    return null;
+}
+
+export function getActiveSystem() {
+    if (activeDescriptor.system) {
+        return activeDescriptor.system;
+    }
+    const registry = getSystemRegistry();
+    if (registry && typeof registry.getActiveSystem === 'function') {
+        return registry.getActiveSystem();
+    }
+    return null;
+}
+
+export function getActiveEngine() {
+    const system = getActiveSystem();
+    const engine = toEngine(system);
+    if (engine) {
+        return engine;
+    }
+    if (typeof window !== 'undefined') {
+        return window.currentSystemEngine || window.engine || null;
+    }
+    return null;
+}
+
+export function getActiveParameterManager() {
+    const engine = getActiveEngine();
+    if (engine?.parameterManager) {
+        return engine.parameterManager;
+    }
+    if (typeof window !== 'undefined') {
+        return window.activeParameterManager || window.parameterManager || null;
+    }
+    return null;
+}
+
+export function getActiveParameterSnapshot() {
+    const manager = getActiveParameterManager();
+    if (manager?.getAllParameters) {
+        try {
+            return manager.getAllParameters();
+        } catch (error) {
+            console.warn('[SystemAccess] Active parameter manager snapshot failed', error);
+        }
+    }
+
+    const engine = getActiveEngine();
+    if (engine?.getParameters) {
+        try {
+            return engine.getParameters();
+        } catch (error) {
+            console.warn('[SystemAccess] Active engine parameter snapshot failed', error);
+        }
+    }
+
+    return null;
+}
+
+export function hasSystemRegistry() {
+    return !!getSystemRegistry();
+}
+
+// Initialize from window globals if they already exist (e.g., legacy pages)
+if (typeof window !== 'undefined' && window.systemRegistry) {
+    registerSystemRegistry(window.systemRegistry);
+    syncActiveSystemState();
+}

--- a/src/systems/shared/SystemRegistry.js
+++ b/src/systems/shared/SystemRegistry.js
@@ -1,0 +1,188 @@
+/**
+ * SystemRegistry - orchestrates BaseSystem lifecycles and switching
+ */
+
+export class SystemRegistry {
+    constructor(options = {}) {
+        this.containerId = options.containerId || null;
+        this.container = this.#resolveContainer(options.container || this.containerId);
+        this.autoClear = options.autoClear !== false;
+        this.destroyOnSwitch = options.destroyOnSwitch !== false;
+
+        this.systems = new Map(); // key => { factory, instance, metadata }
+        this.activeKey = null;
+        this.listeners = new Set();
+    }
+
+    register(key, factory, metadata = {}) {
+        if (!key) {
+            throw new Error('SystemRegistry.register requires a unique key');
+        }
+        if (typeof factory !== 'function') {
+            throw new Error(`SystemRegistry.register(${key}) requires a factory function`);
+        }
+
+        this.systems.set(key, {
+            factory,
+            instance: null,
+            metadata
+        });
+    }
+
+    has(key) {
+        return this.systems.has(key);
+    }
+
+    getActiveKey() {
+        return this.activeKey;
+    }
+
+    getActiveSystem() {
+        const entry = this.activeKey ? this.systems.get(this.activeKey) : null;
+        return entry?.instance || null;
+    }
+
+    onChange(callback) {
+        if (typeof callback === 'function') {
+            this.listeners.add(callback);
+        }
+        return () => this.listeners.delete(callback);
+    }
+
+    async activate(key, options = {}) {
+        if (!this.systems.has(key)) {
+            throw new Error(`SystemRegistry could not find system: ${key}`);
+        }
+
+        const entry = this.systems.get(key);
+        const container = this.#prepareContainer(options);
+
+        if (this.activeKey && this.activeKey !== key) {
+            await this.#deactivateCurrent({ reason: 'switch', next: key });
+        }
+
+        if (this.autoClear && container && options.clearContainer !== false) {
+            container.innerHTML = '';
+        }
+
+        const system = await this.#ensureInstance(entry, { container });
+        await system.activate({ ...options, container });
+
+        this.activeKey = key;
+        if (typeof window !== 'undefined') {
+            window.currentSystem = key;
+            window.currentSystemEngine = system.engine || null;
+        }
+
+        this.listeners.forEach(listener => {
+            try {
+                listener({ key, system, metadata: entry.metadata });
+            } catch (error) {
+                console.warn('[SystemRegistry] listener error', error);
+            }
+        });
+
+        return system;
+    }
+
+    async deactivate(key, options = {}) {
+        if (!this.systems.has(key)) return;
+        const entry = this.systems.get(key);
+        if (!entry.instance) return;
+
+        await entry.instance.deactivate({ ...options, reason: options.reason || 'manual' });
+        if (this.destroyOnSwitch || options.destroy !== false) {
+            await entry.instance.destroy({ ...options, reason: options.reason || 'manual' });
+            entry.instance = null;
+        }
+
+        if (this.activeKey === key) {
+            this.activeKey = null;
+            if (typeof window !== 'undefined' && window.currentSystem === key) {
+                window.currentSystem = null;
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async destroyAll(options = {}) {
+        const keys = Array.from(this.systems.keys());
+        for (const key of keys) {
+            await this.deactivate(key, { ...options, destroy: true, reason: 'registry-destroy' });
+        }
+        this.systems.clear();
+        this.activeKey = null;
+    }
+
+    #resolveContainer(target) {
+        if (!target) return null;
+        if (typeof target === 'string') {
+            return document.getElementById(target) || document.querySelector(target);
+        }
+        if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+            return target;
+        }
+        return null;
+    }
+
+    #prepareContainer(options = {}) {
+        if (options.container) {
+            return options.container;
+        }
+
+        if (!this.container || options.containerId) {
+            this.container = this.#resolveContainer(options.containerId || this.containerId);
+        }
+
+        if (!this.container) {
+            this.container = this.#resolveContainer('vib34dLayers');
+        }
+
+        if (!this.container) {
+            throw new Error('SystemRegistry could not resolve a visualization container');
+        }
+
+        return this.container;
+    }
+
+    async #ensureInstance(entry, context = {}) {
+        if (entry.instance) {
+            return entry.instance;
+        }
+
+        const instance = await entry.factory({ metadata: entry.metadata, container: context.container });
+        if (!instance) {
+            throw new Error('SystemRegistry factory did not return a system instance');
+        }
+
+        if (context.container) {
+            await instance.initialize({ container: context.container });
+        }
+
+        entry.instance = instance;
+        return instance;
+    }
+
+    async #deactivateCurrent(options = {}) {
+        if (!this.activeKey) return;
+        const currentKey = this.activeKey;
+        const currentEntry = this.systems.get(currentKey);
+        if (!currentEntry?.instance) {
+            this.activeKey = null;
+            return;
+        }
+
+        await currentEntry.instance.deactivate({ reason: options.reason || 'switch', nextSystem: options.next });
+        if (this.destroyOnSwitch) {
+            await currentEntry.instance.destroy({ reason: options.reason || 'switch', nextSystem: options.next });
+            currentEntry.instance = null;
+        }
+
+        if (typeof window !== 'undefined' && window.currentSystem === currentKey) {
+            window.currentSystem = null;
+            window.currentSystemEngine = null;
+        }
+
+        this.activeKey = null;
+    }
+}


### PR DESCRIPTION
## Summary
- extend the advanced audio engine with media-element attachment so analyzer, color, and mapping pipelines can drive imported tracks without microphone access
- rewire the MusicVideoChoreographer to subscribe to the shared analyzer output, fall back to the legacy analyser only when needed, and surface richer beat/energy telemetry in the UI
- document the playback integration milestone inside the unified refactor plan's audio section

## Testing
- npm test *(fails: playwright: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e8cb2e8c8329811e9f0b4c6836c9