### PR TITLE
Finish metadata-driven timeline defaults and add UI test

### DIFF
--- a/UNIFIED-REFACTOR-PLAN.md
+++ b/UNIFIED-REFACTOR-PLAN.md
@@ -1,0 +1,743 @@
+# 🎯 VIB34D MUSIC CHOREOGRAPHER - UNIFIED REFACTORING PLAN
+
+**Date**: October 5, 2025
+**Objective**: Refactor multiple systems together, make elegant, expand colors and audio reactivity
+
+---
+
+## 📊 REPOSITORY ANALYSIS COMPLETE
+
+### **Branch Structure:**
+```
+* html-versions-catalog (current)
+  - Contains comprehensive HTML versions catalog at versions-index.html
+  - Latest commit: "🌟 Add comprehensive HTML versions catalog"
+
+* main / origin/main
+  - Primary development branch
+  - Latest: "🎥 PROPER FIX: Composite canvas for export with smart system switching"
+
+* v3-professional
+  - Advanced audio-visual system experimentation
+  - NOT YET MERGED
+
+* music-video-choreographer-refactor (remote)
+  - Previous refactoring attempt
+  - Useful learnings in branch history
+```
+
+### **Key Files Count:**
+- **14 index-*.html variants** (514-3526 lines each)
+- **57 JavaScript modules** in src/
+- **3 visualization engines**: Faceted, Quantum, Holographic
+- **1 specialized system**: Polychora (4D mathematics)
+
+---
+
+## 🔍 CURRENT SYSTEM INVENTORY
+
+### **INDEX.HTML VARIANTS ANALYSIS:**
+
+| File | Lines | Purpose | Status |
+|------|-------|---------|--------|
+| **index-MASTER.html** | 678 | Beat-synced choreography + manual sequences + video export | ✅ WORKING |
+| **index-ULTIMATE-V2.html** | 645 | Musical timing with 4D rotation focus | ✅ WORKING |
+| **index-ULTIMATE.html** | 514 | Original AI choreography system | ✅ WORKING |
+| **index-WORKING-GOLD.html** | 3526 | Full features + reactivity (original backup) | ✅ ARCHIVE |
+| **index-enhanced.html** | 2225 | Enhanced UI + features | ⚠️ LEGACY |
+| **index-working-simple.html** | 1070 | Hybrid mode + timeline | ✅ USEFUL |
+| **index-FINAL.html** | 812 | Simplified choreographer | ✅ CLEAN |
+| **index-ULTRA.html** | 813 | Ultra version (experimental) | ⚠️ EXPERIMENTAL |
+
+**BEST VERSIONS IDENTIFIED:**
+1. **index-MASTER.html** - Most complete, working export, beat sync
+2. **index-ULTIMATE-V2.html** - Best 4D rotation usage, musical timing
+3. **index-working-simple.html** - Clean hybrid mode implementation
+
+---
+
+## 🎨 SOURCE ARCHITECTURE ANALYSIS
+
+### **Current Module Structure:**
+```
+src/
+├── core/ (14 files)
+│   ├── Engine.js                    // Faceted system
+│   ├── Visualizer.js                // Faceted visualizer (GLSL shaders)
+│   ├── ParameterMapper.js           // V3 advanced mapping (INCOMPLETE)
+│   ├── Parameters.js                // Parameter definitions + validation
+│   ├── CanvasManager.js             // Canvas lifecycle management
+│   ├── ReactivityManager.js         // Mouse/touch/scroll interactions
+│   └── UnifiedEngine.js             // Attempted unification (partial)
+│
+├── quantum/ (2 files)
+│   ├── QuantumEngine.js             // Complex 3D system
+│   └── QuantumVisualizer.js         // Advanced GLSL with volumetric lighting
+│
+├── holograms/ (6 files)
+│   ├── RealHolographicSystem.js     // Audio-reactive system
+│   ├── HolographicVisualizer.js     // Core holographic rendering
+│   ├── ActiveHolographicSystem.js   // Enhanced version
+│   └── HolographicSystem.js         // Legacy version
+│
+├── core/PolychoraSystem.js          // 4D polytope mathematics
+│
+├── export/ (15 files)
+│   └── Trading card + video export systems (per-engine variants)
+│
+├── audio/
+│   ├── AudioAnalyzer.js           // ✅ Implemented: 7-band + spectral analysis
+│   ├── ADSREnvelope.js            // ✅ Implemented: ADSR smoothing utilities
+│   └── ParameterMapper.js         // ✅ Implemented: audio-to-parameter routing
+│
+├── color/
+│   └── ColorSystem.js             // ✅ Implemented: palettes, gradients, reactive blending
+│
+└── geometry/
+    └── GeometryLibrary.js           // 8 geometry types shared
+```
+
+Supporting modules:
+- `js/audio/audio-engine.js` // ✅ AdvancedAudioEngine wiring analyzer → global state + color pipeline bridge
+- `window.colorState` // ✅ Shared color palette + gradient state exposed for visualizers/UI
+
+### **🚨 CRITICAL ARCHITECTURE PROBLEMS:**
+1. **INCONSISTENT INTERFACES**: Each system has different initialization patterns
+2. **NO UNIFIED PARAMETER SYSTEM**: 3 different parameter management approaches
+3. **DUPLICATE VISUALIZERS**: Multiple versions of Holographic system
+4. **LEGACY V3 GAPS**: Systems still need to adopt the new AudioAnalyzer + ParameterMapper pipeline
+5. **COLOR SYSTEM INTEGRATION**: New ColorSystem drives palettes + gradients, but shaders/UI still need full adoption
+6. **AUDIO INTEGRATION DRIFT**: Advanced analyzer now powers the global engine, but each visualization still needs bespoke mappings
+
+---
+
+## 🎯 UNIFIED REFACTORING GOALS
+
+### **1. ELEGANT SYSTEM ARCHITECTURE**
+
+Create **BaseSystem** interface that all engines implement:
+```javascript
+class BaseSystem {
+    constructor(config) {
+        this.name = config.name;
+        this.type = config.type; // 'faceted'|'quantum'|'holographic'|'polychora'
+        this.canvas = null;
+        this.visualizer = null;
+        this.parameters = new UnifiedParameters();
+        this.interactions = new UnifiedInteractions();
+    }
+
+    async initialize() {
+        // Standard init sequence
+        await this.createCanvas();
+        await this.createVisualizer();
+        await this.setupInteractions();
+        await this.setupAudio();
+    }
+
+    updateParameter(name, value) {
+        // Unified parameter update
+    }
+
+    render() {
+        // Unified render loop
+    }
+
+    destroy() {
+        // Proper cleanup
+    }
+}
+```
+
+**Benefits:**
+- ✅ Switch between systems with identical API
+- ✅ Predictable behavior across all engines
+- ✅ Easy to add new visualization systems
+- ✅ Clean separation of concerns
+
+---
+
+### **2. ADVANCED COLOR SYSTEM**
+
+**Current Limitation**: Single hue parameter (0-360)
+
+**New Color Architecture:**
+```javascript
+class ColorSystem {
+    constructor() {
+        // Multiple color modes
+        this.modes = {
+            single: this.singleHue,
+            dual: this.dualHue,
+            triad: this.triadHue,
+            complementary: this.complementaryHue,
+            analogous: this.analogousHue,
+            palette: this.paletteMode,
+            gradient: this.gradientMode,
+            reactive: this.audioReactiveMode
+        };
+
+        // Color palettes
+        this.palettes = {
+            vaporwave: ['#ff71ce', '#01cdfe', '#05ffa1', '#b967ff'],
+            cyberpunk: ['#ff006e', '#fb5607', '#ffbe0b', '#8338ec'],
+            synthwave: ['#f72585', '#7209b7', '#3a0ca3', '#4361ee'],
+            holographic: ['#ff00ff', '#00ffff', '#ff00aa', '#00aaff'],
+            neon: ['#fe00fe', '#00fefe', '#fefe00', '#00fe00'],
+            fire: ['#ff0000', '#ff4400', '#ff8800', '#ffcc00'],
+            ocean: ['#001eff', '#0088ff', '#00ccff', '#00ffee'],
+            forest: ['#004d00', '#008800', '#00cc00', '#88ff00']
+        };
+
+        // Gradient definitions
+        this.gradients = {
+            horizontal: (time, pos) => this.horizontalGradient(time, pos),
+            vertical: (time, pos) => this.verticalGradient(time, pos),
+            radial: (time, pos) => this.radialGradient(time, pos),
+            spiral: (time, pos) => this.spiralGradient(time, pos),
+            wave: (time, pos) => this.waveGradient(time, pos)
+        };
+    }
+
+    // Audio-reactive color
+    audioReactiveColor(audioData) {
+        const { bass, mid, high, spectralCentroid, spectralFlux } = audioData;
+
+        // Brightness from loudness
+        const brightness = audioData.rms;
+
+        // Hue from spectral centroid (brightness of sound)
+        const hue = spectralCentroid * 360;
+
+        // Saturation from spectral flux (energy change)
+        const saturation = 0.5 + (spectralFlux * 0.5);
+
+        return { h: hue, s: saturation, v: brightness };
+    }
+
+    // Multi-hue systems
+    triadHue(baseHue) {
+        return [
+            baseHue,
+            (baseHue + 120) % 360,
+            (baseHue + 240) % 360
+        ];
+    }
+
+    complementaryHue(baseHue) {
+        return [
+            baseHue,
+            (baseHue + 180) % 360
+        ];
+    }
+}
+```
+
+**New Parameters:**
+- `colorMode`: 'single'|'dual'|'triad'|'complementary'|'palette'|'gradient'|'reactive'
+- `colorPalette`: Selection from predefined palettes
+- `gradientType`: 'horizontal'|'vertical'|'radial'|'spiral'|'wave'
+- `gradientSpeed`: Animation speed of gradient
+- `colorReactivity`: How much audio influences color (0-1)
+- `colorSaturation`: Independent from hue (0-1) - ALREADY EXISTS
+- `colorIntensity`: Independent brightness (0-1) - ALREADY EXISTS
+
+**Implementation in Shaders:**
+```glsl
+uniform int u_colorMode;
+uniform vec3 u_palette[4];
+uniform int u_paletteSize;
+uniform float u_gradientPhase;
+
+vec3 getColor(vec2 uv, float audioData) {
+    if (u_colorMode == MODE_PALETTE) {
+        // Cycle through palette based on position + audio
+        int index = int(mod(uv.x * float(u_paletteSize) + audioData, float(u_paletteSize)));
+        return u_palette[index];
+    } else if (u_colorMode == MODE_GRADIENT) {
+        // Gradient between colors
+        return mix(u_palette[0], u_palette[1], uv.x + u_gradientPhase);
+    }
+    // ... other modes
+}
+```
+
+---
+
+### **3. PROFESSIONAL AUDIO REACTIVITY**
+
+**Current Limitation**: 3 frequency bands (bass, mid, high) with simple addition
+
+**New Audio Architecture** (from V3 plan):
+```javascript
+class AudioAnalyzer {
+    constructor(analyserNode) {
+        this.analyser = analyserNode;
+
+        // 7 frequency bands instead of 3
+        this.bands = {
+            subBass: { low: 20, high: 60, value: 0 },      // Kick drums, sub bass
+            bass: { low: 60, high: 250, value: 0 },        // Bass guitar, low toms
+            lowMid: { low: 250, high: 500, value: 0 },     // Guitars, keyboards
+            mid: { low: 500, high: 2000, value: 0 },       // Vocals, snares
+            highMid: { low: 2000, high: 4000, value: 0 },  // Cymbals, guitars
+            high: { low: 4000, high: 8000, value: 0 },     // Hi-hats, strings
+            air: { low: 8000, high: 20000, value: 0 }      // Airiness, sparkle
+        };
+
+        // Spectral features
+        this.spectralCentroid = 0;  // Brightness of sound (0-1)
+        this.spectralRolloff = 0;   // Frequency where 85% energy below (0-1)
+        this.spectralFlux = 0;      // Rate of spectral change (onset detection)
+        this.rms = 0;               // Overall loudness (0-1)
+
+        // Onset detection
+        this.onsetHistory = [];
+        this.lastOnsetTime = 0;
+        this.onsetThreshold = 0.15;
+
+        // BPM estimation
+        this.estimatedBPM = 120;
+
+        // Smoothing buffers
+        this.smoothingFactor = 0.8;
+        this.smoothedBands = { ...this.bands };
+    }
+
+    analyze() {
+        // Multi-band analysis
+        this.analyzeBands();
+
+        // Spectral features
+        this.calcSpectralCentroid();   // Brightness
+        this.calcSpectralRolloff();    // High frequency content
+        this.calcSpectralFlux();       // Change detection
+        this.calcRMS();                // Loudness
+
+        // Onset detection (kicks, snares, transients)
+        const onset = this.detectOnset();
+
+        // BPM estimation from onsets
+        if (this.onsetHistory.length > 8) {
+            this.estimateBPM();
+        }
+
+        return {
+            bands: this.smoothedBands,
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset: onset,
+            bpm: this.estimatedBPM
+        };
+    }
+}
+```
+
+**Parameter Mapping with ADSR Envelopes:**
+```javascript
+class ParameterMapper {
+    constructor() {
+        this.mappings = {
+            // 4D rotations react to different bands
+            rot4dXW: {
+                source: 'bass',
+                curve: 'exponential',  // Exponential response
+                range: [-2, 2],
+                envelope: new ADSREnvelope(200, 500, 0.6, 1000) // Attack, Decay, Sustain, Release
+            },
+            rot4dYW: {
+                source: 'mid',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(100, 300, 0.7, 800)
+            },
+            rot4dZW: {
+                source: 'high',
+                curve: 'exponential',
+                range: [-2, 2],
+                envelope: new ADSREnvelope(50, 200, 0.8, 600)
+            },
+
+            // Grid density reacts to spectral flux (onsets)
+            gridDensity: {
+                source: 'spectralFlux',
+                curve: 'threshold',  // Only responds to strong onsets
+                range: [10, 100],
+                threshold: 0.15,
+                envelope: new ADSREnvelope(50, 1000, 0.3, 2000)
+            },
+
+            // Hue follows spectral centroid (brightness of sound)
+            hue: {
+                source: 'spectralCentroid',
+                curve: 'linear',
+                range: [0, 360],
+                envelope: null  // Instant response for color
+            },
+
+            // Intensity follows RMS (loudness)
+            intensity: {
+                source: 'rms',
+                curve: 'logarithmic',
+                range: [0.3, 1.0],
+                envelope: new ADSREnvelope(10, 50, 0.8, 200)
+            }
+        };
+    }
+
+    applyCurve(value, curve) {
+        switch(curve) {
+            case 'exponential':
+                return Math.pow(value, 2);
+            case 'logarithmic':
+                return Math.log10(1 + value * 9) / Math.log10(10);
+            case 's-curve':
+                return 1 / (1 + Math.exp(-10 * (value - 0.5)));
+            case 'threshold':
+                return value > this.threshold ? 1 : 0;
+            default:
+                return value; // linear
+        }
+    }
+}
+```
+
+**ADSR Envelope for Smooth Parameter Changes:**
+```javascript
+class ADSREnvelope {
+    constructor(attackMs, decayMs, sustain, releaseMs) {
+        this.attack = attackMs;
+        this.decay = decayMs;
+        this.sustain = sustain;  // 0-1
+        this.release = releaseMs;
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = 0;
+    }
+
+    trigger(value) {
+        this.targetValue = value;
+        this.phase = 'attack';
+        this.phaseStartTime = Date.now();
+    }
+
+    update() {
+        const now = Date.now();
+        const elapsed = now - this.phaseStartTime;
+
+        switch(this.phase) {
+            case 'attack':
+                this.value = (elapsed / this.attack) * this.targetValue;
+                if (elapsed >= this.attack) {
+                    this.phase = 'decay';
+                    this.phaseStartTime = now;
+                }
+                break;
+
+            case 'decay':
+                const decayProgress = elapsed / this.decay;
+                this.value = this.targetValue * (1 - decayProgress * (1 - this.sustain));
+                if (elapsed >= this.decay) {
+                    this.phase = 'sustain';
+                }
+                break;
+
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+
+            case 'release':
+                this.value *= 1 - (elapsed / this.release);
+                if (elapsed >= this.release) {
+                    this.phase = 'idle';
+                    this.value = 0;
+                }
+                break;
+        }
+
+        return this.value;
+    }
+}
+```
+
+---
+
+## 🏗️ REFACTORING IMPLEMENTATION PLAN
+
+### **PHASE 1: FOUNDATION (Week 1)**
+
+**1.1 Create BaseSystem Interface** ✅
+- [x] Write `src/systems/shared/BaseSystem.js`
+- [x] Define standard lifecycle: init → render → update → destroy
+- [x] Standard parameter interface
+- [x] Standard canvas management via reusable canvas factory
+- [x] Add `BaseVisualizer` + `SystemRegistry` scaffolding for consistent engine wiring
+- [x] Wrap faceted/quantum/holographic engines with new BaseSystem adapters
+
+**1.2 Extract Best Features from Each Index Variant**
+- [ ] From `index-MASTER.html`: Beat sync + video export
+- [ ] From `index-ULTIMATE-V2.html`: 4D rotation focus + musical timing
+- [ ] From `index-working-simple.html`: Clean hybrid mode
+- [ ] Document which features to preserve from each
+
+**1.3 Consolidate Parameter System**
+- [ ] Unify `Parameters.js` to work across all systems
+- [x] Add new color parameters
+- [ ] Add audio reactivity parameters
+- [ ] Validation + ranges for all parameters
+
+> ✅ ParameterManager now defines color mode, palette, and gradient controls with enum-aware validation and default ranges; audio mapping fields remain to be unified.
+
+---
+
+### **PHASE 2: COLOR SYSTEM (Week 1-2)**
+
+**2.1 Implement ColorSystem Class**
+- [x] Create `src/color/ColorSystem.js`
+- [x] Define 8+ color palettes
+- [x] Implement gradient functions
+- [x] Audio-reactive color mapping (palettes + gradients respond to analyzer state)
+
+**2.2 Update Shaders**
+- [ ] Modify `Visualizer.js` shader for multi-color support
+- [ ] Modify `QuantumVisualizer.js` shader
+- [ ] Modify `HolographicVisualizer.js` shader
+- [ ] Add palette uniforms to GLSL
+
+**2.3 UI for Color Control** ✅
+- [x] Color mode selector
+- [x] Palette picker
+- [x] Gradient controls
+- [x] Preview system with live gradient loop
+
+---
+
+### **PHASE 3: AUDIO SYSTEM (Week 2-3)**
+
+**3.1 Implement AudioAnalyzer**
+- [x] Create `src/audio/AudioAnalyzer.js` (complete V3 implementation)
+- [x] 7-band frequency analysis
+- [x] Spectral features (centroid, rolloff, flux)
+- [x] Onset detection
+- [x] BPM estimation
+
+**3.2 Implement ADSR Envelopes**
+- [x] Create `src/audio/ADSREnvelope.js`
+- [x] Attack/Decay/Sustain/Release phases
+- [x] Per-parameter envelope configuration
+- [x] Smooth parameter transitions
+
+**3.3 Implement ParameterMapper**
+- [x] Create `src/audio/ParameterMapper.js`
+- [x] Curve functions (exponential, logarithmic, s-curve, threshold)
+- [x] Band-to-parameter routing
+- [x] Envelope integration
+
+**3.4 Integration**
+- [x] Connect AudioAnalyzer to the global audio engine used by all systems (`js/audio/audio-engine.js`)
+- [x] Map audio features to parameters intelligently via default ParameterMapper presets
+- [ ] Test with various music genres
+- [ ] Optimize performance
+
+---
+
+### **PHASE 4: SYSTEM REFACTORING (Week 3-4)**
+
+**4.1 Refactor Faceted System**
+- [ ] Migrate `Engine.js` to extend `BaseSystem`
+- [ ] Integrate ColorSystem
+- [ ] Integrate AudioAnalyzer + ParameterMapper
+- [ ] Test all features
+
+**4.2 Refactor Quantum System**
+- [ ] Migrate `QuantumEngine.js` to extend `BaseSystem`
+- [ ] Integrate advanced color
+- [ ] Integrate advanced audio
+- [ ] Test volumetric lighting with new audio
+
+**4.3 Refactor Holographic System**
+- [ ] Consolidate 3 holographic variants into 1
+- [ ] Extend `BaseSystem`
+- [ ] Enhance audio reactivity with new system
+- [ ] Test multi-layer rendering
+
+**4.4 Refactor Polychora System**
+- [x] Migrate `PolychoraSystem.js` to extend `BaseSystem`
+- [x] 4D rotation optimization
+- [x] Audio-reactive 4D transformations
+- [ ] Test polytope rendering
+
+---
+
+### **PHASE 5: UNIFIED INTERFACE (Week 4-5)**
+
+**5.1 Create Single Master Index**
+- [ ] New `index.html` using BaseSystem architecture
+- [ ] Dynamic system loading
+- [ ] Unified UI that adapts per system
+    - [x] Registry-driven system info panel with metadata badges + accent theming
+- [ ] System switcher with smooth transitions
+
+**5.2 Consolidate CSS**
+- [ ] Extract inline CSS to modules
+- [ ] Per-system themes
+- [ ] Responsive design
+- [ ] Animation system
+
+**5.3 Export System**
+- [ ] Unify trading card generation across all systems
+- [ ] Video export with proper canvas handling
+- [ ] JSON save/load for all systems
+- [ ] Gallery system integration
+
+---
+
+### **PHASE 6: OPTIMIZATION & POLISH (Week 5-6)**
+
+**6.1 Performance**
+- [ ] WebGL optimization
+- [ ] Mobile performance testing
+- [ ] Memory leak prevention
+- [ ] Frame rate monitoring
+
+**6.2 Testing**
+- [ ] Unit tests for audio analysis
+- [ ] Integration tests for system switching
+- [ ] Visual regression tests
+- [ ] Mobile device testing
+
+**6.3 Documentation**
+- [ ] API documentation
+- [ ] User guide
+- [ ] Developer guide
+- [ ] Example presets
+
+---
+
+## 📁 NEW FILE STRUCTURE
+```
+vib34d-music-video-choreographer-alternative/
+├── index.html                           // NEW: Unified master interface
+├── src/
+│   ├── systems/
+│   │   ├── shared/
+│   │   │   ├── BaseSystem.js           // NEW: Base class all systems extend
+│   │   │   ├── BaseVisualizer.js       // NEW: Base visualizer interface
+│   │   │   └── SystemRegistry.js       // NEW: System management
+│   │   ├── faceted/
+│   │   │   ├── FacetedSystem.js        // REFACTORED: from Engine.js
+│   │   │   └── FacetedVisualizer.js    // REFACTORED: from Visualizer.js
+│   │   ├── quantum/
+│   │   │   ├── QuantumSystem.js        // REFACTORED: from QuantumEngine.js
+│   │   │   └── QuantumVisualizer.js    // REFACTORED
+│   │   ├── holographic/
+│   │   │   ├── HolographicSystem.js    // CONSOLIDATED: from 3 variants
+│   │   │   └── HolographicVisualizer.js
+│   │   └── polychora/
+│   │       ├── PolychoraSystem.js      // REFACTORED
+│   │       └── PolychoraVisualizer.js  // EXTRACTED
+│   ├── core/
+│   │   ├── Parameters.js               // ENHANCED: unified parameters
+│   │   ├── CanvasManager.js            // KEEP: working well
+│   │   └── ReactivityManager.js        // KEEP: working well
+│   ├── audio/
+│   │   ├── AudioAnalyzer.js            // NEW: 7-band + spectral analysis
+│   │   ├── ADSREnvelope.js             // NEW: smooth parameter transitions
+│   │   └── ParameterMapper.js          // NEW: audio-to-parameter routing
+│   ├── color/
+│   │   └── ColorSystem.js              // NEW: palettes + gradients + reactive
+│   ├── geometry/
+│   │   └── GeometryLibrary.js          // KEEP: shared geometries
+│   └── export/
+│       ├── UnifiedExportManager.js     // NEW: single export system
+│       └── [consolidate card generators]
+├── styles/
+│   ├── base.css                        // NEW: extracted from inline
+│   ├── systems/
+│   │   ├── faceted.css                 // NEW: system-specific styling
+│   │   ├── quantum.css
+│   │   ├── holographic.css
+│   │   └── polychora.css
+│   └── ui/
+│       ├── controls.css                // NEW: unified controls
+│       └── mobile.css                  // NEW: responsive design
+└── archive/
+    └── [move all old index-*.html here]
+```
+
+---
+
+## 🎯 SUCCESS CRITERIA
+
+### **Elegance:**
+- ✅ Single `index.html` under 500 lines
+- ✅ All systems extend `BaseSystem` with identical API
+- ✅ No code duplication between systems
+- ✅ Clean separation: systems / audio / color / export
+
+### **Color Expansion:**
+- ✅ 8+ color modes (single, dual, triad, palette, gradient, reactive)
+- ✅ 8+ predefined palettes
+- ✅ 5+ gradient types
+- ✅ Audio-reactive color that responds to spectral features
+
+### **Audio Reactivity:**
+- ✅ 7 frequency bands (vs current 3)
+- ✅ 4 spectral features (centroid, rolloff, flux, rms)
+- ✅ Onset detection for transients
+- ✅ BPM estimation
+- ✅ ADSR envelopes for smooth parameter changes
+- ✅ Multiple mapping curves (exponential, logarithmic, s-curve, threshold)
+
+### **Performance:**
+- ✅ 60 FPS on desktop
+- ✅ 45+ FPS on mobile
+- ✅ Smooth system switching (< 500ms)
+- ✅ No memory leaks
+
+---
+
+## 🚀 IMMEDIATE NEXT STEPS
+
+1. **Advanced Audio Pipeline Integration** ✅
+   - Faceted, Quantum, and Holographic renderers now consume the analyzer's multi-band + spectral output with smoothing envelopes
+   - Audio-driven boosts power grid density, morphing, chaos, color, and 4D rotation without destabilizing base parameters
+   - Debug hooks remain for spot-checking live signals while preserving graceful fallbacks when audio is disabled
+
+2. **Color System Integration** ✅
+   - ✅ Implemented `ColorSystem.js` with palettes, gradients, and audio-reactive blending
+   - ✅ Advanced audio engine now publishes `window.colorState` for every frame
+   - ✅ Feed palette uniforms + gradient data into shaders and UI controls (faceted, quantum, holographic) with live UI selectors
+
+3. **Unified System Architecture (in progress)**:
+   - ✅ BaseSystem + BaseVisualizer scaffolding created under `src/systems/shared`
+   - ✅ SystemRegistry orchestrates switching + lifecycle teardown
+   - ✅ Faceted, Quantum, and Holographic engines now run through BaseSystem adapters
+   - ✅ ParameterManager, timeline bridge, and export tooling resolve engines via SystemAccess helpers
+   - ✅ Timeline editor sequences now source defaults + form controls from shared metadata with sanitized rendering
+   - 🔜 Port remaining consumers (gallery, remote embeds) to query registry instead of globals
+   - ✅ Added Polychora adapter powered by BaseSystem + SystemRegistry (`src/polychora/PolychoraEngine.js`, `src/systems/polychora/PolychoraSystem.js`)
+   - ✅ New Polychora visualizer consumes shared ColorSystem + audio analyzer for 4D palette + rotation reactivity
+
+4. **System-aware interface foundation** ✅
+   - Registry metadata feeds the live system info panel with accent colors, descriptions, and capability tags
+   - System selector buttons expose per-engine tooltips sourced from shared descriptors
+   - Status banner auto-highlights the active system when idle, prepping adaptive control groups
+   - Adaptive control panel renders metadata-driven parameter groups with shared accent theming and hosts the integrated timeline shell
+   - Timeline presets, quick actions, and editor toggles now resolve through shared metadata with live registry updates
+
+5. **Finally Consolidation**:
+   - New unified `index.html`
+   - Move old versions to archive
+   - Polish and optimize
+
+---
+
+**TIMELINE**: 6 weeks for complete refactoring
+**PRIORITY**: Audio system first (can integrate with current architecture immediately)
+
+**Next Command**: Extend metadata-aware timeline defaults into choreography import/export routines and broaden automated tests to cover geometry presets + multi-system sequence insertion.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VIB34D Music Video Choreographer - Dual Mode</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./styles/controls.css">
+    <link rel="stylesheet" href="./styles/mobile.css">
     <style>
         * {
             margin: 0;
@@ -161,6 +163,52 @@
             cursor: not-allowed;
         }
 
+        select,
+        input[type="range"] {
+            background: rgba(0, 0, 0, 0.7);
+            border: 1px solid rgba(0, 255, 255, 0.6);
+            color: #0ff;
+            font-family: 'Orbitron', monospace;
+            padding: 8px 12px;
+            border-radius: 8px;
+            appearance: none;
+        }
+
+        .control-value {
+            min-width: 48px;
+            text-align: right;
+            font-size: 12px;
+            color: #0ff;
+        }
+
+        .color-controls {
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .color-controls label {
+            font-size: 11px;
+            text-transform: uppercase;
+            opacity: 0.75;
+            letter-spacing: 0.05em;
+        }
+
+        .color-controls select {
+            min-width: 140px;
+        }
+
+        .color-controls input[type="range"] {
+            flex: 1;
+        }
+
+        .gradient-preview {
+            width: 140px;
+            height: 22px;
+            border-radius: 8px;
+            border: 1px solid rgba(0, 255, 255, 0.4);
+            background: linear-gradient(90deg, #0ff, #f0f);
+        }
+
         .file-input-label {
             background: linear-gradient(135deg, #4a0a68, #f0f);
             padding: 12px 24px;
@@ -249,6 +297,43 @@
             margin-bottom: 8px;
         }
 
+        .system-info {
+            margin-top: 12px;
+            padding-top: 12px;
+            border-top: 1px solid var(--system-accent, rgba(0, 255, 255, 0.2));
+        }
+
+        .system-info h4 {
+            font-size: 12px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--system-accent, #0ff);
+            margin-bottom: 6px;
+        }
+
+        .system-info p {
+            color: #a7f6ff;
+            font-size: 11px;
+            margin-bottom: 10px;
+        }
+
+        .system-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .system-tag {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 4px 8px;
+            border-radius: 6px;
+            border: 1px solid rgba(0, 255, 255, 0.35);
+            background: rgba(0, 255, 255, 0.12);
+            color: #7ff;
+        }
+
         .beat-indicator {
             position: fixed;
             top: 50%;
@@ -277,20 +362,14 @@
 
         /* Timeline Editor Mode */
         #timeline-editor {
-            position: fixed;
-            left: 20px;
-            top: 120px;
-            bottom: 20px;
-            width: 350px;
-            background: rgba(0, 0, 0, 0.95);
-            border: 2px solid #f0f;
-            border-radius: 10px;
-            padding: 15px;
-            z-index: 1500;
             display: none;
             flex-direction: column;
             gap: 10px;
-            overflow-y: auto;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 0, 255, 0.35);
+            border-radius: 10px;
+            padding: 12px;
+            margin-top: 12px;
         }
 
         #timeline-editor.active {
@@ -300,11 +379,12 @@
         #timeline-editor h3 {
             color: #f0f;
             margin-bottom: 10px;
+            font-size: 14px;
         }
 
         .sequence-item {
-            background: rgba(255, 0, 255, 0.1);
-            border: 1px solid #f0f;
+            background: rgba(255, 0, 255, 0.08);
+            border: 1px solid rgba(255, 0, 255, 0.35);
             border-radius: 5px;
             padding: 10px;
             margin-bottom: 10px;
@@ -340,8 +420,7 @@
         }
 
         .add-sequence-btn {
-            background: linear-gradient(135deg, #4a0a68, #f0f);
-            margin-top: 10px;
+            margin-top: 6px;
         }
 
         .mode-toggle {
@@ -364,10 +443,6 @@
                 max-width: 90%;
             }
 
-            #timeline-editor {
-                width: 90%;
-                left: 5%;
-            }
         }
     </style>
 </head>
@@ -403,16 +478,59 @@
         <p id="mode-description">Real-time audio analysis with automatic parameter mapping</p>
         <p id="beat-info">BPM: -- | Beat: --</p>
         <p id="energy-info">Energy: -- | Bass: --</p>
+        <div class="system-info" id="systemInfo">
+            <h4 id="systemName">Faceted Prism Engine</h4>
+            <p id="systemDescription">Crystal prisms pulse with bass-driven density while mid-band morphing sculpts razor-sharp silhouettes.</p>
+            <div class="system-tags" id="systemTags">
+                <span class="system-tag">Geometric</span>
+                <span class="system-tag">Reactive</span>
+            </div>
+        </div>
     </div>
 
-    <!-- Timeline Editor for Choreography Mode -->
-    <div id="timeline-editor">
-        <h3>📝 Sequence Timeline</h3>
-        <button class="add-sequence-btn" onclick="addSequence()">+ Add Sequence</button>
-        <div id="sequence-list"></div>
-        <button onclick="saveChoreography()">💾 Save Choreography</button>
-        <button onclick="loadChoreography()">📂 Load Choreography</button>
-    </div>
+    <aside class="control-panel hidden" id="controlPanel" aria-label="System Control Panel">
+        <div class="panel-header">
+            <span id="controlPanelTitle">Control Center</span>
+            <button class="mobile-collapse-btn" type="button" onclick="toggleMobilePanel()" aria-expanded="true" aria-controls="controlPanelContent">▼</button>
+        </div>
+        <div id="controlPanelContent">
+            <section class="control-section timeline-section" id="timelineSection">
+                <div class="section-title">Timeline</div>
+                <div class="timeline-wrapper">
+                    <div id="timeline" class="timeline-track">
+                        <div id="timeline-progress" class="timeline-progress"></div>
+                    </div>
+                    <div class="timeline-meta">
+                        <span id="timelineCurrent">0:00</span>
+                        <span id="timelineDuration">0:00</span>
+                    </div>
+                    <div class="timeline-actions">
+                        <button class="panel-btn compact" id="timelineEditorToggle" type="button" onclick="toggleTimelineEditor()" disabled>📝 Edit Timeline</button>
+                    </div>
+                    <div class="timeline-presets" id="timelinePresetList"></div>
+                    <div class="timeline-hints" id="timelineHints"></div>
+                </div>
+                <div id="timeline-editor" aria-hidden="true">
+                    <h3>📝 Sequence Timeline</h3>
+                    <div class="timeline-editor-actions" id="timelineEditorActions"></div>
+                    <div id="sequence-list"></div>
+                </div>
+            </section>
+            <section class="control-section" id="geometrySection">
+                <div class="section-title">Geometry Library</div>
+                <div class="geometry-readout" id="v-geometry">--</div>
+                <div class="geometry-grid" id="geometryGrid"></div>
+            </section>
+            <section class="control-section" id="dynamicControlSection">
+                <div class="section-title">System Controls</div>
+                <div class="control-groups" id="dynamicControlGroups"></div>
+            </section>
+            <section class="control-section actions-section" id="controlActionsSection">
+                <div class="section-title">Quick Actions</div>
+                <div class="action-list" id="controlActionList"></div>
+            </section>
+        </div>
+    </aside>
 
     <div id="controls">
         <div class="control-row">
@@ -426,44 +544,121 @@
             <button class="mode-toggle" onclick="toggleMode()">🔄 Switch Mode</button>
         </div>
 
-        <div id="timeline">
-            <div id="timeline-progress"></div>
-        </div>
-
         <div class="system-selector">
             <button class="system-btn active" data-system="faceted">🔷 FACETED</button>
             <button class="system-btn" data-system="quantum">🌌 QUANTUM</button>
             <button class="system-btn" data-system="holographic">✨ HOLOGRAPHIC</button>
+            <button class="system-btn" data-system="polychora">🔮 POLYCHORA</button>
+        </div>
+
+        <div class="control-row color-controls">
+            <label for="colorModeControl">Color Mode</label>
+            <select id="colorModeControl"></select>
+            <label for="colorPaletteControl">Palette</label>
+            <select id="colorPaletteControl"></select>
+            <div class="gradient-preview" id="gradientPreview"></div>
+        </div>
+
+        <div class="control-row color-controls">
+            <label for="gradientTypeControl">Gradient</label>
+            <select id="gradientTypeControl"></select>
+            <label for="gradientSpeedControl">Speed</label>
+            <input type="range" id="gradientSpeedControl" min="0" max="2" step="0.01" value="0.25">
+            <span class="control-value" id="gradientSpeedValue">0.25x</span>
+            <label for="colorReactivityControl">Reactivity</label>
+            <input type="range" id="colorReactivityControl" min="0" max="1" step="0.05" value="0.65">
+            <span class="control-value" id="colorReactivityValue">65%</span>
         </div>
 
         <div id="status">Select a mode to begin</div>
     </div>
 
     <script type="module">
+        import './js/audio/audio-engine.js';
+        import './js/controls/ui-handlers.js';
         import { VIB34DIntegratedEngine } from './src/core/Engine.js';
         import { QuantumEngine } from './src/quantum/QuantumEngine.js';
         import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
 
         let choreographer = null;
         let currentMode = null;
+        window.currentMode = currentMode;
+
+        function updateTimelineAvailability(mode) {
+            const isChoreographed = mode === 'choreographed';
+            const timelineSection = document.getElementById('timelineSection');
+            const toggleButton = document.getElementById('timelineEditorToggle');
+
+            if (timelineSection) {
+                timelineSection.classList.toggle('inactive', !isChoreographed);
+                timelineSection.setAttribute('aria-disabled', isChoreographed ? 'false' : 'true');
+            }
+
+            if (toggleButton) {
+                toggleButton.disabled = !isChoreographed;
+                toggleButton.setAttribute('aria-disabled', isChoreographed ? 'false' : 'true');
+            }
+        }
+
+        window.toggleTimelineEditor = function(force) {
+            const editor = document.getElementById('timeline-editor');
+            const toggleButton = document.getElementById('timelineEditorToggle');
+            if (!editor) return;
+
+            const isChoreographed = currentMode === 'choreographed';
+            let shouldOpen;
+
+            if (typeof force === 'boolean') {
+                shouldOpen = force && isChoreographed;
+            } else {
+                shouldOpen = !editor.classList.contains('active');
+                if (shouldOpen && !isChoreographed) {
+                    shouldOpen = false;
+                }
+            }
+
+            editor.classList.toggle('active', shouldOpen);
+            editor.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+
+            if (toggleButton) {
+                toggleButton.textContent = shouldOpen ? 'Hide Timeline' : '📝 Edit Timeline';
+                toggleButton.setAttribute('aria-pressed', shouldOpen ? 'true' : 'false');
+            }
+        };
 
         window.selectMode = function(mode) {
             currentMode = mode;
+            window.currentMode = currentMode;
             document.getElementById('mode-selector').style.display = 'none';
             document.getElementById('controls').classList.add('active');
             document.getElementById('info-panel').classList.add('active');
+            const controlPanel = document.getElementById('controlPanel');
+            if (controlPanel) {
+                controlPanel.classList.remove('hidden');
+            }
 
             if (mode === 'choreographed') {
-                document.getElementById('timeline-editor').classList.add('active');
                 document.getElementById('mode-title').textContent = '🎬 HYBRID MODE';
                 document.getElementById('mode-description').textContent = 'Choreographed sequences + Full audio reactivity + System switching';
+                toggleTimelineEditor(true);
             } else {
                 document.getElementById('mode-title').textContent = '🎧 REACTIVE MODE';
                 document.getElementById('mode-description').textContent = 'Real-time audio analysis with automatic parameter mapping';
+                toggleTimelineEditor(false);
             }
+
+            updateTimelineAvailability(mode);
 
             // Initialize choreographer with selected mode
             initChoreographer(mode);
+
+            if (window.refreshColorControls) {
+                window.refreshColorControls();
+            }
+
+            if (window.refreshControlPanel) {
+                window.refreshControlPanel();
+            }
         };
 
         window.toggleMode = function() {
@@ -484,17 +679,14 @@
         // Global functions for timeline editor
         window.addSequence = function() {
             if (!choreographer) return;
-            choreographer.addSequenceToTimeline({
-                time: 0,
-                duration: 10,
-                effects: {
-                    geometry: 'hold',
-                    rotation: 'smooth',
-                    chaos: 0.5,
-                    speed: 1.0,
-                    colorShift: 'medium'
-                }
-            });
+            const sequence = typeof choreographer.createSequenceFromDefaults === 'function'
+                ? choreographer.createSequenceFromDefaults()
+                : {
+                    time: 0,
+                    duration: 10,
+                    effects: { geometry: 'cycle', rotation: 'smooth', chaos: 0.3, speed: 1.0, colorShift: 'medium' }
+                };
+            choreographer.addSequenceToTimeline(sequence);
         };
 
         window.saveChoreography = function() {

--- a/js/audio/audio-engine.js
+++ b/js/audio/audio-engine.js
@@ -1,139 +1,562 @@
 /**
  * VIB34D Audio Engine Module
- * Mobile-safe audio reactivity system with global window integration
- * Extracted from monolithic index.html for clean architecture
+ * Advanced audio reactivity hub that feeds all visualization systems
+ * Built on the unified AudioAnalyzer / ParameterMapper toolkit
  */
+
+import { AudioAnalyzer } from '../../src/audio/AudioAnalyzer.js';
+import { ParameterMapper } from '../../src/audio/ParameterMapper.js';
+import { ADSREnvelope } from '../../src/audio/ADSREnvelope.js';
+import { ColorSystem } from '../../src/color/ColorSystem.js';
 
 // Global audio state flags - CRITICAL for system integration
 window.audioEnabled = false; // Global audio flag (will auto-enable on interaction)
 
-/**
- * Simple Audio Engine - Mobile-safe and actually works
- * Provides real-time audio analysis for all visualization systems
- */
-export class SimpleAudioEngine {
-    constructor() {
-        this.context = null;
-        this.analyser = null;
-        this.dataArray = null;
-        this.isActive = false;
-        
-        // Mobile-safe: Initialize with defaults
-        window.audioReactive = {
+const clamp01 = value => Math.min(Math.max(value, 0), 1);
+
+function createDefaultReactiveState(colorState = null) {
+    return {
+        bass: 0,
+        mid: 0,
+        high: 0,
+        sparkle: 0,
+        energy: 0,
+        motion: 0,
+        onset: 0,
+        hueShift: 0,
+        intensity: 0,
+        spectralCentroid: 0,
+        spectralRolloff: 0,
+        spectralFlux: 0,
+        rms: 0,
+        bpm: 0,
+        bands: {
+            subBass: 0,
             bass: 0,
-            mid: 0, 
+            lowMid: 0,
+            mid: 0,
+            highMid: 0,
             high: 0,
-            energy: 0
+            air: 0
+        },
+        color: colorState
+    };
+}
+
+/**
+ * Advanced Audio Engine - Unified analysis + parameter routing
+ */
+export class AdvancedAudioEngine {
+    constructor(options = {}) {
+        this.context = null;
+        this.mediaStream = null;
+        this.analyserNode = null;
+        this.audioAnalyzer = null;
+        this.parameterMapper = null;
+        this.colorSystem = new ColorSystem(options.colorSystem || {});
+        this.listeners = new Set();
+
+        this.isActive = false;
+        this.isEnabled = false;
+        this.processingHandle = null;
+        this.frameScheduler = 'raf';
+
+        this.options = {
+            fftSize: options.fftSize || 2048,
+            smoothingTimeConstant: options.smoothingTimeConstant ?? 0.7,
+            energySmoothing: options.energySmoothing ?? 0.75,
+            onsetThreshold: options.onsetThreshold ?? 0.18,
+            minimumOnsetInterval: options.minimumOnsetInterval ?? 110
         };
-        
-        console.log('🎵 Audio Engine: Initialized with default values');
+
+        this.sensitivity = {
+            bass: options.bassGain ?? 1,
+            mid: options.midGain ?? 1,
+            high: options.highGain ?? 1,
+            energy: options.energyGain ?? 1,
+            sparkle: options.sparkleGain ?? 1,
+            motion: options.motionGain ?? 1
+        };
+
+        const initialColorState = this.colorSystem.getState();
+        window.colorState = initialColorState;
+        window.audioReactive = createDefaultReactiveState(initialColorState);
+
+        this.#emitColorEvent(initialColorState);
+
+        console.log('🎵 Audio Engine: Advanced analyzer initialized with default values');
     }
-    
+
     async init() {
-        if (this.isActive) return true;
-        
+        if (this.isActive) {
+            if (this.context?.state === 'suspended') {
+                await this.context.resume();
+            }
+            this.setEnabled(true);
+            return true;
+        }
+
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            console.warn('⚠️ Audio Analyzer: getUserMedia not available.');
+            return false;
+        }
+
         try {
-            console.log('🎵 Simple Audio Engine: Starting...');
-            
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            console.log('🎵 Advanced Audio Engine: Requesting microphone access…');
+            this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
             this.context = new (window.AudioContext || window.webkitAudioContext)();
-            
+
             if (this.context.state === 'suspended') {
                 await this.context.resume();
             }
-            
-            this.analyser = this.context.createAnalyser();
-            this.analyser.fftSize = 256;
-            this.analyser.smoothingTimeConstant = 0.8;
-            
-            const source = this.context.createMediaStreamSource(stream);
-            source.connect(this.analyser);
-            
-            this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+
+            this.analyserNode = this.context.createAnalyser();
+            this.analyserNode.fftSize = this.options.fftSize;
+            this.analyserNode.smoothingTimeConstant = this.options.smoothingTimeConstant;
+
+            const source = this.context.createMediaStreamSource(this.mediaStream);
+            source.connect(this.analyserNode);
+
+            this.audioAnalyzer = new AudioAnalyzer(this.analyserNode, {
+                fftSize: this.options.fftSize,
+                frequencySmoothing: this.options.smoothingTimeConstant,
+                energySmoothing: this.options.energySmoothing,
+                onsetThreshold: this.options.onsetThreshold,
+                minimumOnsetInterval: this.options.minimumOnsetInterval
+            });
+
+            this.parameterMapper = this.#createDefaultMapper();
+
             this.isActive = true;
-            
-            // CRITICAL FIX: Enable global audio flag so visualizers will use the data
-            window.audioEnabled = true;
-            
-            this.startProcessing();
-            console.log('✅ Audio Engine: Active - window.audioEnabled = true');
+            this.setEnabled(true);
+            this.#startProcessing();
+
+            console.log('✅ Audio Engine: Advanced analyzer active');
             return true;
-            
         } catch (error) {
-            console.log('⚠️ Audio denied - silent mode');
-            window.audioEnabled = false; // Keep audio disabled if permission denied
+            console.warn('⚠️ Audio Analyzer: Permission denied or device unavailable', error);
+            this.isActive = false;
+            this.setEnabled(false);
             return false;
         }
     }
-    
-    startProcessing() {
-        const process = () => {
-            if (!this.isActive || !this.analyser) {
-                requestAnimationFrame(process);
-                return;
-            }
-            
-            this.analyser.getByteFrequencyData(this.dataArray);
-            
-            // Simple frequency analysis
-            const len = this.dataArray.length;
-            const bassRange = Math.floor(len * 0.1);
-            const midRange = Math.floor(len * 0.3);
-            
-            let bass = 0, mid = 0, high = 0;
-            
-            for (let i = 0; i < bassRange; i++) bass += this.dataArray[i];
-            for (let i = bassRange; i < midRange; i++) mid += this.dataArray[i];
-            for (let i = midRange; i < len; i++) high += this.dataArray[i];
-            
-            bass = (bass / bassRange) / 255;
-            mid = (mid / (midRange - bassRange)) / 255;
-            high = (high / (len - midRange)) / 255;
-            
-            const smoothing = 0.7;
-            window.audioReactive.bass = bass * smoothing + window.audioReactive.bass * (1 - smoothing);
-            window.audioReactive.mid = mid * smoothing + window.audioReactive.mid * (1 - smoothing);
-            window.audioReactive.high = high * smoothing + window.audioReactive.high * (1 - smoothing);
-            window.audioReactive.energy = (window.audioReactive.bass + window.audioReactive.mid + window.audioReactive.high) / 3;
-            
-            // Debug logging every 5 seconds to verify audio processing
-            if (Date.now() % 5000 < 16) {
-                console.log(`🎵 Audio levels: Bass=${window.audioReactive.bass.toFixed(2)} Mid=${window.audioReactive.mid.toFixed(2)} High=${window.audioReactive.high.toFixed(2)} Energy=${window.audioReactive.energy.toFixed(2)}`);
-            }
-            
-            requestAnimationFrame(process);
-        };
-        
-        process();
-    }
-    
-    /**
-     * Check if audio is currently active and processing
-     */
+
     isAudioActive() {
-        return this.isActive && window.audioEnabled;
+        return this.isActive && this.isEnabled && window.audioEnabled;
     }
-    
-    /**
-     * Get current audio reactive values
-     */
+
+    setEnabled(enabled) {
+        this.isEnabled = Boolean(enabled);
+        window.audioEnabled = this.isEnabled;
+
+        if (!this.isEnabled) {
+            this.#resetReactiveState();
+            this.#stopProcessingLoop();
+        }
+
+        if (!this.processingHandle && this.isActive && this.isEnabled) {
+            this.#startProcessing();
+        }
+    }
+
+    updateSensitivity(settings = {}) {
+        if (typeof settings.bassGain === 'number') {
+            this.sensitivity.bass = Math.max(0, settings.bassGain);
+        }
+        if (typeof settings.midGain === 'number') {
+            this.sensitivity.mid = Math.max(0, settings.midGain);
+        }
+        if (typeof settings.highGain === 'number') {
+            this.sensitivity.high = Math.max(0, settings.highGain);
+        }
+        if (typeof settings.energyGain === 'number') {
+            this.sensitivity.energy = Math.max(0, settings.energyGain);
+        }
+        if (typeof settings.sparkleGain === 'number') {
+            this.sensitivity.sparkle = Math.max(0, settings.sparkleGain);
+        }
+        if (typeof settings.motionGain === 'number') {
+            this.sensitivity.motion = Math.max(0, settings.motionGain);
+        }
+    }
+
+    registerMappings(parameterMappings = {}) {
+        if (!this.parameterMapper) {
+            this.parameterMapper = new ParameterMapper(parameterMappings);
+            return;
+        }
+
+        Object.entries(parameterMappings).forEach(([parameter, config]) => {
+            this.parameterMapper.registerMapping(parameter, config);
+        });
+    }
+
+    getColorConfiguration() {
+        if (this.colorSystem && typeof this.colorSystem.getConfig === 'function') {
+            return this.colorSystem.getConfig();
+        }
+        return {};
+    }
+
+    getAvailableColorModes() {
+        if (this.colorSystem && typeof this.colorSystem.getAvailableModes === 'function') {
+            return this.colorSystem.getAvailableModes();
+        }
+        return [];
+    }
+
+    getAvailablePalettes() {
+        if (this.colorSystem && typeof this.colorSystem.getAvailablePalettes === 'function') {
+            return this.colorSystem.getAvailablePalettes();
+        }
+        return [];
+    }
+
+    getAvailableGradients() {
+        if (this.colorSystem && typeof this.colorSystem.getAvailableGradients === 'function') {
+            return this.colorSystem.getAvailableGradients();
+        }
+        return [];
+    }
+
+    updateColorSettings(settings = {}) {
+        if (!this.colorSystem || !settings || typeof settings !== 'object') {
+            return this.getColorState();
+        }
+
+        const state = this.colorSystem.updateConfig(settings);
+        window.colorState = state;
+        if (window.audioReactive) {
+            window.audioReactive.color = state;
+        }
+
+        this.#emitColorEvent(state);
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(window.audioReactive, null);
+            } catch (error) {
+                console.warn('Audio Engine listener error during color update', error);
+            }
+        });
+
+        return state;
+    }
+
+    setColorMode(mode) {
+        if (typeof mode !== 'string') {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ colorMode: mode });
+    }
+
+    setColorPalette(name) {
+        if (typeof name !== 'string') {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ colorPalette: name });
+    }
+
+    setGradientType(type) {
+        if (typeof type !== 'string') {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ gradientType: type });
+    }
+
+    setGradientSpeed(speed) {
+        const numeric = Number(speed);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ gradientSpeed: numeric });
+    }
+
+    setColorReactivity(amount) {
+        const numeric = Number(amount);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ colorReactivity: numeric });
+    }
+
+    setBaseHue(hue) {
+        const numeric = Number(hue);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ baseHue: numeric });
+    }
+
+    setBaseSaturation(saturation) {
+        const numeric = Number(saturation);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ baseSaturation: numeric });
+    }
+
+    setBaseIntensity(intensity) {
+        const numeric = Number(intensity);
+        if (!Number.isFinite(numeric)) {
+            return this.getColorState();
+        }
+        return this.updateColorSettings({ baseIntensity: numeric });
+    }
+
+    subscribe(listener) {
+        if (typeof listener !== 'function') {
+            return () => {};
+        }
+
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
     getAudioLevels() {
         return window.audioReactive;
     }
-    
-    /**
-     * Stop audio processing and clean up resources
-     */
+
+    getColorState() {
+        return this.colorSystem?.getState() ?? window.colorState ?? null;
+    }
+
     stop() {
-        this.isActive = false;
+        this.isEnabled = false;
         window.audioEnabled = false;
-        
+
+        this.#stopProcessingLoop();
+
+        if (this.analyserNode) {
+            this.analyserNode.disconnect();
+            this.analyserNode = null;
+        }
+
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach(track => track.stop());
+            this.mediaStream = null;
+        }
+
         if (this.context) {
             this.context.close();
             this.context = null;
         }
-        
-        console.log('🎵 Audio Engine: Stopped');
+
+        this.isActive = false;
+        this.#resetReactiveState();
+
+        console.log('🎵 Audio Engine: Stopped and cleaned up');
+    }
+
+    #startProcessing() {
+        if (!this.isActive || !this.isEnabled || !this.audioAnalyzer || this.processingHandle != null) {
+            return;
+        }
+
+        const useRaf = typeof requestAnimationFrame === 'function';
+        this.frameScheduler = useRaf ? 'raf' : 'timeout';
+
+        const step = () => {
+            if (!this.isActive) {
+                this.#stopProcessingLoop();
+                return;
+            }
+
+            if (this.isEnabled) {
+                this.#processFrame();
+            }
+
+            if (this.frameScheduler === 'raf') {
+                this.processingHandle = requestAnimationFrame(step);
+            } else {
+                this.processingHandle = setTimeout(step, 16);
+            }
+        };
+
+        if (this.frameScheduler === 'raf') {
+            this.processingHandle = requestAnimationFrame(step);
+        } else {
+            this.processingHandle = setTimeout(step, 16);
+        }
+    }
+
+    #processFrame() {
+        if (!this.audioAnalyzer || !this.parameterMapper) {
+            return;
+        }
+
+        const audioData = this.audioAnalyzer.analyze();
+        const now = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+        const mapped = this.parameterMapper.map(audioData, now);
+
+        const combinedBands = {
+            subBass: clamp01(audioData.bands?.subBass ?? 0),
+            bass: clamp01(audioData.bands?.bass ?? 0),
+            lowMid: clamp01(audioData.bands?.lowMid ?? 0),
+            mid: clamp01(audioData.bands?.mid ?? 0),
+            highMid: clamp01(audioData.bands?.highMid ?? 0),
+            high: clamp01(audioData.bands?.high ?? 0),
+            air: clamp01(audioData.bands?.air ?? 0)
+        };
+
+        const reactive = {
+            bass: clamp01((mapped.bass ?? 0) * this.sensitivity.bass),
+            mid: clamp01((mapped.mid ?? 0) * this.sensitivity.mid),
+            high: clamp01((mapped.high ?? 0) * this.sensitivity.high),
+            sparkle: clamp01((mapped.sparkle ?? combinedBands.air) * this.sensitivity.sparkle),
+            energy: clamp01((mapped.energy ?? audioData.rms ?? 0) * this.sensitivity.energy),
+            motion: clamp01((mapped.motion ?? audioData.spectralFlux ?? 0) * this.sensitivity.motion),
+            onset: audioData.onset ? 1 : 0,
+            hueShift: clamp01(mapped.hueShift ?? audioData.spectralCentroid ?? 0),
+            intensity: clamp01(mapped.intensity ?? audioData.rms ?? 0),
+            spectralCentroid: clamp01(audioData.spectralCentroid ?? 0),
+            spectralRolloff: clamp01(audioData.spectralRolloff ?? 0),
+            spectralFlux: clamp01(audioData.spectralFlux ?? 0),
+            rms: clamp01(audioData.rms ?? 0),
+            bpm: audioData.bpm || 0,
+            bands: combinedBands
+        };
+
+        reactive.energy = Math.max(reactive.energy, (reactive.bass + reactive.mid + reactive.high) / 3);
+
+        if (this.colorSystem) {
+            const colorState = this.colorSystem.update(now, audioData, reactive);
+            reactive.color = colorState;
+            window.colorState = colorState;
+        }
+
+        window.audioReactive = reactive;
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(reactive, audioData);
+            } catch (error) {
+                console.warn('Audio Engine listener error', error);
+            }
+        });
+
+        if (Math.floor(now) % 5000 < 32) {
+            console.log(
+                `🎵 Audio levels: Bass=${reactive.bass.toFixed(2)} Mid=${reactive.mid.toFixed(2)} High=${reactive.high.toFixed(2)} Energy=${reactive.energy.toFixed(2)} BPM=${Math.round(reactive.bpm)}`
+            );
+        }
+    }
+
+    #stopProcessingLoop() {
+        if (this.processingHandle == null) {
+            return;
+        }
+
+        if (this.frameScheduler === 'raf') {
+            if (typeof cancelAnimationFrame === 'function') {
+                cancelAnimationFrame(this.processingHandle);
+            }
+        } else if (this.frameScheduler === 'timeout') {
+            clearTimeout(this.processingHandle);
+        }
+
+        this.processingHandle = null;
+    }
+
+    #createDefaultMapper() {
+        return new ParameterMapper({
+            bass: {
+                source: data => ((data.bands.subBass + data.bands.bass) / 2) || 0,
+                curve: 'exponential',
+                range: [0, 1],
+                envelope: new ADSREnvelope(60, 140, 0.65, 220),
+                envelopeTrigger: 0.05,
+                envelopeRelease: 0.03
+            },
+            mid: {
+                source: data => ((data.bands.lowMid + data.bands.mid) / 2) || 0,
+                curve: 's-curve',
+                intensity: 0.8,
+                range: [0, 1],
+                envelope: new ADSREnvelope(50, 100, 0.7, 200),
+                envelopeTrigger: 0.05,
+                envelopeRelease: 0.03
+            },
+            high: {
+                source: data => ((data.bands.highMid + data.bands.high) / 2) || 0,
+                curve: 'power',
+                power: 1.4,
+                range: [0, 1],
+                envelope: new ADSREnvelope(35, 90, 0.6, 160),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.025
+            },
+            sparkle: {
+                source: data => data.bands.air || 0,
+                curve: 'power',
+                power: 1.6,
+                range: [0, 1],
+                envelope: new ADSREnvelope(25, 80, 0.5, 140),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            },
+            energy: {
+                source: data => data.rms || 0,
+                curve: 'logarithmic',
+                range: [0.1, 1],
+                envelope: new ADSREnvelope(30, 120, 0.75, 260),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            },
+            motion: {
+                source: data => data.spectralFlux || 0,
+                curve: 'exponential',
+                range: [0, 1],
+                envelope: new ADSREnvelope(20, 80, 0.5, 180),
+                envelopeTrigger: 0.03,
+                envelopeRelease: 0.015
+            },
+            hueShift: {
+                source: data => data.spectralCentroid || 0,
+                curve: 'linear',
+                range: [0, 1]
+            },
+            intensity: {
+                source: data => data.rms || 0,
+                curve: 's-curve',
+                intensity: 0.6,
+                range: [0.2, 1],
+                envelope: new ADSREnvelope(25, 70, 0.8, 160),
+                envelopeTrigger: 0.04,
+                envelopeRelease: 0.02
+            }
+        });
+    }
+
+    #resetReactiveState() {
+        const colorState = this.colorSystem ? this.colorSystem.reset() : null;
+        window.colorState = colorState;
+        window.audioReactive = createDefaultReactiveState(colorState);
+        this.#emitColorEvent(colorState);
+
+        this.listeners.forEach(listener => {
+            try {
+                listener(window.audioReactive, null);
+            } catch (error) {
+                console.warn('Audio Engine listener error during reset', error);
+            }
+        });
+    }
+
+    #emitColorEvent(state) {
+        if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+            return;
+        }
+
+        try {
+            const detail = {
+                state: state || this.getColorState(),
+                config: this.getColorConfiguration()
+            };
+            window.dispatchEvent(new CustomEvent('vib34d:color-state', { detail }));
+        } catch (error) {
+            console.warn('Audio Engine color event dispatch failed', error);
+        }
     }
 }
 
@@ -142,56 +565,45 @@ export class SimpleAudioEngine {
  * Toggles audio reactivity and updates UI state
  */
 export function setupAudioToggle() {
-    window.toggleAudio = function() {
+    window.toggleAudio = async function toggleAudio() {
         const audioBtn = document.getElementById('audioToggle') || document.querySelector('[onclick="toggleAudio()"]');
-        
-        if (!window.audioEngine.isActive) {
-            // Try to start audio
-            window.audioEngine.init().then(success => {
-                if (success) {
-                    if (audioBtn) {
-                        audioBtn.classList.add('active');
-                        audioBtn.title = 'Audio Reactivity: ON';
-                    }
-                    console.log('🎵 Audio Reactivity: ON');
-                } else {
-                    console.log('⚠️ Audio permission denied or not available');
-                }
-            });
-        } else {
-            // Toggle audio processing
-            let audioEnabled = !window.audioEnabled;
-            window.audioEnabled = audioEnabled; // Update global flag
-            
-            if (audioBtn) {
-                // Update button visual state
-                if (audioEnabled) {
-                    audioBtn.classList.add('active');
-                } else {
-                    audioBtn.classList.remove('active');
-                }
-                audioBtn.title = `Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`;
-            }
-            
-            // Audio permission check for mobile
-            if (audioEnabled) {
-                navigator.mediaDevices.getUserMedia({ audio: true }).catch(e => {
-                    audioEnabled = false;
-                    window.audioEnabled = false;
-                    console.log('⚠️ Audio permission denied:', e.message);
-                });
-            }
-            
-            console.log(`🎵 Audio Reactivity: ${audioEnabled ? 'ON' : 'OFF'}`);
+
+        if (!window.audioEngine) {
+            console.warn('⚠️ No audio engine instance available');
+            return;
         }
+
+        if (!window.audioEngine.isActive) {
+            const success = await window.audioEngine.init();
+            if (!success) {
+                console.warn('⚠️ Audio Reactivity: Permission denied or unavailable');
+                return;
+            }
+            if (audioBtn) {
+                audioBtn.classList.add('active');
+                audioBtn.title = 'Audio Reactivity: ON';
+            }
+            console.log('🎵 Audio Reactivity: ON');
+            return;
+        }
+
+        const nextEnabled = !window.audioEnabled;
+        window.audioEngine.setEnabled(nextEnabled);
+
+        if (audioBtn) {
+            audioBtn.classList.toggle('active', nextEnabled);
+            audioBtn.title = `Audio Reactivity: ${nextEnabled ? 'ON' : 'OFF'}`;
+        }
+
+        console.log(`🎵 Audio Reactivity: ${nextEnabled ? 'ON' : 'OFF'}`);
     };
 }
 
 // Create and initialize the global audio engine instance
-const audioEngine = new SimpleAudioEngine();
+const audioEngine = new AdvancedAudioEngine();
 window.audioEngine = audioEngine;
 
 // Set up global audio toggle function
 setupAudioToggle();
 
-console.log('🎵 Audio Engine Module: Loaded');
+console.log('🎵 Audio Engine Module: Advanced analyzer loaded');

--- a/js/controls/ui-handlers.js
+++ b/js/controls/ui-handlers.js
@@ -5,6 +5,388 @@
  */
 
 import { GeometryLibrary } from '../../src/geometry/GeometryLibrary.js';
+import { COLOR_MODES, GRADIENT_TYPES, COLOR_PALETTES } from '../../src/color/ColorSystem.js';
+import {
+    getActiveEngine,
+    getActiveParameterManager,
+    getActiveSystemKey,
+    onRegistryChange,
+    getSystemMetadata,
+    listRegisteredSystems
+} from '../../src/systems/shared/SystemAccess.js';
+import { resolveSystemDescriptor } from '../../src/systems/shared/SystemMetadata.js';
+
+const CONTROL_PANEL_IDS = {
+    panel: 'controlPanel',
+    title: 'controlPanelTitle',
+    groups: 'dynamicControlGroups',
+    geometrySection: 'geometrySection',
+    timelineSection: 'timelineSection',
+    timelineToggle: 'timelineEditorToggle',
+    timelinePresets: 'timelinePresetList',
+    timelineHints: 'timelineHints',
+    timelineEditorActions: 'timelineEditorActions',
+    actionsContainer: 'controlActionList'
+};
+
+let controlShellElements = {
+    panel: null,
+    title: null,
+    groups: null,
+    geometrySection: null,
+    timelineSection: null,
+    timelineToggle: null,
+    timelinePresets: null,
+    timelineHints: null,
+    timelineEditorActions: null,
+    actionsContainer: null
+};
+let controlShellReady = false;
+let controlShellInitialized = false;
+
+let systemInfoElements = {
+    container: null,
+    title: null,
+    description: null,
+    tags: null
+};
+let systemInfoPanelReady = false;
+let pendingSystemDescriptor = null;
+
+function ensureControlShellElements() {
+    if (controlShellReady) {
+        return true;
+    }
+
+    if (typeof document === 'undefined') {
+        return false;
+    }
+
+    const panel = document.getElementById(CONTROL_PANEL_IDS.panel);
+    if (!panel) {
+        return false;
+    }
+
+    controlShellElements = {
+        panel,
+        title: document.getElementById(CONTROL_PANEL_IDS.title),
+        groups: document.getElementById(CONTROL_PANEL_IDS.groups),
+        geometrySection: document.getElementById(CONTROL_PANEL_IDS.geometrySection),
+        timelineSection: document.getElementById(CONTROL_PANEL_IDS.timelineSection),
+        timelineToggle: document.getElementById(CONTROL_PANEL_IDS.timelineToggle),
+        timelinePresets: document.getElementById(CONTROL_PANEL_IDS.timelinePresets),
+        timelineHints: document.getElementById(CONTROL_PANEL_IDS.timelineHints),
+        timelineEditorActions: document.getElementById(CONTROL_PANEL_IDS.timelineEditorActions),
+        actionsContainer: document.getElementById(CONTROL_PANEL_IDS.actionsContainer)
+    };
+
+    geometryGridElement = document.getElementById('geometryGrid');
+    if (geometryGridElement) {
+        geometryGridSystem = getSystemKeyFallback();
+        if (!geometrySubscriptionCleanup) {
+            ensureGeometrySubscription();
+        }
+        renderGeometryGrid();
+    }
+
+    controlShellReady = true;
+    return true;
+}
+
+function ensureSystemInfoElements() {
+    if (systemInfoPanelReady) {
+        return true;
+    }
+
+    if (typeof document === 'undefined') {
+        return false;
+    }
+
+    const container = document.getElementById('systemInfo');
+    const title = document.getElementById('systemName');
+    const description = document.getElementById('systemDescription');
+    const tags = document.getElementById('systemTags');
+
+    if (!container || !title || !description || !tags) {
+        return false;
+    }
+
+    systemInfoElements = { container, title, description, tags };
+    systemInfoPanelReady = true;
+    return true;
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function applyControlPanelAccent(accentColor) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const panel = controlShellElements.panel;
+    if (!panel) {
+        return;
+    }
+
+    const accent = typeof accentColor === 'string' && accentColor.trim()
+        ? accentColor.trim()
+        : '#00ffff';
+
+    panel.style.setProperty('--control-accent', accent);
+    const soft = hexToRgba(accent, 0.25) || 'rgba(0, 255, 255, 0.25)';
+    const strong = hexToRgba(accent, 0.6) || 'rgba(0, 255, 255, 0.6)';
+    panel.style.setProperty('--control-accent-soft', soft);
+    panel.style.setProperty('--control-accent-strong', strong);
+}
+
+function toTagList(...sources) {
+    const tags = [];
+    const seen = new Set();
+
+    const push = (tag) => {
+        if (!tag || typeof tag !== 'string') return;
+        const normalized = tag.trim();
+        if (!normalized) return;
+        const key = normalized.toLowerCase();
+        if (seen.has(key)) return;
+        seen.add(key);
+        tags.push(normalized);
+    };
+
+    sources.forEach(source => {
+        if (!source) return;
+        if (Array.isArray(source)) {
+            source.forEach(item => push(typeof item === 'string' ? item : String(item)));
+        } else if (typeof source === 'string') {
+            source.split(/[|,]/).forEach(part => push(part));
+        }
+    });
+
+    return tags;
+}
+
+function hexToRgba(hex, alpha = 1) {
+    if (typeof hex !== 'string') {
+        return null;
+    }
+
+    const normalized = hex.trim();
+    const shortMatch = normalized.match(/^#([0-9a-f]{3})$/i);
+    const longMatch = normalized.match(/^#([0-9a-f]{6})$/i);
+
+    if (!shortMatch && !longMatch) {
+        return null;
+    }
+
+    let r;
+    let g;
+    let b;
+
+    if (longMatch) {
+        const value = longMatch[1];
+        r = parseInt(value.slice(0, 2), 16);
+        g = parseInt(value.slice(2, 4), 16);
+        b = parseInt(value.slice(4, 6), 16);
+    } else {
+        const value = shortMatch[1];
+        r = parseInt(value[0] + value[0], 16);
+        g = parseInt(value[1] + value[1], 16);
+        b = parseInt(value[2] + value[2], 16);
+    }
+
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function applySystemAccent(accentColor) {
+    if (!systemInfoPanelReady && !ensureSystemInfoElements()) {
+        return;
+    }
+
+    const hasAccent = typeof accentColor === 'string' && accentColor.trim().length > 0;
+    const container = systemInfoElements.container;
+    const title = systemInfoElements.title;
+    const tagsContainer = systemInfoElements.tags;
+
+    if (container) {
+        if (hasAccent) {
+            container.style.setProperty('--system-accent', accentColor);
+        } else {
+            container.style.removeProperty('--system-accent');
+        }
+    }
+
+    if (title) {
+        if (hasAccent) {
+            title.style.color = accentColor;
+        } else {
+            title.style.removeProperty('color');
+        }
+    }
+
+    if (tagsContainer) {
+        const accentBackground = hasAccent ? (hexToRgba(accentColor, 0.14) || 'rgba(0, 255, 255, 0.12)') : '';
+        tagsContainer.querySelectorAll('.system-tag').forEach(tag => {
+            if (hasAccent) {
+                tag.style.borderColor = accentColor;
+                tag.style.color = accentColor;
+                tag.style.backgroundColor = accentBackground;
+            } else {
+                tag.style.removeProperty('border-color');
+                tag.style.removeProperty('color');
+                tag.style.removeProperty('background-color');
+            }
+        });
+    }
+}
+
+function renderSystemInfo(key, metadata) {
+    if (!ensureSystemInfoElements()) {
+        pendingSystemDescriptor = { key, metadata };
+        return;
+    }
+
+    const normalizedKey = typeof key === 'string' ? key.toLowerCase() : '';
+    const descriptor = resolveSystemDescriptor(normalizedKey, metadata || {});
+
+    const systemTitle = descriptor.title || formatColorLabel(normalizedKey || 'Active System');
+    const descriptionSegments = [];
+
+    if (descriptor.description) {
+        descriptionSegments.push(descriptor.description.trim());
+    }
+    if (descriptor.audioFocus) {
+        descriptionSegments.push(`Audio focus: ${descriptor.audioFocus.trim()}.`);
+    }
+    if (descriptor.visualFocus) {
+        descriptionSegments.push(`Visual focus: ${descriptor.visualFocus.trim()}.`);
+    }
+    if (descriptor.bestFor) {
+        descriptionSegments.push(`Best for ${descriptor.bestFor.trim()}.`);
+    }
+
+    const descriptionText = descriptionSegments.join(' ').replace(/\s+\./g, '.').replace(/\.\./g, '.');
+
+    if (systemInfoElements.title) {
+        systemInfoElements.title.textContent = systemTitle;
+    }
+    if (systemInfoElements.description) {
+        systemInfoElements.description.textContent = descriptionText || 'Explore each visualization system to see its strengths.';
+    }
+
+    if (systemInfoElements.tags) {
+        const tags = toTagList(descriptor.tags, descriptor.keywords, descriptor.moods);
+        if (tags.length) {
+            systemInfoElements.tags.innerHTML = tags
+                .map(tag => `<span class="system-tag">${escapeHtml(tag)}</span>`)
+                .join('');
+        } else {
+            systemInfoElements.tags.innerHTML = '<span class="system-tag">Live Reactive</span>';
+        }
+    }
+
+    applySystemAccent(descriptor.accentColor || descriptor.highlightColor || null);
+    applyControlPanelAccent(descriptor.accentColor || descriptor.highlightColor || null);
+
+    if (systemInfoElements.container) {
+        systemInfoElements.container.dataset.systemKey = descriptor.key || normalizedKey || '';
+    }
+
+    const statusElement = document.getElementById('status');
+    if (statusElement) {
+        const currentStatus = statusElement.textContent || '';
+        if (!currentStatus.trim() || /select a mode/i.test(currentStatus) || /system ready/i.test(currentStatus)) {
+            statusElement.textContent = `System ready: ${systemTitle}`;
+        }
+    }
+}
+
+function refreshSystemInfoPanel() {
+    const key = getSystemKeyFallback();
+    const metadata = getSystemMetadata(key);
+    renderSystemInfo(key, metadata);
+    renderAdaptiveControlPanel(key, metadata);
+}
+
+function syncSystemButtonTooltips() {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    const descriptors = listRegisteredSystems();
+    if (!descriptors.length) {
+        return;
+    }
+
+    const metadataMap = new Map();
+    descriptors.forEach(({ key, metadata }) => {
+        if (!key) return;
+        metadataMap.set(key, resolveSystemDescriptor(key, metadata || {}));
+    });
+
+    document.querySelectorAll('.system-btn').forEach(btn => {
+        const key = btn.dataset.system;
+        if (!key) return;
+        const meta = metadataMap.get(key) || resolveSystemDescriptor(key);
+        if (!meta) return;
+
+        const tooltipSegments = [];
+        if (meta.description) {
+            tooltipSegments.push(meta.description);
+        }
+        if (meta.bestFor) {
+            tooltipSegments.push(`Best for ${meta.bestFor}.`);
+        }
+
+        if (tooltipSegments.length) {
+            btn.title = tooltipSegments.join(' ');
+        }
+    });
+}
+
+function initializeSystemInfoPanel() {
+    if (!ensureSystemInfoElements()) {
+        return;
+    }
+
+    let activeKey = getSystemKeyFallback();
+    let activeMetadata = getSystemMetadata(activeKey);
+
+    if (pendingSystemDescriptor) {
+        const { key, metadata } = pendingSystemDescriptor;
+        pendingSystemDescriptor = null;
+        renderSystemInfo(key, metadata);
+        activeKey = key || activeKey;
+        activeMetadata = metadata || activeMetadata;
+    } else {
+        renderSystemInfo(activeKey, activeMetadata);
+    }
+
+    syncSystemButtonTooltips();
+    initializeControlShell();
+    renderAdaptiveControlPanel(activeKey, activeMetadata);
+}
+
+if (typeof document !== 'undefined') {
+    const initSystemPanel = () => initializeSystemInfoPanel();
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initSystemPanel, { once: true });
+    } else {
+        setTimeout(initSystemPanel, 0);
+    }
+}
+
+onRegistryChange(({ key, metadata }) => {
+    renderSystemInfo(key, metadata);
+    syncSystemButtonTooltips();
+    renderAdaptiveControlPanel(key, metadata);
+});
 
 // Global state variables
 let audioEnabled = window.audioEnabled || false;
@@ -15,7 +397,24 @@ const LEGACY_SYSTEM_KEYS = ['faceted', 'quantum', 'holographic', 'polychora'];
 let cachedGeometryNames = sanitizeGeometryList(GeometryLibrary.getGeometryNames());
 let geometrySubscriptionCleanup = null;
 let geometryGridElement = null;
-let geometryGridSystem = 'faceted';
+let geometryGridSystem = getActiveSystemKey() || 'faceted';
+
+const COLOR_MODE_OPTIONS = Array.from(COLOR_MODES);
+const GRADIENT_TYPE_OPTIONS = Array.from(GRADIENT_TYPES);
+const COLOR_PALETTE_OPTIONS = Object.keys(COLOR_PALETTES);
+const getSystemKeyFallback = () => getActiveSystemKey() || window.currentSystem || 'faceted';
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+let colorControlsInitialized = false;
+let gradientPreviewElement = null;
+let gradientPreviewLoopActive = false;
+let colorModeSelect = null;
+let colorPaletteSelect = null;
+let gradientTypeSelect = null;
+let gradientSpeedInput = null;
+let gradientSpeedValueLabel = null;
+let colorReactivityInput = null;
+let colorReactivityValueLabel = null;
 
 function sanitizeGeometryList(names = []) {
     const seen = new Set();
@@ -113,7 +512,7 @@ function ensureGeometrySubscription() {
     }, { once: true });
 }
 
-function getGeometryNamesForSystem(system = window.currentSystem || 'faceted') {
+function getGeometryNamesForSystem(system = getSystemKeyFallback()) {
     const fallback = cachedGeometryNames.length ? cachedGeometryNames : sanitizeGeometryList(GeometryLibrary.getGeometryNames());
     const manual = window.geometries?.[system];
     if (!Array.isArray(manual) || !manual.length) {
@@ -153,22 +552,1045 @@ function renderGeometryGrid() {
 syncLegacyGeometryState(cachedGeometryNames);
 ensureGeometrySubscription();
 
+onRegistryChange(({ key }) => {
+    if (!key) {
+        return;
+    }
+    if (geometryGridSystem !== key) {
+        geometryGridSystem = key;
+        if (geometryGridElement) {
+            renderGeometryGrid();
+        }
+    }
+});
+
+function formatColorLabel(key) {
+    if (!key) {
+        return 'Default';
+    }
+    return key.replace(/[-_]/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function normalizeControlGroups(groups) {
+    if (!Array.isArray(groups)) {
+        return [];
+    }
+
+    return groups
+        .map(group => {
+            if (!group) {
+                return null;
+            }
+
+            const parameters = Array.isArray(group.parameters)
+                ? group.parameters
+                    .map(param => {
+                        if (!param) {
+                            return null;
+                        }
+                        const parameter = param.parameter || param.name || param.id;
+                        if (!parameter) {
+                            return null;
+                        }
+                        return {
+                            parameter,
+                            label: param.label || param.title || formatColorLabel(parameter),
+                            icon: param.icon || null,
+                            displayId: param.displayId || `${parameter}Value`,
+                            min: typeof param.min === 'number' ? param.min : undefined,
+                            max: typeof param.max === 'number' ? param.max : undefined,
+                            step: typeof param.step === 'number' ? param.step : undefined,
+                            decimals: typeof param.decimals === 'number' ? param.decimals : undefined,
+                            format: param.format || null,
+                            unit: param.unit || '',
+                            hint: param.hint || '',
+                            defaultValue: param.defaultValue
+                        };
+                    })
+                    .filter(Boolean)
+                : [];
+
+            if (!parameters.length) {
+                return null;
+            }
+
+            return {
+                id: group.id || group.key || group.title || '',
+                title: group.title || group.name || '',
+                icon: group.icon || null,
+                description: group.description || '',
+                parameters
+            };
+        })
+        .filter(Boolean);
+}
+
+function normalizeActionHandler(action) {
+    if (!action) {
+        return null;
+    }
+
+    if (typeof action === 'function') {
+        return action;
+    }
+
+    if (typeof action === 'string') {
+        return {
+            type: 'global',
+            name: action,
+            args: []
+        };
+    }
+
+    if (typeof action === 'object') {
+        const handlerName = action.method || action.name || action.handler || null;
+        const normalizedType = action.type || (action.method ? 'choreographer' : 'global');
+        return {
+            type: normalizedType,
+            name: handlerName,
+            method: action.method || handlerName,
+            args: Array.isArray(action.args) ? action.args : [],
+            requireMode: action.requireMode,
+            event: action.event || null,
+            payload: action.payload,
+            toggle: action.toggle || null
+        };
+    }
+
+    return null;
+}
+
+function normalizeActionList(actions) {
+    if (!Array.isArray(actions)) {
+        return [];
+    }
+
+    return actions
+        .map((item, index) => {
+            if (!item) {
+                return null;
+            }
+
+            const label = item.label || item.title || null;
+            const handler = normalizeActionHandler(item.action ?? item.handler ?? null);
+
+            if (!label || !handler) {
+                return null;
+            }
+
+            return {
+                id: item.id || item.key || `${handler.type || 'action'}-${index}`,
+                label,
+                icon: item.icon || null,
+                description: item.description || item.hint || '',
+                action: handler,
+                disabled: Boolean(item.disabled),
+                kind: item.kind || item.category || null,
+                size: item.size || null
+            };
+        })
+        .filter(Boolean);
+}
+
+function normalizeHints(hints) {
+    if (!hints) {
+        return [];
+    }
+
+    if (Array.isArray(hints)) {
+        return hints
+            .map(hint => {
+                if (typeof hint === 'string') {
+                    return hint.trim();
+                }
+                if (hint && typeof hint === 'object' && typeof hint.text === 'string') {
+                    return hint.text.trim();
+                }
+                return null;
+            })
+            .filter(Boolean);
+    }
+
+    if (typeof hints === 'string') {
+        return hints.split(/\n+/).map(line => line.trim()).filter(Boolean);
+    }
+
+    return [];
+}
+
+function resolveActionAvailability(descriptor) {
+    if (!descriptor || descriptor.disabled) {
+        return false;
+    }
+
+    const action = descriptor.action;
+    if (typeof action === 'function') {
+        return true;
+    }
+
+    if (!action) {
+        return false;
+    }
+
+    const type = action.type || 'global';
+    const methodName = action.method || action.name || null;
+
+    const requiredMode = action.requireMode || descriptor.requireMode;
+    if (requiredMode && typeof window !== 'undefined') {
+        const currentMode = window.currentMode || window?.choreographer?.mode || null;
+        if (Array.isArray(requiredMode)) {
+            if (!requiredMode.includes(currentMode)) {
+                return false;
+            }
+        } else if (requiredMode !== currentMode) {
+            return false;
+        }
+    }
+
+    switch (type) {
+        case 'choreographer':
+            return typeof window !== 'undefined'
+                && window.choreographer
+                && methodName
+                && typeof window.choreographer[methodName] === 'function';
+        case 'toggle': {
+            const toggleName = methodName || 'toggleTimelineEditor';
+            return typeof window !== 'undefined'
+                && typeof window[toggleName] === 'function';
+        }
+        case 'dispatch':
+            return typeof window !== 'undefined';
+        case 'global':
+        case 'function':
+        default:
+            if (!methodName) {
+                return false;
+            }
+            return typeof window !== 'undefined'
+                && typeof window[methodName] === 'function';
+    }
+}
+
+function executePanelAction(descriptor, context = {}) {
+    if (!descriptor) {
+        return false;
+    }
+
+    const action = descriptor.action || descriptor;
+
+    try {
+        if (typeof action === 'function') {
+            const result = action({ descriptor, context });
+            if (result && typeof result.then === 'function') {
+                result.catch(error => console.error('[UIHandlers] Action promise rejected', error));
+            }
+            return true;
+        }
+
+        if (!action) {
+            return false;
+        }
+
+        const args = Array.isArray(action.args) ? action.args : [];
+        switch (action.type) {
+            case 'choreographer': {
+                if (typeof window === 'undefined' || !window.choreographer) {
+                    return false;
+                }
+                const methodName = action.method || action.name;
+                if (methodName && typeof window.choreographer[methodName] === 'function') {
+                    const result = window.choreographer[methodName](...args);
+                    if (result && typeof result.then === 'function') {
+                        result.catch(error => console.error('[UIHandlers] Choreographer action failed', methodName, error));
+                    }
+                    return true;
+                }
+                return false;
+            }
+            case 'toggle': {
+                const toggleName = action.method || action.name || 'toggleTimelineEditor';
+                if (typeof window !== 'undefined' && typeof window[toggleName] === 'function') {
+                    window[toggleName](...args);
+                    return true;
+                }
+                return false;
+            }
+            case 'dispatch': {
+                if (typeof window !== 'undefined') {
+                    const eventName = action.event || descriptor.id || 'vib34d:panel-action';
+                    window.dispatchEvent(new CustomEvent(eventName, { detail: { descriptor, context, payload: action.payload } }));
+                    return true;
+                }
+                return false;
+            }
+            case 'global':
+            case 'function':
+            default: {
+                const methodName = action.method || action.name;
+                if (typeof window !== 'undefined' && methodName && typeof window[methodName] === 'function') {
+                    const result = window[methodName](...args);
+                    if (result && typeof result.then === 'function') {
+                        result.catch(error => console.error('[UIHandlers] Global action failed', methodName, error));
+                    }
+                    return true;
+                }
+                return false;
+            }
+        }
+    } catch (error) {
+        console.error('[UIHandlers] Failed to execute action', descriptor, error);
+        return false;
+    }
+}
+
+function createActionButton(descriptor, { size = 'default', context = 'panel' } = {}) {
+    if (!descriptor) {
+        return null;
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'panel-btn';
+    if (size === 'compact' || descriptor.size === 'compact') {
+        button.classList.add('compact');
+    }
+    if (context === 'timeline-preset') {
+        button.classList.add('timeline-preset-btn');
+    } else if (context === 'timeline-editor') {
+        button.classList.add('timeline-editor-btn');
+    }
+
+    button.dataset.actionId = descriptor.id || '';
+    if (descriptor.kind) {
+        button.dataset.actionKind = descriptor.kind;
+    }
+
+    button.textContent = descriptor.icon ? `${descriptor.icon} ${descriptor.label}` : descriptor.label;
+    if (descriptor.description) {
+        button.title = descriptor.description;
+    }
+
+    const available = resolveActionAvailability(descriptor);
+    if (!available) {
+        button.disabled = true;
+    }
+
+    button.addEventListener('click', () => {
+        executePanelAction(descriptor, { source: context });
+    });
+
+    return button;
+}
+
+function renderTimelinePresets(timelineDescriptor) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const container = controlShellElements.timelinePresets;
+    if (!container) {
+        return;
+    }
+
+    const presets = normalizeActionList(timelineDescriptor?.presets);
+    if (!presets.length) {
+        container.innerHTML = '<div class="timeline-empty">Preset templates coming soon.</div>';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    presets.forEach(preset => {
+        const button = createActionButton(preset, { size: 'compact', context: 'timeline-preset' });
+        if (button) {
+            fragment.appendChild(button);
+        }
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+}
+
+function renderTimelineActions(timelineDescriptor) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const container = controlShellElements.timelineEditorActions;
+    if (!container) {
+        return;
+    }
+
+    const actions = normalizeActionList(timelineDescriptor?.actions);
+    if (!actions.length) {
+        container.innerHTML = '<div class="timeline-empty">Timeline actions will appear here.</div>';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    actions.forEach(action => {
+        const button = createActionButton(action, { size: 'compact', context: 'timeline-editor' });
+        if (button) {
+            fragment.appendChild(button);
+        }
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+}
+
+function renderTimelineHints(timelineDescriptor) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const container = controlShellElements.timelineHints;
+    if (!container) {
+        return;
+    }
+
+    const hints = normalizeHints(timelineDescriptor?.hints);
+    if (!hints.length) {
+        container.innerHTML = '';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    hints.forEach(text => {
+        const hint = document.createElement('div');
+        hint.className = 'timeline-hint';
+        hint.textContent = text;
+        fragment.appendChild(hint);
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+}
+
+function renderQuickActions(descriptor) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const container = controlShellElements.actionsContainer;
+    if (!container) {
+        return;
+    }
+
+    const actions = normalizeActionList(descriptor?.quickActions || descriptor);
+    if (!actions.length) {
+        container.innerHTML = '<div class="control-empty">Quick actions coming soon.</div>';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    actions.forEach(action => {
+        const button = createActionButton(action, { size: action.size || 'default', context: 'quick-action' });
+        if (button) {
+            fragment.appendChild(button);
+        }
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+}
+
+function renderTimelineDescriptor(descriptor) {
+    const timelineDescriptor = descriptor?.timeline || descriptor || {};
+    renderTimelinePresets(timelineDescriptor);
+    renderTimelineActions(timelineDescriptor);
+    renderTimelineHints(timelineDescriptor);
+}
+
+function getParameterDefinitionFor(manager, parameter) {
+    if (!manager || typeof parameter !== 'string') {
+        return null;
+    }
+
+    if (typeof manager.getParameterDefinition === 'function') {
+        try {
+            const definition = manager.getParameterDefinition(parameter);
+            if (definition) {
+                return definition;
+            }
+        } catch (error) {
+            console.debug('[UIHandlers] Parameter definition lookup failed', parameter, error);
+        }
+    }
+
+    const defs = manager.parameterDefs || {};
+    if (defs && defs[parameter]) {
+        return { ...defs[parameter] };
+    }
+
+    return null;
+}
+
+function resolveParameterValue(manager, parameter, definition, config = {}) {
+    if (window.userParameterState && Object.prototype.hasOwnProperty.call(window.userParameterState, parameter)) {
+        const userValue = Number(window.userParameterState[parameter]);
+        if (Number.isFinite(userValue)) {
+            return userValue;
+        }
+    }
+
+    if (manager?.params && Object.prototype.hasOwnProperty.call(manager.params, parameter)) {
+        const value = Number(manager.params[parameter]);
+        if (Number.isFinite(value)) {
+            return value;
+        }
+        return manager.params[parameter];
+    }
+
+    if (definition && typeof definition.default !== 'undefined') {
+        const defaultValue = Number(definition.default);
+        if (Number.isFinite(defaultValue)) {
+            return defaultValue;
+        }
+        return definition.default;
+    }
+
+    if (typeof config.defaultValue !== 'undefined') {
+        const fallback = Number(config.defaultValue);
+        if (Number.isFinite(fallback)) {
+            return fallback;
+        }
+        return config.defaultValue;
+    }
+
+    if (definition && typeof definition.min === 'number' && typeof definition.max === 'number') {
+        return (definition.min + definition.max) / 2;
+    }
+
+    return 0;
+}
+
+function formatControlValue(value, config = {}) {
+    if (!Number.isFinite(value)) {
+        return '--';
+    }
+
+    const format = config.format || null;
+    const unit = typeof config.unit === 'string' ? config.unit : '';
+    const decimals = typeof config.decimals === 'number'
+        ? config.decimals
+        : (Math.abs(value) >= 10 ? 1 : 2);
+
+    if (format === 'degrees') {
+        if (typeof config.decimals === 'number') {
+            return `${value.toFixed(config.decimals)}${unit || '°'}`;
+        }
+        return `${Math.round(value)}${unit || '°'}`;
+    }
+
+    if (format === 'integer') {
+        return `${Math.round(value)}${unit}`;
+    }
+
+    const text = value.toFixed(decimals);
+    return unit ? `${text}${unit}` : text;
+}
+
+function buildControlForParameter(manager, config) {
+    if (!config || !config.parameter) {
+        return null;
+    }
+
+    const parameter = config.parameter;
+    const definition = getParameterDefinitionFor(manager, parameter) || {};
+    const min = typeof config.min === 'number'
+        ? config.min
+        : (typeof definition.min === 'number' ? definition.min : 0);
+    const max = typeof config.max === 'number'
+        ? config.max
+        : (typeof definition.max === 'number' ? definition.max : 1);
+    const step = typeof config.step === 'number'
+        ? config.step
+        : (typeof definition.step === 'number' ? definition.step : 0.01);
+
+    let value = resolveParameterValue(manager, parameter, definition, config);
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue)) {
+        value = numericValue;
+    }
+
+    if (Number.isFinite(value)) {
+        if (Number.isFinite(min)) {
+            value = Math.max(value, min);
+        }
+        if (Number.isFinite(max)) {
+            value = Math.min(value, max);
+        }
+    } else {
+        value = Number.isFinite(min) ? min : 0;
+    }
+
+    const container = document.createElement('div');
+    container.className = 'control-group';
+    container.dataset.parameter = parameter;
+
+    const label = document.createElement('label');
+    label.className = 'control-label';
+    label.setAttribute('for', parameter);
+
+    const labelText = document.createElement('span');
+    labelText.textContent = config.icon ? `${config.icon} ${config.label || formatColorLabel(parameter)}` : (config.label || formatColorLabel(parameter));
+    label.appendChild(labelText);
+
+    const valueDisplay = document.createElement('span');
+    valueDisplay.className = 'control-value';
+    valueDisplay.id = config.displayId || `${parameter}Value`;
+    valueDisplay.textContent = formatControlValue(Number(value), config);
+    label.appendChild(valueDisplay);
+
+    container.appendChild(label);
+
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.className = 'control-slider';
+    slider.id = parameter;
+    slider.name = parameter;
+
+    if (Number.isFinite(min)) {
+        slider.min = String(min);
+    }
+    if (Number.isFinite(max)) {
+        slider.max = String(max);
+    }
+    if (Number.isFinite(step) && step > 0) {
+        slider.step = String(step);
+    }
+    slider.value = String(Number.isFinite(value) ? value : (Number.isFinite(min) ? min : 0));
+
+    slider.addEventListener('input', () => {
+        const numeric = parseFloat(slider.value);
+        if (!Number.isFinite(numeric)) {
+            return;
+        }
+        valueDisplay.textContent = formatControlValue(numeric, config);
+        if (typeof window.updateParameter === 'function') {
+            window.updateParameter(parameter, numeric);
+        }
+    });
+
+    container.appendChild(slider);
+
+    if (config.hint) {
+        const hint = document.createElement('div');
+        hint.className = 'control-hint';
+        hint.textContent = config.hint;
+        container.appendChild(hint);
+    }
+
+    return container;
+}
+
+function renderAdaptiveControlGroups(descriptor) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const container = controlShellElements.groups;
+    if (!container) {
+        return;
+    }
+
+    const manager = getActiveParameterManager();
+    const engine = getActiveEngine();
+    const groups = normalizeControlGroups(descriptor?.controlGroups);
+
+    if (!groups.length) {
+        container.innerHTML = '<div class="control-empty">Control definitions coming soon.</div>';
+        return;
+    }
+
+    if (!manager && !engine) {
+        container.innerHTML = '<div class="control-empty">System initializing… controls will unlock shortly.</div>';
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    groups.forEach(group => {
+        const section = document.createElement('div');
+        section.className = 'control-collection';
+        if (group.id) {
+            section.dataset.group = group.id;
+        }
+
+        if (group.title || group.icon) {
+            const titleEl = document.createElement('div');
+            titleEl.className = 'control-group-title';
+            if (group.icon) {
+                const iconSpan = document.createElement('span');
+                iconSpan.className = 'control-group-icon';
+                iconSpan.textContent = group.icon;
+                titleEl.appendChild(iconSpan);
+            }
+            if (group.title) {
+                const titleSpan = document.createElement('span');
+                titleSpan.textContent = group.title;
+                titleEl.appendChild(titleSpan);
+            }
+            section.appendChild(titleEl);
+        }
+
+        if (group.description) {
+            const descriptionEl = document.createElement('div');
+            descriptionEl.className = 'control-group-description';
+            descriptionEl.textContent = group.description;
+            section.appendChild(descriptionEl);
+        }
+
+        group.parameters.forEach(parameterConfig => {
+            const control = buildControlForParameter(manager, parameterConfig);
+            if (control) {
+                section.appendChild(control);
+            }
+        });
+
+        fragment.appendChild(section);
+    });
+
+    container.innerHTML = '';
+    container.appendChild(fragment);
+}
+
+function renderAdaptiveControlPanel(key, metadata) {
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    const descriptor = resolveSystemDescriptor(key, metadata || {});
+
+    if (controlShellElements.panel) {
+        controlShellElements.panel.dataset.systemKey = descriptor.key || key || '';
+    }
+
+    if (controlShellElements.title) {
+        controlShellElements.title.textContent = descriptor.panelTitle
+            || descriptor.title
+            || formatColorLabel(descriptor.key || key || 'Active System');
+    }
+
+    if (controlShellElements.geometrySection) {
+        controlShellElements.geometrySection.style.display = descriptor.supportsGeometryGrid === false ? 'none' : '';
+    }
+
+    if (controlShellElements.timelineSection) {
+        controlShellElements.timelineSection.dataset.supportsTimeline = descriptor.supportsTimeline ? 'true' : 'false';
+    }
+
+    if (controlShellElements.timelineToggle) {
+        controlShellElements.timelineToggle.dataset.systemSupportsTimeline = descriptor.supportsTimeline ? 'true' : 'false';
+    }
+
+    applyControlPanelAccent(descriptor.accentColor || descriptor.highlightColor || null);
+    renderAdaptiveControlGroups(descriptor);
+    renderTimelineDescriptor(descriptor);
+    renderQuickActions(descriptor);
+}
+
+function initializeControlShell(force = false) {
+    if (!force && controlShellInitialized) {
+        return;
+    }
+
+    if (!ensureControlShellElements()) {
+        return;
+    }
+
+    controlShellInitialized = true;
+
+    const key = getSystemKeyFallback();
+    const metadata = getSystemMetadata(key);
+    renderAdaptiveControlPanel(key, metadata);
+}
+
+function ensureSelectOptions(select, options) {
+    if (!select || !Array.isArray(options)) {
+        return;
+    }
+
+    const existing = Array.from(select.options).map(option => option.value);
+    const needsUpdate = existing.length !== options.length || existing.some((value, index) => value !== options[index]);
+
+    if (!needsUpdate) {
+        return;
+    }
+
+    select.innerHTML = options.map(option => `<option value="${option}">${formatColorLabel(option)}</option>`).join('');
+}
+
+function startGradientPreviewLoop() {
+    if (gradientPreviewLoopActive || !gradientPreviewElement) {
+        return;
+    }
+
+    gradientPreviewLoopActive = true;
+
+    const update = () => {
+        if (!gradientPreviewElement) {
+            gradientPreviewLoopActive = false;
+            return;
+        }
+
+        const gradientState = window.colorState?.gradient;
+        if (gradientState?.css && gradientPreviewElement.dataset.currentCss !== gradientState.css) {
+            gradientPreviewElement.style.background = gradientState.css;
+            gradientPreviewElement.dataset.currentCss = gradientState.css;
+        }
+
+        requestAnimationFrame(update);
+    };
+
+    requestAnimationFrame(update);
+}
+
+function syncColorControls(config, state) {
+    if (!colorControlsInitialized) {
+        return;
+    }
+
+    const audioEngine = window.audioEngine;
+    const activeConfig = config || audioEngine?.getColorConfiguration?.() || {};
+    const activeState = state || audioEngine?.getColorState?.() || window.colorState || {};
+
+    if (colorModeSelect) {
+        const modeValue = activeConfig.colorMode || 'single';
+        if (colorModeSelect.value !== modeValue) {
+            colorModeSelect.value = modeValue;
+        }
+    }
+
+    if (colorPaletteSelect) {
+        const paletteValue = activeConfig.colorPalette || '';
+        if (paletteValue && !Array.from(colorPaletteSelect.options).some(option => option.value === paletteValue)) {
+            const option = document.createElement('option');
+            option.value = paletteValue;
+            option.textContent = formatColorLabel(paletteValue);
+            colorPaletteSelect.appendChild(option);
+        }
+        if (paletteValue && colorPaletteSelect.value !== paletteValue) {
+            colorPaletteSelect.value = paletteValue;
+        }
+    }
+
+    if (gradientTypeSelect) {
+        const gradientValue = activeConfig.gradientType || 'horizontal';
+        if (gradientTypeSelect.value !== gradientValue) {
+            gradientTypeSelect.value = gradientValue;
+        }
+    }
+
+    if (gradientSpeedInput) {
+        const speedValue = typeof activeConfig.gradientSpeed === 'number' ? activeConfig.gradientSpeed : 0.25;
+        if (gradientSpeedInput.value !== String(speedValue)) {
+            gradientSpeedInput.value = String(speedValue);
+        }
+        if (gradientSpeedValueLabel) {
+            gradientSpeedValueLabel.textContent = `${speedValue.toFixed(2)}x`;
+        }
+    }
+
+    if (colorReactivityInput) {
+        const reactivityValue = typeof activeConfig.colorReactivity === 'number' ? activeConfig.colorReactivity : 0.65;
+        if (colorReactivityInput.value !== String(reactivityValue)) {
+            colorReactivityInput.value = String(reactivityValue);
+        }
+        if (colorReactivityValueLabel) {
+            colorReactivityValueLabel.textContent = `${Math.round(clamp(reactivityValue, 0, 1) * 100)}%`;
+        }
+    }
+
+    if (gradientPreviewElement && activeState?.gradient?.css) {
+        gradientPreviewElement.style.background = activeState.gradient.css;
+        gradientPreviewElement.dataset.currentCss = activeState.gradient.css;
+    }
+}
+
+function initializeColorControls(force = false) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    if (!force && colorControlsInitialized) {
+        syncColorControls();
+        return;
+    }
+
+    if (!window.audioEngine) {
+        setTimeout(() => initializeColorControls(force), 150);
+        return;
+    }
+
+    colorModeSelect = document.getElementById('colorModeControl');
+    colorPaletteSelect = document.getElementById('colorPaletteControl');
+    gradientTypeSelect = document.getElementById('gradientTypeControl');
+    gradientSpeedInput = document.getElementById('gradientSpeedControl');
+    gradientSpeedValueLabel = document.getElementById('gradientSpeedValue');
+    colorReactivityInput = document.getElementById('colorReactivityControl');
+    colorReactivityValueLabel = document.getElementById('colorReactivityValue');
+    gradientPreviewElement = document.getElementById('gradientPreview');
+
+    if (!colorModeSelect || !colorPaletteSelect || !gradientTypeSelect || !gradientSpeedInput || !colorReactivityInput) {
+        return;
+    }
+
+    const audioEngine = window.audioEngine;
+    const availableModes = audioEngine?.getAvailableColorModes?.() ?? COLOR_MODE_OPTIONS;
+    const availablePalettes = audioEngine?.getAvailablePalettes?.() ?? COLOR_PALETTE_OPTIONS;
+    const availableGradients = audioEngine?.getAvailableGradients?.() ?? GRADIENT_TYPE_OPTIONS;
+
+    ensureSelectOptions(colorModeSelect, availableModes);
+    ensureSelectOptions(colorPaletteSelect, availablePalettes.length ? availablePalettes : COLOR_PALETTE_OPTIONS);
+    ensureSelectOptions(gradientTypeSelect, availableGradients);
+
+    colorModeSelect.addEventListener('change', event => {
+        audioEngine?.setColorMode?.(event.target.value);
+    });
+
+    colorPaletteSelect.addEventListener('change', event => {
+        audioEngine?.setColorPalette?.(event.target.value);
+    });
+
+    gradientTypeSelect.addEventListener('change', event => {
+        audioEngine?.setGradientType?.(event.target.value);
+    });
+
+    gradientSpeedInput.addEventListener('input', event => {
+        const value = parseFloat(event.target.value);
+        if (gradientSpeedValueLabel) {
+            gradientSpeedValueLabel.textContent = `${(Number.isFinite(value) ? value : 0).toFixed(2)}x`;
+        }
+        audioEngine?.setGradientSpeed?.(value);
+    });
+
+    colorReactivityInput.addEventListener('input', event => {
+        const value = parseFloat(event.target.value);
+        if (colorReactivityValueLabel) {
+            colorReactivityValueLabel.textContent = `${Math.round(clamp(value, 0, 1) * 100)}%`;
+        }
+        audioEngine?.setColorReactivity?.(value);
+    });
+
+    colorControlsInitialized = true;
+    syncColorControls();
+
+    if (gradientPreviewElement) {
+        startGradientPreviewLoop();
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('vib34d:system-selected', event => {
+        const detail = event?.detail || {};
+        renderSystemInfo(detail.key, detail.metadata);
+        syncSystemButtonTooltips();
+        renderAdaptiveControlPanel(detail.key, detail.metadata);
+    });
+
+    window.addEventListener('vib34d:color-state', event => {
+        syncColorControls(event.detail?.config, event.detail?.state);
+    });
+
+    window.addEventListener('vib34d:timeline-updated', event => {
+        const detail = event?.detail || {};
+        if (ensureControlShellElements() && controlShellElements.timelineSection) {
+            if (typeof detail.count === 'number') {
+                controlShellElements.timelineSection.dataset.sequenceCount = String(detail.count);
+            }
+            if (typeof detail.mode === 'string') {
+                controlShellElements.timelineSection.dataset.mode = detail.mode;
+            }
+        }
+
+        const key = getSystemKeyFallback();
+        const metadata = getSystemMetadata(key);
+        const descriptor = resolveSystemDescriptor(key, metadata || {});
+        renderTimelineDescriptor(descriptor);
+        renderQuickActions(descriptor);
+    });
+
+    window.refreshColorControls = (force = false) => {
+        initializeColorControls(force);
+    };
+
+    window.refreshSystemInfoPanel = () => refreshSystemInfoPanel();
+
+    window.refreshControlPanel = () => {
+        initializeControlShell();
+        const key = getSystemKeyFallback();
+        renderAdaptiveControlPanel(key, getSystemMetadata(key));
+    };
+}
+
+if (typeof document !== 'undefined') {
+    const initControls = () => initializeColorControls();
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initControls, { once: true });
+    } else {
+        setTimeout(initControls, 0);
+    }
+}
+
+if (typeof document !== 'undefined') {
+    const initControlShell = () => initializeControlShell();
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initControlShell, { once: true });
+    } else {
+        setTimeout(initControlShell, 0);
+    }
+}
+
 /**
  * Main parameter update function - CRITICAL for all visualizers
  * Routes parameters to appropriate engine based on current system
  */
 window.updateParameter = function(param, value) {
-    // CRITICAL: Store user's parameter choice for persistence
-    window.userParameterState[param] = parseFloat(value);
-    
-    // GALLERY PERFORMANCE FIX: Reduce parameter logging spam in gallery context
-    if (!window.isGalleryPreview) {
-        console.log(`💾 User parameter: ${param} = ${value}`);
+    if (!window.userParameterState) {
+        window.userParameterState = {};
     }
-    
+
+    const systemKey = getSystemKeyFallback();
+    const manager = getActiveParameterManager();
+    const definition = manager?.getParameterDefinition?.(param) || manager?.parameterDefs?.[param] || null;
+
+    let numericValue = Number(value);
+    const isNumeric = Number.isFinite(numericValue);
+    let processedValue = value;
+
+    if (definition) {
+        if (definition.type === 'enum') {
+            processedValue = typeof value === 'string' ? value : (value === null || value === undefined ? '' : String(value));
+        } else if (definition.type === 'bool' || definition.type === 'boolean') {
+            processedValue = Boolean(value);
+        } else {
+            processedValue = isNumeric ? numericValue : Number(definition.default ?? manager?.params?.[param] ?? value);
+            numericValue = Number(processedValue);
+        }
+    } else if (isNumeric) {
+        processedValue = numericValue;
+    }
+
+    window.userParameterState[param] = processedValue;
+
+    if (!window.isGalleryPreview) {
+        console.log(`💾 User parameter: ${param} = ${processedValue}`);
+    }
+
+    if (window.audioEngine && isNumeric) {
+        if (param === 'hue') {
+            window.audioEngine.setBaseHue?.(numericValue);
+        } else if (param === 'saturation') {
+            window.audioEngine.setBaseSaturation?.(numericValue);
+        } else if (param === 'intensity') {
+            window.audioEngine.setBaseIntensity?.(numericValue);
+        }
+    }
+
     const displays = {
         rot4dXW: 'xwValue',
-        rot4dYW: 'ywValue', 
+        rot4dYW: 'ywValue',
         rot4dZW: 'zwValue',
         gridDensity: 'densityValue',
         morphFactor: 'morphValue',
@@ -176,74 +1598,53 @@ window.updateParameter = function(param, value) {
         speed: 'speedValue',
         hue: 'hueValue',
         intensity: 'intensityValue',
-        saturation: 'saturationValue'
+        saturation: 'saturationValue',
+        dimension: 'dimensionValue'
     };
-    
+
     const display = document.getElementById(displays[param]);
     if (display) {
-        if (param === 'hue') {
-            display.textContent = value + '°';
-        } else if (param.startsWith('rot4d')) {
-            display.textContent = parseFloat(value).toFixed(2);
-        } else {
-            display.textContent = parseFloat(value).toFixed(1);
+        if (definition?.type === 'enum') {
+            display.textContent = String(processedValue);
+        } else if (param === 'hue' && isNumeric) {
+            display.textContent = `${Math.round(numericValue)}°`;
+        } else if (param.startsWith('rot4d') && isNumeric) {
+            display.textContent = numericValue.toFixed(2);
+        } else if (isNumeric) {
+            display.textContent = numericValue.toFixed(1);
         }
     }
-    
-    // SURGICAL FIX: Unified parameter router - eliminates scope confusion
+
     try {
-        const activeSystem = window.currentSystem || 'faceted';
-        const engines = {
-            faceted: window.engine,
-            quantum: window.quantumEngine,
-            holographic: window.holographicSystem,
-            polychora: window.polychoraSystem
-        };
-        
-        const engine = engines[activeSystem];
+        let handled = false;
+        if (manager?.setParameter) {
+            handled = manager.setParameter(param, processedValue) || handled;
+        }
+
+        const engine = getActiveEngine();
         if (!engine) {
-            console.warn(`⚠️ System ${activeSystem} not available - engines:`, Object.keys(engines).map(k => `${k}:${!!engines[k]}`).join(', '));
-            
-            // CRITICAL FIX: Track retry count to prevent infinite loops
-            if (!window.parameterRetryCount) window.parameterRetryCount = {};
-            const retryKey = `${param}_${value}_${activeSystem}`;
-            const currentRetries = window.parameterRetryCount[retryKey] || 0;
-            
-            // Only retry once, then give up to prevent infinite loops
-            if (currentRetries < 1) {
-                window.parameterRetryCount[retryKey] = currentRetries + 1;
-                console.log(`🔄 Retrying parameter ${param} = ${value} for ${activeSystem} (attempt ${currentRetries + 2})`);
-                setTimeout(() => {
-                    window.updateParameter(param, value);
-                }, 100);
-            } else {
-                console.warn(`❌ Parameter ${param} = ${value} failed for ${activeSystem} - system not available, giving up after 2 attempts`);
-                // Clean up retry tracking for this parameter
-                delete window.parameterRetryCount[retryKey];
-            }
+            console.warn(`[UIHandlers] No active engine available for ${systemKey}`);
             return;
         }
-        
-        // Route to appropriate engine method
-        if (activeSystem === 'faceted') {
-            engine.parameterManager.setParameter(param, parseFloat(value));
-            engine.updateVisualizers();
-        } else if (activeSystem === 'quantum') {
-            engine.updateParameter(param, parseFloat(value));
-        } else if (activeSystem === 'holographic') {
-            engine.updateParameter(param, parseFloat(value));
-        } else if (activeSystem === 'polychora') {
-            engine.updateParameters({ [param]: parseFloat(value) });
+
+        if (systemKey === 'faceted') {
+            if (!handled && engine.parameterManager && engine.parameterManager !== manager) {
+                engine.parameterManager.setParameter?.(param, processedValue);
+            }
+            engine.updateVisualizers?.();
+        } else if (!handled) {
+            if (typeof engine.updateParameter === 'function') {
+                engine.updateParameter(param, processedValue);
+            } else if (typeof engine.updateParameters === 'function') {
+                engine.updateParameters({ [param]: processedValue });
+            }
         }
-        
-        // GALLERY PERFORMANCE FIX: Reduce engine parameter logging spam in gallery context
+
         if (!window.isGalleryPreview) {
-            console.log(`📊 ${activeSystem.toUpperCase()}: ${param} = ${value}`);
+            console.log(`📊 ${systemKey.toUpperCase()}: ${param} = ${processedValue}`);
         }
-        
     } catch (error) {
-        console.error(`❌ Parameter update error in ${window.currentSystem || 'unknown'} for ${param}:`, error);
-        // Don't break the UI, just log the error
+        console.error(`❌ Parameter update error in ${systemKey} for ${param}:`, error);
     }
 };
 
@@ -290,8 +1691,9 @@ function randomizeParameters() {
  */
 function randomizeGeometryAndHue() {
     // Randomize geometry selection
-    if (window.currentSystem !== 'holographic') {
-        const geometryNames = getGeometryNamesForSystem(window.currentSystem);
+    const systemKey = getSystemKeyFallback();
+    if (systemKey !== 'holographic') {
+        const geometryNames = getGeometryNamesForSystem(systemKey);
         if (geometryNames.length) {
             const randomGeometry = Math.floor(Math.random() * geometryNames.length);
             if (window.selectGeometry) {
@@ -409,7 +1811,7 @@ window.openViewer = function() {
     console.log('👁️ Navigating to viewer...');
     // Save current parameters for viewer
     const currentState = {
-        system: window.currentSystem || 'faceted',
+        system: getSystemKeyFallback(),
         parameters: window.userParameterState || {},
         toggleStates: {
             audioEnabled: window.audioEnabled || false,
@@ -743,49 +2145,41 @@ document.addEventListener('keydown', (e) => {
 
 // Listen for mouse events from gallery iframe for visualizer interactivity
 window.addEventListener('message', (event) => {
-    if (event.data && event.data.type) {
-        if (event.data.type === 'mouseMove') {
-            // Update all visualizers with mouse position
-            const updateMouseForSystem = (system) => {
-                if (system && system.visualizers) {
-                    system.visualizers.forEach(vis => {
-                        if (vis) {
-                            vis.mouseX = event.data.x;
-                            vis.mouseY = event.data.y;
-                            vis.mouseIntensity = event.data.intensity || 0.5;
-                        }
-                    });
-                }
-            };
-            
-            // Update the active system's visualizers
-            if (window.currentSystem === 'faceted' && window.engine) {
-                updateMouseForSystem(window.engine);
-            } else if (window.currentSystem === 'quantum' && window.quantumEngine) {
-                updateMouseForSystem(window.quantumEngine);
-            } else if (window.currentSystem === 'holographic' && window.holographicSystem) {
-                updateMouseForSystem(window.holographicSystem);
+    if (!event.data || !event.data.type) {
+        return;
+    }
+
+    if (event.data.type === 'mouseMove') {
+        const updateMouseForSystem = (system) => {
+            if (system && system.visualizers) {
+                system.visualizers.forEach(vis => {
+                    if (vis) {
+                        vis.mouseX = event.data.x;
+                        vis.mouseY = event.data.y;
+                        vis.mouseIntensity = event.data.intensity || 0.5;
+                    }
+                });
             }
-        } else if (event.data.type === 'mouseClick') {
-            // Trigger click effects on all visualizers
-            const triggerClickForSystem = (system) => {
-                if (system && system.visualizers) {
-                    system.visualizers.forEach(vis => {
-                        if (vis) {
-                            vis.clickIntensity = event.data.intensity || 1.0;
-                        }
-                    });
-                }
-            };
-            
-            // Trigger click on active system
-            if (window.currentSystem === 'faceted' && window.engine) {
-                triggerClickForSystem(window.engine);
-            } else if (window.currentSystem === 'quantum' && window.quantumEngine) {
-                triggerClickForSystem(window.quantumEngine);
-            } else if (window.currentSystem === 'holographic' && window.holographicSystem) {
-                triggerClickForSystem(window.holographicSystem);
+        };
+
+        const engine = getActiveEngine();
+        if (engine) {
+            updateMouseForSystem(engine);
+        }
+    } else if (event.data.type === 'mouseClick') {
+        const triggerClickForSystem = (system) => {
+            if (system && system.visualizers) {
+                system.visualizers.forEach(vis => {
+                    if (vis) {
+                        vis.clickIntensity = event.data.intensity || 1.0;
+                    }
+                });
             }
+        };
+
+        const engine = getActiveEngine();
+        if (engine) {
+            triggerClickForSystem(engine);
         }
     }
 });
@@ -798,7 +2192,7 @@ window.setupGeometry = function(system) {
     if (!grid) return;
 
     geometryGridElement = grid;
-    geometryGridSystem = system || window.currentSystem || 'faceted';
+    geometryGridSystem = system || getSystemKeyFallback();
 
     if (!geometrySubscriptionCleanup) {
         ensureGeometrySubscription();

--- a/music-choreographer-engine.js
+++ b/music-choreographer-engine.js
@@ -3,11 +3,213 @@
  * Dual-mode system: Reactive (built-in audio reactivity) + Choreographed (timeline-based)
  */
 
-import { VIB34DIntegratedEngine } from './src/core/Engine.js';
-import { QuantumEngine } from './src/quantum/QuantumEngine.js';
-import { RealHolographicSystem } from './src/holograms/RealHolographicSystem.js';
 import { DynamicParameterBridge } from './src/choreography/DynamicParameterBridge.js';
 import { GeometryLibrary } from './src/geometry/GeometryLibrary.js';
+import { SystemRegistry } from './src/systems/shared/SystemRegistry.js';
+import { FacetedSystem } from './src/systems/faceted/FacetedSystem.js';
+import { QuantumSystem } from './src/systems/quantum/QuantumSystem.js';
+import { HolographicSystem } from './src/systems/holographic/HolographicSystem.js';
+import { PolychoraSystem } from './src/systems/polychora/PolychoraSystem.js';
+import {
+    registerSystemRegistry,
+    syncActiveSystemState,
+    getActiveParameterManager as getRegistryParameterManager
+} from './src/systems/shared/SystemAccess.js';
+import { resolveSystemDescriptor } from './src/systems/shared/SystemMetadata.js';
+
+const SYSTEM_ICON_MAP = {
+    faceted: '🔷',
+    quantum: '🌌',
+    holographic: '✨',
+    polychora: '🔮'
+};
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function toNumber(value) {
+    if (value === undefined || value === null || value === '') {
+        return null;
+    }
+    const numeric = typeof value === 'number' ? value : parseFloat(value);
+    return Number.isFinite(numeric) ? numeric : null;
+}
+
+function coerceNumber(value, fallback) {
+    const numeric = toNumber(value);
+    if (numeric === null) {
+        return fallback;
+    }
+    return numeric;
+}
+
+function formatOptionLabel(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? String(value) : '';
+    }
+    const text = String(value).trim();
+    if (!text) {
+        return 'Auto';
+    }
+    if (text.length === 1) {
+        return text.toUpperCase();
+    }
+    return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function formatValueForInput(value) {
+    if (value === undefined || value === null || value === '') {
+        return '';
+    }
+    return escapeHtml(String(value));
+}
+
+function normalizeOptionEntry(option, { allowEmpty = false } = {}) {
+    if (option === null || option === undefined) {
+        return null;
+    }
+
+    if (typeof option === 'string' || typeof option === 'number') {
+        const raw = String(option);
+        const trimmed = raw.trim();
+        if (!trimmed && !allowEmpty) {
+            return null;
+        }
+        const value = trimmed || (allowEmpty ? '' : trimmed);
+        const label = trimmed || raw || (allowEmpty ? 'Auto' : '');
+        return { value, label, icon: null };
+    }
+
+    if (typeof option === 'object') {
+        const rawValue = option.value ?? option.key ?? option.id ?? option.name ?? option.label;
+        const stringValue = rawValue === undefined || rawValue === null ? '' : String(rawValue);
+        const trimmed = stringValue.trim();
+        if (!trimmed && !allowEmpty) {
+            return null;
+        }
+        const value = trimmed || (allowEmpty ? '' : trimmed);
+        let label = option.label || option.title || option.name || '';
+        label = label && typeof label === 'string' ? label.trim() : '';
+        if (!label) {
+            label = trimmed || (allowEmpty && !value ? 'Auto' : '');
+        }
+        const normalized = {
+            value,
+            label,
+            icon: option.icon || null
+        };
+        if (option.description || option.hint) {
+            normalized.description = option.description || option.hint;
+        }
+        if (option.dataset && typeof option.dataset === 'object') {
+            normalized.dataset = { ...option.dataset };
+        }
+        return normalized;
+    }
+
+    return null;
+}
+
+function collectOptions(groups, { allowEmpty = false } = {}) {
+    const result = [];
+    const seen = new Set();
+    const sourceGroups = Array.isArray(groups) ? groups : [groups];
+
+    sourceGroups.forEach(group => {
+        if (!group) {
+            return;
+        }
+        const entries = Array.isArray(group) ? group : [group];
+        entries.forEach(entry => {
+            const option = normalizeOptionEntry(entry, { allowEmpty });
+            if (!option) {
+                return;
+            }
+            const value = option.value ?? '';
+            const normalizedValue = value.toLowerCase();
+            if (!normalizedValue && allowEmpty) {
+                if (result.some(opt => opt.value === '')) {
+                    return;
+                }
+                result.push(option);
+                return;
+            }
+            if (seen.has(normalizedValue)) {
+                return;
+            }
+            seen.add(normalizedValue);
+            result.push(option);
+        });
+    });
+
+    return result;
+}
+
+function cloneSequenceInput(sequence) {
+    if (!sequence || typeof sequence !== 'object') {
+        return { time: 0, duration: 0, effects: {} };
+    }
+
+    if (typeof structuredClone === 'function') {
+        try {
+            return structuredClone(sequence);
+        } catch (error) {
+            // Fallback to JSON copy below
+        }
+    }
+
+    try {
+        return JSON.parse(JSON.stringify(sequence));
+    } catch (error) {
+        const clone = { ...sequence };
+        clone.effects = sequence.effects && typeof sequence.effects === 'object'
+            ? { ...sequence.effects }
+            : {};
+        return clone;
+    }
+}
+
+function cloneDeep(value, cache = new WeakMap()) {
+    if (value === null || typeof value !== 'object') {
+        return value;
+    }
+
+    if (cache.has(value)) {
+        return cache.get(value);
+    }
+
+    if (typeof structuredClone === 'function') {
+        try {
+            const cloned = structuredClone(value);
+            cache.set(value, cloned);
+            return cloned;
+        } catch (error) {
+            // structuredClone may throw for certain object types; fall back to manual clone
+        }
+    }
+
+    if (Array.isArray(value)) {
+        const clonedArray = value.map(item => cloneDeep(item, cache));
+        cache.set(value, clonedArray);
+        return clonedArray;
+    }
+
+    const clonedObject = {};
+    cache.set(value, clonedObject);
+    Object.keys(value).forEach(key => {
+        clonedObject[key] = cloneDeep(value[key], cache);
+    });
+    return clonedObject;
+}
 
 export class MusicVideoChoreographer {
     constructor(mode = 'reactive') {
@@ -21,6 +223,25 @@ export class MusicVideoChoreographer {
         this.isPlaying = false;
         this.animationId = null;
         this.canvasManager = null;
+
+        this.systemRegistry = new SystemRegistry({
+            containerId: 'vib34dLayers',
+            autoClear: true,
+            destroyOnSwitch: true
+        });
+
+        const facetedDescriptor = resolveSystemDescriptor('faceted');
+        const quantumDescriptor = resolveSystemDescriptor('quantum');
+        const holographicDescriptor = resolveSystemDescriptor('holographic');
+        const polychoraDescriptor = resolveSystemDescriptor('polychora');
+
+        this.systemRegistry.register('faceted', () => new FacetedSystem(), facetedDescriptor);
+        this.systemRegistry.register('quantum', () => new QuantumSystem(), quantumDescriptor);
+        this.systemRegistry.register('holographic', () => new HolographicSystem(), holographicDescriptor);
+        this.systemRegistry.register('polychora', () => new PolychoraSystem(), polychoraDescriptor);
+        this.defaultTimelineDescriptor = facetedDescriptor?.timeline || null;
+        registerSystemRegistry(this.systemRegistry);
+        this.activeSystem = null;
 
         // Beat detection
         this.beatThreshold = 0.7;
@@ -54,6 +275,205 @@ export class MusicVideoChoreographer {
         this.init();
     }
 
+    resolveParameterManager() {
+        const registryManager = getRegistryParameterManager();
+        if (registryManager) {
+            return registryManager;
+        }
+        if (this.currentEngine?.parameterManager) {
+            return this.currentEngine.parameterManager;
+        }
+        if (this.activeSystem?.engine?.parameterManager) {
+            return this.activeSystem.engine.parameterManager;
+        }
+        return null;
+    }
+
+    setParameterValue(param, value, options = {}) {
+        const manager = this.resolveParameterManager();
+        const allowOverflow = options?.allowOverflow ?? false;
+
+        if (manager) {
+            try {
+                if (allowOverflow && typeof manager.setParameterExternal === 'function') {
+                    const applied = manager.setParameterExternal(param, value, { allowOverflow: true });
+                    if (applied) {
+                        return true;
+                    }
+                }
+
+                if (typeof manager.setParameter === 'function') {
+                    const ownsParam = manager.params && Object.prototype.hasOwnProperty.call(manager.params, param);
+                    const result = manager.setParameter(param, value);
+                    if (ownsParam || result !== false) {
+                        return true;
+                    }
+                }
+            } catch (error) {
+                console.debug('[MusicVideoChoreographer] ParameterManager set failed', param, error);
+            }
+        }
+
+        const engineManager = this.currentEngine?.parameterManager;
+        if (engineManager && engineManager !== manager && typeof engineManager.setParameter === 'function') {
+            try {
+                const result = engineManager.setParameter(param, value);
+                if (result !== false) {
+                    return true;
+                }
+            } catch (error) {
+                console.debug('[MusicVideoChoreographer] Engine parameter set failed', param, error);
+            }
+        }
+
+        if (this.currentEngine?.updateParameter) {
+            try {
+                this.currentEngine.updateParameter(param, value);
+                return true;
+            } catch (error) {
+                console.debug('[MusicVideoChoreographer] updateParameter fallback failed', param, error);
+            }
+        }
+
+        if (this.currentEngine?.updateParameters) {
+            try {
+                this.currentEngine.updateParameters({ [param]: value });
+                return true;
+            } catch (error) {
+                console.debug('[MusicVideoChoreographer] updateParameters fallback failed', param, error);
+            }
+        }
+
+        if (this.currentEngine && param in this.currentEngine) {
+            this.currentEngine[param] = value;
+            return true;
+        }
+
+        return false;
+    }
+
+    getSystemIcon(systemKey) {
+        const normalized = typeof systemKey === 'string' ? systemKey.toLowerCase() : '';
+        return SYSTEM_ICON_MAP[normalized] || '';
+    }
+
+    formatSystemLabel(systemKey) {
+        if (!systemKey) {
+            return 'System';
+        }
+        const metadata = this.systemRegistry.getSystemMetadata(systemKey)
+            || resolveSystemDescriptor(systemKey);
+        if (metadata?.title) {
+            return metadata.title;
+        }
+        const text = String(systemKey).trim();
+        if (!text) {
+            return 'System';
+        }
+        return text.charAt(0).toUpperCase() + text.slice(1);
+    }
+
+    getTimelineDescriptor(systemKey = this.currentSystem || 'faceted') {
+        const normalized = typeof systemKey === 'string' ? systemKey.toLowerCase() : 'faceted';
+        const metadata = this.systemRegistry.getSystemMetadata(normalized);
+        if (metadata?.timeline) {
+            return metadata.timeline;
+        }
+        const fallback = resolveSystemDescriptor(normalized);
+        if (fallback?.timeline) {
+            return fallback.timeline;
+        }
+        return this.defaultTimelineDescriptor || null;
+    }
+
+    getTimelineFormOptions() {
+        const activeKey = this.currentSystem || 'faceted';
+        const activeDescriptor = this.systemRegistry.getSystemMetadata(activeKey) || resolveSystemDescriptor(activeKey);
+        const activeTimeline = activeDescriptor?.timeline || this.defaultTimelineDescriptor || {};
+        const fallbackTimeline = this.defaultTimelineDescriptor
+            || resolveSystemDescriptor('faceted')?.timeline
+            || {};
+        const registrySystems = this.systemRegistry.listSystems();
+        const registryOptions = registrySystems.map(({ key, metadata }) => ({
+            value: key,
+            label: metadata?.title || this.formatSystemLabel(key),
+            icon: this.getSystemIcon(key)
+        }));
+
+        return {
+            systemOptions: collectOptions([
+                activeTimeline.form?.systemOptions,
+                fallbackTimeline.form?.systemOptions,
+                registryOptions
+            ]),
+            geometryModes: collectOptions([
+                activeTimeline.form?.geometryModes,
+                fallbackTimeline.form?.geometryModes
+            ]),
+            rotationModes: collectOptions([
+                activeTimeline.form?.rotationModes,
+                fallbackTimeline.form?.rotationModes
+            ]),
+            colorShiftModes: collectOptions([
+                activeTimeline.form?.colorShiftModes,
+                fallbackTimeline.form?.colorShiftModes
+            ]),
+            geometryAudioAxes: collectOptions([
+                activeTimeline.form?.geometryAudioAxes,
+                fallbackTimeline.form?.geometryAudioAxes
+            ], { allowEmpty: true })
+        };
+    }
+
+    buildOptionMarkup(selectedValue, options, { allowEmpty = false, fallbackLabel } = {}) {
+        const optionList = Array.isArray(options) ? options : [];
+        const selectedString = selectedValue === undefined || selectedValue === null
+            ? ''
+            : typeof selectedValue === 'string'
+                ? selectedValue
+                : String(selectedValue);
+        const normalizedSelected = selectedString.toLowerCase();
+        let hasSelected = false;
+
+        const markup = optionList.map(option => {
+            if (!option) {
+                return '';
+            }
+            const value = option.value === undefined || option.value === null ? '' : String(option.value);
+            const normalizedValue = value.toLowerCase();
+            const isSelected = normalizedValue === normalizedSelected
+                || (allowEmpty && !normalizedSelected && !normalizedValue);
+            if (isSelected) {
+                hasSelected = true;
+            }
+            const labelParts = [];
+            if (option.icon) {
+                labelParts.push(option.icon);
+            }
+            const optionLabel = option.label || value || (allowEmpty && !value ? 'Auto' : '');
+            if (optionLabel) {
+                labelParts.push(optionLabel);
+            }
+            const label = labelParts.join(' ').trim() || (allowEmpty && !value ? 'Auto' : value);
+            return `<option value="${escapeHtml(value)}"${isSelected ? ' selected' : ''}>${escapeHtml(label)}</option>`;
+        }).join('');
+
+        if (!hasSelected && selectedString) {
+            const label = typeof fallbackLabel === 'function'
+                ? fallbackLabel(selectedValue)
+                : formatOptionLabel(selectedValue);
+            return `${markup}<option value="${escapeHtml(selectedString)}" selected>${escapeHtml(label)}</option>`;
+        }
+
+        return markup;
+    }
+
+    buildSystemOptionsMarkup(selectedValue, options) {
+        return this.buildOptionMarkup(selectedValue, options, {
+            fallbackLabel: value => this.formatSystemLabel(value)
+        });
+    }
+
     refreshGeometryMetadata() {
         this.geometryNames = GeometryLibrary.getGeometryNames();
         this.geometryCount = this.geometryNames.length;
@@ -68,8 +488,9 @@ export class MusicVideoChoreographer {
             this.lastGeometryIndex = 0;
         }
 
-        if (this.currentEngine && this.currentEngine.parameterManager && this.currentEngine.parameterManager.updateGeometryRange) {
-            this.currentEngine.parameterManager.updateGeometryRange(this.geometryCount);
+        const manager = this.resolveParameterManager();
+        if (manager?.updateGeometryRange) {
+            manager.updateGeometryRange(this.geometryCount);
         }
 
         this.applyGeometryMetadataToUI();
@@ -121,6 +542,12 @@ export class MusicVideoChoreographer {
                 console.warn('[MusicVideoChoreographer] geometry unsubscribe failed', err);
             }
             this.geometrySubscription = null;
+        }
+
+        if (this.systemRegistry) {
+            this.systemRegistry.destroyAll({ reason: 'choreographer-destroy' }).catch(error => {
+                console.warn('[MusicVideoChoreographer] Failed to destroy system registry', error);
+            });
         }
     }
 
@@ -222,6 +649,9 @@ export class MusicVideoChoreographer {
         // Audio events
         this.audio.addEventListener('ended', () => this.stop());
         this.audio.addEventListener('timeupdate', () => this.updateTimeline());
+
+        this.updateTimelineReadout(0, this.audio?.duration || 0);
+        this.emitTimelineUpdate('init');
     }
 
     async loadAudioFile(file) {
@@ -229,6 +659,10 @@ export class MusicVideoChoreographer {
 
         const url = URL.createObjectURL(file);
         this.audio.src = url;
+
+        this.audio.addEventListener('loadedmetadata', () => {
+            this.updateTimelineReadout(0, this.audio.duration);
+        }, { once: true });
 
         // Connect audio to analyser
         if (!this.sourceNode) {
@@ -248,7 +682,7 @@ export class MusicVideoChoreographer {
 
     async generateDefaultChoreography() {
         // Auto-generate choreography sequences WITH SYSTEM SWITCHING
-        this.sequences = [
+        const templates = [
             {
                 time: 0,
                 duration: 14,
@@ -460,124 +894,363 @@ export class MusicVideoChoreographer {
             }
         ];
 
+        this.sequences = templates.map(seq => this.applySequenceDefaults(seq, { assignTime: false }));
+        this.sequences.sort((a, b) => (toNumber(a.time) ?? 0) - (toNumber(b.time) ?? 0));
         this.resetGeometryState(false);
         this.renderSequenceList();
         this.scanGeometryDescriptors(this.sequences);
         console.log('🎬 Generated default choreography with system switching');
     }
 
+    async applyTimelinePreset(presetId) {
+        const id = typeof presetId === 'string' ? presetId.toLowerCase() : '';
+
+        try {
+            if (['blank', 'blank-timeline', 'blank slate', 'blank-slate', 'empty', 'clear'].includes(id)) {
+                this.clearTimeline({ silent: true });
+                this.updateStatus('Timeline cleared — ready for manual choreography');
+                return true;
+            }
+
+            await this.generateDefaultChoreography();
+            this.updateStatus('Loaded cinematic switch-up preset');
+            return true;
+        } catch (error) {
+            console.error('Failed to apply timeline preset', presetId, error);
+        }
+
+        return false;
+    }
+
+    resolveSequenceDefaults(systemKey = this.currentSystem || 'faceted', overrides = {}) {
+        const normalized = typeof systemKey === 'string' ? systemKey.toLowerCase() : 'faceted';
+        const timeline = this.getTimelineDescriptor(normalized) || {};
+        const fallbackTimeline = this.defaultTimelineDescriptor
+            || resolveSystemDescriptor('faceted')?.timeline
+            || {};
+
+        const baseDefaults = cloneDeep({
+            ...(fallbackTimeline.sequenceDefaults?.base || {}),
+            ...(timeline.sequenceDefaults?.base || timeline.sequenceDefaults || {})
+        });
+
+        const fallbackPerSystem = fallbackTimeline.sequenceDefaults?.perSystem || {};
+        const perSystem = timeline.sequenceDefaults?.perSystem || timeline.sequenceDefaults?.systems || {};
+        const systemDefaults = cloneDeep({
+            ...(fallbackPerSystem[normalized] || {}),
+            ...(perSystem?.[normalized] || {})
+        });
+
+        const overrideSource = overrides && typeof overrides === 'object' ? cloneDeep(overrides) : {};
+
+        return {
+            ...baseDefaults,
+            ...systemDefaults,
+            ...overrideSource
+        };
+    }
+
+    calculateNextSequenceStart(spacing = 0) {
+        if (!Array.isArray(this.sequences) || !this.sequences.length) {
+            return 0;
+        }
+
+        const lastEnd = this.sequences.reduce((max, seq) => {
+            const start = toNumber(seq?.time) ?? 0;
+            const duration = toNumber(seq?.duration) ?? 0;
+            const end = start + duration;
+            return end > max ? end : max;
+        }, 0);
+
+        const spacingValue = toNumber(spacing) ?? 0;
+        const total = lastEnd + spacingValue;
+        return Math.round(total * 100) / 100;
+    }
+
+    createSequenceFromDefaults(options = {}) {
+        const systemKey = (options.system || this.currentSystem || 'faceted').toString().toLowerCase();
+        const overrides = options.overrides && typeof options.overrides === 'object'
+            ? cloneDeep(options.overrides)
+            : {};
+        const defaults = this.resolveSequenceDefaults(systemKey);
+        const spacing = toNumber(defaults.spacing) ?? 0;
+        const duration = coerceNumber(options.duration ?? defaults.duration, defaults.duration ?? 12);
+        const providedTime = toNumber(options.time);
+        const time = providedTime !== null ? providedTime : this.calculateNextSequenceStart(spacing);
+
+        const effectsOverrides = overrides.effects && typeof overrides.effects === 'object'
+            ? cloneDeep(overrides.effects)
+            : overrides;
+        const effects = {
+            system: systemKey
+        };
+
+        const geometryValue = effectsOverrides.geometry ?? defaults.geometry;
+        if (typeof geometryValue === 'number' && Number.isFinite(geometryValue)) {
+            effects.geometry = geometryValue;
+        } else if (typeof geometryValue === 'string') {
+            effects.geometry = geometryValue.trim();
+        } else if (geometryValue !== undefined) {
+            effects.geometry = geometryValue;
+        }
+
+        const rotationValue = effectsOverrides.rotation ?? defaults.rotation;
+        if (rotationValue !== undefined && rotationValue !== null) {
+            effects.rotation = typeof rotationValue === 'string' ? rotationValue.trim() : rotationValue;
+        }
+
+        const colorShiftValue = effectsOverrides.colorShift ?? defaults.colorShift ?? 'medium';
+        effects.colorShift = typeof colorShiftValue === 'string' ? colorShiftValue.trim() : colorShiftValue;
+
+        effects.chaos = coerceNumber(effectsOverrides.chaos ?? defaults.chaos, defaults.chaos ?? 0.25);
+        effects.speed = coerceNumber(effectsOverrides.speed ?? defaults.speed, defaults.speed ?? 1);
+        effects.geometryInterval = coerceNumber(
+            effectsOverrides.geometryInterval ?? defaults.geometryInterval,
+            defaults.geometryInterval ?? 4
+        );
+        effects.geometryCycles = coerceNumber(
+            effectsOverrides.geometryCycles ?? defaults.geometryCycles,
+            defaults.geometryCycles ?? 2
+        );
+
+        const axisSource = effectsOverrides.geometryAudioAxis ?? defaults.geometryAudioAxis ?? '';
+        effects.geometryAudioAxis = typeof axisSource === 'string'
+            ? axisSource.trim()
+            : axisSource !== undefined && axisSource !== null
+                ? String(axisSource)
+                : '';
+
+        effects.geometryEnergyThreshold = coerceNumber(
+            effectsOverrides.geometryEnergyThreshold ?? defaults.geometryEnergyThreshold,
+            defaults.geometryEnergyThreshold ?? 0.5
+        );
+
+        Object.entries(effectsOverrides).forEach(([key, value]) => {
+            if (value === undefined) {
+                return;
+            }
+            if ([
+                'geometry',
+                'rotation',
+                'colorShift',
+                'chaos',
+                'speed',
+                'geometryInterval',
+                'geometryCycles',
+                'geometryAudioAxis',
+                'geometryEnergyThreshold'
+            ].includes(key)) {
+                return;
+            }
+            effects[key] = value;
+        });
+
+        return {
+            time,
+            duration,
+            effects
+        };
+    }
+
+    applySequenceDefaults(sequence, { assignTime = true } = {}) {
+        const clone = cloneSequenceInput(sequence);
+        const effects = clone.effects && typeof clone.effects === 'object' ? clone.effects : {};
+        clone.effects = effects;
+
+        const systemKey = (effects.system || clone.system || this.currentSystem || 'faceted').toString().toLowerCase();
+        effects.system = systemKey;
+
+        const defaults = this.resolveSequenceDefaults(systemKey);
+        const spacing = toNumber(defaults.spacing) ?? 0;
+
+        if (assignTime) {
+            const timeNumeric = toNumber(clone.time);
+            clone.time = timeNumeric !== null ? timeNumeric : this.calculateNextSequenceStart(spacing);
+        } else if (clone.time !== undefined) {
+            const timeNumeric = toNumber(clone.time);
+            if (timeNumeric !== null) {
+                clone.time = timeNumeric;
+            }
+        }
+
+        const durationNumeric = coerceNumber(clone.duration, defaults.duration ?? 12);
+        clone.duration = durationNumeric;
+
+        if (effects.geometry === undefined || effects.geometry === null || (typeof effects.geometry === 'string' && !effects.geometry.trim())) {
+            effects.geometry = defaults.geometry;
+        } else if (typeof effects.geometry === 'string') {
+            effects.geometry = effects.geometry.trim();
+        }
+
+        if (effects.rotation === undefined || effects.rotation === null || (typeof effects.rotation === 'string' && !effects.rotation.trim())) {
+            effects.rotation = defaults.rotation;
+        } else if (typeof effects.rotation === 'string') {
+            effects.rotation = effects.rotation.trim();
+        }
+
+        if (effects.colorShift === undefined || effects.colorShift === null || (typeof effects.colorShift === 'string' && !effects.colorShift.trim())) {
+            effects.colorShift = defaults.colorShift ?? 'medium';
+        } else if (typeof effects.colorShift === 'string') {
+            effects.colorShift = effects.colorShift.trim();
+        }
+
+        const numericProps = {
+            chaos: defaults.chaos,
+            speed: defaults.speed,
+            geometryInterval: defaults.geometryInterval,
+            geometryCycles: defaults.geometryCycles,
+            geometryEnergyThreshold: defaults.geometryEnergyThreshold
+        };
+
+        Object.entries(numericProps).forEach(([prop, fallback]) => {
+            const numeric = toNumber(effects[prop]);
+            if (numeric === null) {
+                if (fallback !== undefined) {
+                    effects[prop] = coerceNumber(fallback, fallback);
+                }
+            } else {
+                effects[prop] = numeric;
+            }
+        });
+
+        const axisSource = effects.geometryAudioAxis ?? defaults.geometryAudioAxis ?? '';
+        effects.geometryAudioAxis = typeof axisSource === 'string'
+            ? axisSource.trim()
+            : axisSource !== undefined && axisSource !== null
+                ? String(axisSource)
+                : '';
+
+        return clone;
+    }
+
     renderSequenceList() {
         const list = document.getElementById('sequence-list');
         if (!list) return;
 
+        const formOptions = this.getTimelineFormOptions();
+
         const legendMarkup = `
             <div class="geometry-legend-panel" style="margin-bottom:10px;padding:8px;border-radius:6px;background:rgba(0,255,255,0.06);border:1px solid rgba(0,255,255,0.2);font-size:10px;line-height:1.5;">
                 <strong>Available Geometries (${this.geometryNames.length})</strong><br>
-                ${this.geometryNames.map((name, idx) => `<span style="display:inline-block;margin:2px 4px;padding:2px 6px;border-radius:4px;background:rgba(0,255,255,0.08);">${idx}: ${name}</span>`).join(' ')}
+                ${this.geometryNames.map((name, idx) => `<span style="display:inline-block;margin:2px 4px;padding:2px 6px;border-radius:4px;background:rgba(0,255,255,0.08);">${idx}: ${escapeHtml(name)}</span>`).join(' ')}
             </div>
         `;
 
         const sequenceMarkup = this.sequences.length ? this.sequences.map((seq, index) => {
-            const dynamicSummary = this.renderDynamicSummary(seq.effects);
-            const startIndex = this.resolveGeometryDescriptor(seq.effects.geometryStart);
-            const geometryListValue = this.describeGeometryListInput(seq.effects.geometryList);
-            const intervalValue = seq.effects.geometryInterval ?? '';
-            const cyclesValue = seq.effects.geometryCycles ?? '';
-            const thresholdValue = seq.effects.geometryEnergyThreshold ?? '';
-            const axisValue = seq.effects.geometryAudioAxis ?? '';
-            const geometryValue = seq.effects.geometry;
+            const effects = seq.effects || {};
+            const systemValue = effects.system || this.currentSystem || 'faceted';
+            const defaults = this.resolveSequenceDefaults(systemValue);
+
+            const startNumeric = toNumber(seq.time);
+            const durationNumeric = toNumber(seq.duration);
+            const startDisplay = startNumeric !== null ? startNumeric : 0;
+            const endDisplay = startDisplay + (durationNumeric !== null ? durationNumeric : (defaults.duration ?? 0));
+
+            const geometryValue = effects.geometry;
+            const geometryValueNormalized = typeof geometryValue === 'string' ? geometryValue.trim().toLowerCase() : '';
+            const geometrySelectedMode = geometryValueNormalized
+                && formOptions.geometryModes.some(option => option && option.value && option.value.toLowerCase() === geometryValueNormalized);
+            const geometryModeMarkup = this.buildOptionMarkup(
+                geometrySelectedMode ? geometryValue : '',
+                formOptions.geometryModes
+            );
+
             const numericGeometryTarget = (typeof geometryValue === 'number' && Number.isFinite(geometryValue))
                 ? this.normalizeGeometryIndex(geometryValue)
                 : null;
+
+            const geometryOptionsMarkup = this.geometryNames.map((name, idx) => {
+                const normalized = name.toLowerCase();
+                const isSelected = (typeof geometryValue === 'string' && geometryValueNormalized === normalized)
+                    || (numericGeometryTarget !== null && numericGeometryTarget === idx);
+                return `<option value="${escapeHtml(name)}"${isSelected ? ' selected' : ''}>${escapeHtml(name)}</option>`;
+            }).join('');
+
+            const systemOptionsMarkup = this.buildSystemOptionsMarkup(systemValue, formOptions.systemOptions);
+            const rotationOptionsMarkup = this.buildOptionMarkup(effects.rotation, formOptions.rotationModes);
+            const colorShiftOptionsMarkup = this.buildOptionMarkup(effects.colorShift, formOptions.colorShiftModes);
+            const axisOptionsMarkup = this.renderGeometryAxisOptions(effects.geometryAudioAxis, formOptions.geometryAudioAxes);
+
+            const startIndex = this.resolveGeometryDescriptor(effects.geometryStart);
+            const geometryListValue = this.describeGeometryListInput(effects.geometryList);
+            const intervalNumeric = toNumber(effects.geometryInterval);
+            const cyclesNumeric = toNumber(effects.geometryCycles);
+            const thresholdNumeric = toNumber(effects.geometryEnergyThreshold);
+            const chaosNumeric = toNumber(effects.chaos);
+            const speedNumeric = toNumber(effects.speed);
+
+            const thresholdPlaceholderValue = defaults.geometryEnergyThreshold ?? (effects.geometry === 'explosive' ? 0.4 : 0.6);
+
             return `
             <div class="sequence-item">
-                <h4>Sequence ${index + 1} (${seq.time}s - ${seq.time + seq.duration}s)</h4>
+                <h4>Sequence ${index + 1} (${escapeHtml(String(startDisplay))}s - ${escapeHtml(String(endDisplay))}s)</h4>
                 <div class="sequence-controls">
                     <label>Start Time (s)</label>
-                    <input type="number" value="${seq.time}" onchange="choreographer.updateSequence(${index}, 'time', this.value)">
+                    <input type="number" value="${formatValueForInput(startNumeric !== null ? startNumeric : 0)}" onchange="choreographer.updateSequence(${index}, 'time', this.value)">
 
                     <label>Duration (s)</label>
-                    <input type="number" value="${seq.duration}" onchange="choreographer.updateSequence(${index}, 'duration', this.value)">
+                    <input type="number" value="${formatValueForInput(durationNumeric !== null ? durationNumeric : defaults.duration ?? 0)}" onchange="choreographer.updateSequence(${index}, 'duration', this.value)">
 
                     <label>🎨 System</label>
                     <select onchange="choreographer.updateSequence(${index}, 'system', this.value)" style="grid-column: span 2;">
-                        <option value="faceted" ${seq.effects.system === 'faceted' ? 'selected' : ''}>🔷 Faceted</option>
-                        <option value="quantum" ${seq.effects.system === 'quantum' ? 'selected' : ''}>🌌 Quantum</option>
-                        <option value="holographic" ${seq.effects.system === 'holographic' ? 'selected' : ''}>✨ Holographic</option>
+                        ${systemOptionsMarkup}
                     </select>
 
                     <label>Geometry</label>
                     <select onchange="choreographer.updateSequence(${index}, 'geometry', this.value)">
-                        <option value="hold" ${seq.effects.geometry === 'hold' ? 'selected' : ''}>Hold</option>
-                        <option value="cycle" ${seq.effects.geometry === 'cycle' ? 'selected' : ''}>Cycle</option>
-                        <option value="morph" ${seq.effects.geometry === 'morph' ? 'selected' : ''}>Morph</option>
-                        <option value="random" ${seq.effects.geometry === 'random' ? 'selected' : ''}>Random</option>
-                        <option value="explosive" ${seq.effects.geometry === 'explosive' ? 'selected' : ''}>Explosive</option>
-                        ${this.geometryNames.map((name, idx) => {
-                            const normalized = name.toLowerCase();
-                            const isSelected = (typeof geometryValue === 'string' && geometryValue.toLowerCase() === normalized)
-                                || (numericGeometryTarget !== null && numericGeometryTarget === idx);
-                            return `<option value="${name}" ${isSelected ? 'selected' : ''}>${name}</option>`;
-                        }).join('')}
+                        ${geometryModeMarkup}${geometryOptionsMarkup}
                     </select>
 
                     <label>Start Geometry</label>
                     <select onchange="choreographer.updateSequence(${index}, 'geometryStart', this.value)">
                         <option value="" ${startIndex === null || startIndex === undefined ? 'selected' : ''}>Auto (carry over)</option>
-                        ${this.geometryNames.map((name, idx) => `<option value="${idx}" ${startIndex === idx ? 'selected' : ''}>${idx}: ${name}</option>`).join('')}
+                        ${this.geometryNames.map((name, idx) => `<option value="${idx}" ${startIndex === idx ? 'selected' : ''}>${idx}: ${escapeHtml(name)}</option>`).join('')}
                     </select>
 
                     <label>Geometry List</label>
-                    <input type="text" value="${geometryListValue}" placeholder="e.g. Tetrahedron, Wave, 3" onchange="choreographer.updateSequence(${index}, 'geometryList', this.value)">
+                    <input type="text" value="${formatValueForInput(geometryListValue)}" placeholder="e.g. Tetrahedron, Wave, 3" onchange="choreographer.updateSequence(${index}, 'geometryList', this.value)">
 
                     <label>Geometry Interval (s)</label>
-                    <input type="number" step="0.1" min="0.1" value="${intervalValue}" placeholder="2" onchange="choreographer.updateSequence(${index}, 'geometryInterval', this.value)">
+                    <input type="number" step="0.1" min="0.1" value="${formatValueForInput(intervalNumeric !== null ? intervalNumeric : '')}" placeholder="${formatValueForInput(defaults.geometryInterval ?? '')}" onchange="choreographer.updateSequence(${index}, 'geometryInterval', this.value)">
 
                     <label>Geometry Cycles</label>
-                    <input type="number" step="1" min="1" value="${cyclesValue}" placeholder="1" onchange="choreographer.updateSequence(${index}, 'geometryCycles', this.value)">
+                    <input type="number" step="1" min="1" value="${formatValueForInput(cyclesNumeric !== null ? cyclesNumeric : '')}" placeholder="${formatValueForInput(defaults.geometryCycles ?? '')}" onchange="choreographer.updateSequence(${index}, 'geometryCycles', this.value)">
 
                     <label>Geometry Audio Axis</label>
                     <select onchange="choreographer.updateSequence(${index}, 'geometryAudioAxis', this.value)">
-                        ${this.renderGeometryAxisOptions(axisValue)}
+                        ${axisOptionsMarkup}
                     </select>
 
                     <label>Random Threshold</label>
-                    <input type="number" step="0.05" min="0" max="1" value="${thresholdValue}" placeholder="${seq.effects.geometry === 'explosive' ? 0.4 : 0.6}" onchange="choreographer.updateSequence(${index}, 'geometryEnergyThreshold', this.value)">
+                    <input type="number" step="0.05" min="0" max="1" value="${formatValueForInput(thresholdNumeric !== null ? thresholdNumeric : '')}" placeholder="${formatValueForInput(thresholdPlaceholderValue)}" onchange="choreographer.updateSequence(${index}, 'geometryEnergyThreshold', this.value)">
 
                     <label>Rotation</label>
                     <select onchange="choreographer.updateSequence(${index}, 'rotation', this.value)">
-                        <option value="minimal" ${seq.effects.rotation === 'minimal' ? 'selected' : ''}>Minimal</option>
-                        <option value="smooth" ${seq.effects.rotation === 'smooth' ? 'selected' : ''}>Smooth</option>
-                        <option value="accelerate" ${seq.effects.rotation === 'accelerate' ? 'selected' : ''}>Accelerate</option>
-                        <option value="chaos" ${seq.effects.rotation === 'chaos' ? 'selected' : ''}>Chaos</option>
-                        <option value="extreme" ${seq.effects.rotation === 'extreme' ? 'selected' : ''}>Extreme</option>
+                        ${rotationOptionsMarkup}
                     </select>
 
                     <label>Chaos Base</label>
-                    <input type="number" step="0.1" min="0" max="1" value="${seq.effects.chaos || 0.5}" onchange="choreographer.updateSequence(${index}, 'chaos', this.value)">
+                    <input type="number" step="0.1" min="0" max="1" value="${formatValueForInput(chaosNumeric !== null ? chaosNumeric : defaults.chaos ?? 0.5)}" onchange="choreographer.updateSequence(${index}, 'chaos', this.value)">
 
                     <label>Speed Base</label>
-                    <input type="number" step="0.1" min="0.1" max="3" value="${seq.effects.speed || 1.0}" onchange="choreographer.updateSequence(${index}, 'speed', this.value)">
+                    <input type="number" step="0.1" min="0.1" max="3" value="${formatValueForInput(speedNumeric !== null ? speedNumeric : defaults.speed ?? 1)}" onchange="choreographer.updateSequence(${index}, 'speed', this.value)">
 
                     <label>Color Shift</label>
                     <select onchange="choreographer.updateSequence(${index}, 'colorShift', this.value)">
-                        <option value="freeze" ${seq.effects.colorShift === 'freeze' ? 'selected' : ''}>Freeze</option>
-                        <option value="slow" ${seq.effects.colorShift === 'slow' ? 'selected' : ''}>Slow</option>
-                        <option value="medium" ${seq.effects.colorShift === 'medium' ? 'selected' : ''}>Medium</option>
-                        <option value="fast" ${seq.effects.colorShift === 'fast' ? 'selected' : ''}>Fast</option>
-                        <option value="rainbow" ${seq.effects.colorShift === 'rainbow' ? 'selected' : ''}>Rainbow</option>
+                        ${colorShiftOptionsMarkup}
                     </select>
                 </div>
                 <div style="font-size: 9px; color: #666; margin-top: 5px; padding: 5px; background: rgba(0,255,255,0.05); border-radius: 3px;">
                     ℹ️ Audio reactivity is ALWAYS active - these are base values that audio modulates
                 </div>
-                ${dynamicSummary}
+                ${this.renderDynamicSummary(effects)}
                 <button onclick="choreographer.deleteSequence(${index})" style="margin-top: 10px; background: #f44; font-size: 10px; padding: 5px;">Delete</button>
             </div>
         `;
         }).join('') : `<div class="sequence-empty" style="padding:12px;border:1px dashed rgba(0,255,255,0.3);border-radius:6px;font-size:11px;color:#7ff;">No sequences defined yet.</div>`;
 
         list.innerHTML = legendMarkup + sequenceMarkup;
+        this.emitTimelineUpdate('render');
     }
 
     describeGeometryStrategy(effects = {}) {
@@ -590,35 +1263,38 @@ export class MusicVideoChoreographer {
             if (typeof geometry === 'string') {
                 const trimmed = geometry.trim();
                 if (this.geometryModes.has(trimmed.toLowerCase())) {
-                    summaryParts.push(`Mode: ${trimmed}`);
+                    summaryParts.push(`Mode: ${escapeHtml(trimmed)}`);
                 } else {
                     const index = this.resolveGeometryDescriptor(trimmed);
                     if (index !== null && index !== undefined) {
-                        summaryParts.push(`Target: ${this.getGeometryName(index)} (#${index})`);
+                        const name = escapeHtml(this.getGeometryName(index));
+                        summaryParts.push(`Target: ${name} (#${index})`);
                     } else {
-                        summaryParts.push(`Target: ${GeometryLibrary.normalizeName(trimmed)}`);
+                        summaryParts.push(`Target: ${escapeHtml(GeometryLibrary.normalizeName(trimmed))}`);
                     }
                 }
             } else if (typeof geometry === 'number' && Number.isFinite(geometry)) {
                 const normalized = this.normalizeGeometryIndex(geometry);
-                summaryParts.push(`Target #: ${this.getGeometryName(normalized)} (#${normalized})`);
+                const name = escapeHtml(this.getGeometryName(normalized));
+                summaryParts.push(`Target #: ${name} (#${normalized})`);
             } else if (typeof geometry === 'object') {
                 const mode = geometry.mode || geometry.behavior || geometry.type;
                 if (mode) {
-                    summaryParts.push(`Mode: ${mode}`);
+                    summaryParts.push(`Mode: ${escapeHtml(String(mode))}`);
                 }
                 if (geometry.name) {
                     const index = this.resolveGeometryDescriptor(geometry.name);
                     if (index !== null && index !== undefined) {
-                        summaryParts.push(`Target: ${this.getGeometryName(index)} (#${index})`);
+                        const name = escapeHtml(this.getGeometryName(index));
+                        summaryParts.push(`Target: ${name} (#${index})`);
                     } else {
-                        summaryParts.push(`Target: ${GeometryLibrary.normalizeName(geometry.name)}`);
+                        summaryParts.push(`Target: ${escapeHtml(GeometryLibrary.normalizeName(geometry.name))}`);
                     }
                 }
                 if (geometry.list) {
                     const listSummary = this.describeGeometryListInput(geometry.list);
                     if (listSummary) {
-                        summaryParts.push(`List: ${listSummary}`);
+                        summaryParts.push(`List: ${escapeHtml(listSummary)}`);
                     }
                 }
             }
@@ -626,12 +1302,13 @@ export class MusicVideoChoreographer {
 
         const startIndex = this.resolveGeometryDescriptor(effects.geometryStart);
         if (startIndex !== null && startIndex !== undefined) {
-            summaryParts.push(`Start ➜ ${this.getGeometryName(startIndex)} (#${startIndex})`);
+            const name = escapeHtml(this.getGeometryName(startIndex));
+            summaryParts.push(`Start ➜ ${name} (#${startIndex})`);
         }
 
         const listValue = this.describeGeometryListInput(effects.geometryList);
         if (listValue) {
-            summaryParts.push(`List ➜ ${listValue}`);
+            summaryParts.push(`List ➜ ${escapeHtml(listValue)}`);
         }
 
         if (effects.geometryInterval !== undefined && effects.geometryInterval !== null) {
@@ -643,7 +1320,7 @@ export class MusicVideoChoreographer {
         }
 
         if (effects.geometryAudioAxis) {
-            summaryParts.push(`Axis ${effects.geometryAudioAxis}`);
+            summaryParts.push(`Axis ${escapeHtml(String(effects.geometryAudioAxis))}`);
         }
 
         if (effects.geometryEnergyThreshold !== undefined) {
@@ -665,10 +1342,11 @@ export class MusicVideoChoreographer {
         }
         if (effects.parameters && Object.keys(effects.parameters).length) {
             const entries = Object.entries(effects.parameters).map(([name, descriptor]) => {
+                const safeName = escapeHtml(String(name));
                 if (typeof descriptor === 'number') {
-                    return `${name}: ${descriptor}`;
+                    return `${safeName}: ${escapeHtml(String(descriptor))}`;
                 }
-                if (typeof descriptor === 'object') {
+                if (typeof descriptor === 'object' && descriptor !== null) {
                     const details = [];
                     if (descriptor.audioAxis || descriptor.audio) {
                         details.push(`↔ audio:${descriptor.audioAxis || descriptor.audio}`);
@@ -679,21 +1357,25 @@ export class MusicVideoChoreographer {
                     if (descriptor.mode) {
                         details.push(`mode:${descriptor.mode}`);
                     }
-                    return `${name}: ${descriptor.value ?? descriptor.base ?? 'auto'}${details.length ? ' (' + details.join(', ') + ')' : ''}`;
+                    const baseValue = descriptor.value ?? descriptor.base ?? 'auto';
+                    const detailText = details.length ? ` (${details.join(', ')})` : '';
+                    return `${safeName}: ${escapeHtml(String(baseValue))}${escapeHtml(detailText)}`;
                 }
-                return `${name}: ${descriptor}`;
+                return `${safeName}: ${escapeHtml(String(descriptor))}`;
             }).join('<br>');
             parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(0,255,255,0.05);font-size:10px;line-height:1.4;"><strong>Dynamic Parameters</strong><br>${entries}</div>`);
         }
 
         if (effects.actions && effects.actions.length) {
             const entries = effects.actions.map(action => {
-                if (typeof action === 'string') return action;
-                if (action.type) {
-                    const suffix = action.args ? ` → ${JSON.stringify(action.args)}` : '';
-                    return `${action.type}${suffix}`;
+                if (typeof action === 'string') {
+                    return escapeHtml(action);
                 }
-                return JSON.stringify(action);
+                if (action && typeof action === 'object' && action.type) {
+                    const suffix = action.args ? ` → ${JSON.stringify(action.args)}` : '';
+                    return escapeHtml(`${action.type}${suffix}`);
+                }
+                return escapeHtml(JSON.stringify(action));
             }).join('<br>');
             parts.push(`<div class="dynamic-summary" style="margin-top:6px;padding:6px;border-radius:4px;background:rgba(255,0,255,0.05);font-size:10px;line-height:1.4;"><strong>Actions</strong><br>${entries}</div>`);
         }
@@ -791,73 +1473,67 @@ export class MusicVideoChoreographer {
         this.renderSequenceList();
     }
 
+    clearTimeline(options = {}) {
+        this.sequences = [];
+        this.scanGeometryDescriptors(this.sequences);
+        this.resetGeometryState(true);
+        this.renderSequenceList();
+        if (!options.silent) {
+            this.updateStatus('Timeline cleared');
+        }
+    }
+
     addSequenceToTimeline(newSeq) {
-        this.sequences.push(newSeq);
-        this.sequences.sort((a, b) => a.time - b.time);
+        if (!newSeq) {
+            return;
+        }
+
+        const sequence = this.applySequenceDefaults(newSeq);
+        this.sequences.push(sequence);
+        this.sequences.sort((a, b) => (toNumber(a.time) ?? 0) - (toNumber(b.time) ?? 0));
         this.scanGeometryDescriptors(this.sequences);
         this.resetGeometryState(true);
         this.renderSequenceList();
     }
 
     async switchSystem(systemName) {
-        // Cleanup old engine
-        if (this.currentEngine && this.currentEngine.destroy) {
-            this.currentEngine.destroy();
-        }
-
-        // Clear canvases
-        const container = document.getElementById('vib34dLayers');
-        container.innerHTML = '';
-
-        // Create canvases based on system requirements
-        if (systemName === 'faceted') {
-            const layers = ['background', 'shadow', 'content', 'highlight', 'accent'];
-            layers.forEach(layer => {
-                const canvas = document.createElement('canvas');
-                canvas.id = `${layer}-canvas`;
-                canvas.width = window.innerWidth;
-                canvas.height = window.innerHeight;
-                container.appendChild(canvas);
-            });
-        } else if (systemName === 'quantum') {
-            const layers = ['background', 'shadow', 'content', 'highlight', 'accent'];
-            layers.forEach(layer => {
-                const canvas = document.createElement('canvas');
-                canvas.id = `quantum-${layer}-canvas`;
-                canvas.width = window.innerWidth;
-                canvas.height = window.innerHeight;
-                container.appendChild(canvas);
-            });
-        } else if (systemName === 'holographic') {
-            for (let i = 0; i < 5; i++) {
-                const canvas = document.createElement('canvas');
-                canvas.id = `holo-layer-${i}`;
-                canvas.width = window.innerWidth;
-                canvas.height = window.innerHeight;
-                container.appendChild(canvas);
-            }
-        }
-
-        // Initialize new engine
         try {
-            if (systemName === 'faceted') {
-                this.currentEngine = new VIB34DIntegratedEngine();
-            } else if (systemName === 'quantum') {
-                this.currentEngine = new QuantumEngine();
-            } else if (systemName === 'holographic') {
-                this.currentEngine = new RealHolographicSystem();
-            }
+            const system = await this.systemRegistry.activate(systemName, {
+                clearContainer: true
+            });
 
+            this.activeSystem = system;
+            this.currentEngine = system?.engine || null;
             this.currentSystem = systemName;
-            this.canvasManager = this.currentEngine?.canvasManager || null;
+            this.canvasManager = system?.canvasManager || this.currentEngine?.canvasManager || null;
+
             this.dynamicBridge.bindToEngine(this.currentEngine);
 
-            // Update UI
             document.querySelectorAll('.system-btn').forEach(btn => {
                 btn.classList.toggle('active', btn.dataset.system === systemName);
             });
 
-            console.log('✅ Switched to', systemName, 'system');
+            const metadata = typeof this.systemRegistry.getSystemMetadata === 'function'
+                ? this.systemRegistry.getSystemMetadata(systemName)
+                : null;
+
+            syncActiveSystemState();
+
+            if (metadata) {
+                window.dispatchEvent(new CustomEvent('vib34d:system-selected', {
+                    detail: { key: systemName, metadata }
+                }));
+
+                const statusElement = document.getElementById('status');
+                if (statusElement) {
+                    const currentStatus = statusElement.textContent || '';
+                    if (!currentStatus.trim() || /select a mode/i.test(currentStatus) || /system ready/i.test(currentStatus)) {
+                        statusElement.textContent = `System ready: ${metadata.title || systemName}`;
+                    }
+                }
+            }
+
+            console.log('✅ Switched to', systemName, 'system via SystemRegistry');
             this.refreshGeometryMetadata();
         } catch (error) {
             console.error('Failed to switch system:', error);
@@ -870,6 +1546,7 @@ export class MusicVideoChoreographer {
         }
 
         this.audio.play();
+        this.updateTimeline();
         this.isPlaying = true;
         this.startVisualization();
         this.updateStatus('Playing...');
@@ -878,6 +1555,7 @@ export class MusicVideoChoreographer {
     pause() {
         this.audio.pause();
         this.isPlaying = false;
+        this.updateTimeline();
         this.updateStatus('Paused');
     }
 
@@ -885,6 +1563,7 @@ export class MusicVideoChoreographer {
         this.audio.pause();
         this.audio.currentTime = 0;
         this.isPlaying = false;
+        this.updateTimeline();
         this.updateStatus('Stopped');
     }
 
@@ -956,14 +1635,8 @@ export class MusicVideoChoreographer {
      * REACTIVE MODE: Built-in audio reactivity with direct parameter mapping
      */
     applyReactiveMode(audioData) {
-        const setParam = (param, value) => {
-            if (this.currentEngine.parameterManager) {
-                this.currentEngine.parameterManager.setParameter(param, value);
-            } else if (this.currentEngine.updateParameter) {
-                this.currentEngine.updateParameter(param, value);
-            } else if (this.currentEngine.updateParameters) {
-                this.currentEngine.updateParameters({ [param]: value });
-            }
+        const setParam = (param, value, options) => {
+            this.setParameterValue(param, value, options);
         };
 
         // Direct audio-to-parameter mapping
@@ -1013,14 +1686,8 @@ export class MusicVideoChoreographer {
 
         const effects = activeSequence.effects;
 
-        const setParam = (param, value) => {
-            if (this.currentEngine.parameterManager) {
-                this.currentEngine.parameterManager.setParameter(param, value);
-            } else if (this.currentEngine.updateParameter) {
-                this.currentEngine.updateParameter(param, value);
-            } else if (this.currentEngine.updateParameters) {
-                this.currentEngine.updateParameters({ [param]: value });
-            }
+        const setParam = (param, value, options) => {
+            this.setParameterValue(param, value, options);
         };
 
         // CHECK FOR SYSTEM SWITCH (if sequence specifies a different system)
@@ -1383,20 +2050,18 @@ export class MusicVideoChoreographer {
         return formatted.join(', ');
     }
 
-    renderGeometryAxisOptions(selected) {
-        const normalized = (selected || '').toString().toLowerCase();
-        const options = [
-            { value: '', label: 'Auto (energy mix)' },
-            { value: 'bass', label: 'Bass' },
-            { value: 'mid', label: 'Mid' },
-            { value: 'high', label: 'High' },
-            { value: 'energy', label: 'Energy' }
-        ];
+    renderGeometryAxisOptions(selected, axisOptions = []) {
+        const options = Array.isArray(axisOptions) && axisOptions.length
+            ? axisOptions
+            : collectOptions([
+                axisOptions,
+                this.defaultTimelineDescriptor?.form?.geometryAudioAxes || []
+            ], { allowEmpty: true });
 
-        return options.map(({ value, label }) => {
-            const isSelected = value === '' ? !normalized : normalized === value;
-            return `<option value="${value}" ${isSelected ? 'selected' : ''}>${label}</option>`;
-        }).join('');
+        return this.buildOptionMarkup(selected, options, {
+            allowEmpty: true,
+            fallbackLabel: () => 'Auto'
+        });
     }
 
     normalizeGeometryBehaviorValue(value) {
@@ -1582,8 +2247,56 @@ export class MusicVideoChoreographer {
     }
 
     updateTimeline() {
-        const progress = (this.audio.currentTime / this.audio.duration) * 100;
-        document.getElementById('timeline-progress').style.width = progress + '%';
+        const bar = document.getElementById('timeline-progress');
+        const duration = Number.isFinite(this.audio?.duration) ? this.audio.duration : 0;
+        const current = Number.isFinite(this.audio?.currentTime) ? this.audio.currentTime : 0;
+        const ratio = duration > 0 ? Math.min(Math.max(current / duration, 0), 1) : 0;
+
+        if (bar) {
+            bar.style.width = `${(ratio * 100).toFixed(3)}%`;
+        }
+
+        this.updateTimelineReadout(current, duration);
+    }
+
+    updateTimelineReadout(current = 0, duration = null) {
+        const currentLabel = document.getElementById('timelineCurrent');
+        const durationLabel = document.getElementById('timelineDuration');
+
+        if (currentLabel) {
+            currentLabel.textContent = this.formatTimelineTime(current);
+        }
+
+        if (durationLabel) {
+            const referenceDuration = duration ?? (Number.isFinite(this.audio?.duration) ? this.audio.duration : 0);
+            durationLabel.textContent = this.formatTimelineTime(referenceDuration);
+        }
+    }
+
+    formatTimelineTime(value = 0) {
+        if (!Number.isFinite(value) || value < 0) {
+            return '0:00';
+        }
+
+        const minutes = Math.floor(value / 60);
+        const seconds = Math.floor(value % 60);
+        return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+    }
+
+    emitTimelineUpdate(reason = 'update') {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        const detail = {
+            reason,
+            mode: this.mode,
+            system: this.currentSystem,
+            count: Array.isArray(this.sequences) ? this.sequences.length : 0,
+            duration: Number.isFinite(this.audio?.duration) ? this.audio.duration : null
+        };
+
+        window.dispatchEvent(new CustomEvent('vib34d:timeline-updated', { detail }));
     }
 
     updateInfoPanel(audioData) {

--- a/src/audio/ADSREnvelope.js
+++ b/src/audio/ADSREnvelope.js
@@ -1,0 +1,121 @@
+export class ADSREnvelope {
+    constructor(attackMs = 100, decayMs = 200, sustainLevel = 0.7, releaseMs = 200) {
+        this.attack = Math.max(0, attackMs);
+        this.decay = Math.max(0, decayMs);
+        this.sustain = Math.min(Math.max(sustainLevel, 0), 1);
+        this.release = Math.max(0, releaseMs);
+
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.phaseStartTime = this.#now();
+        this.startValue = 0;
+    }
+
+    reset() {
+        this.phase = 'idle';
+        this.value = 0;
+        this.targetValue = 0;
+        this.startValue = 0;
+        this.phaseStartTime = this.#now();
+    }
+
+    trigger(level = 1, time = this.#now()) {
+        const clamped = Math.min(Math.max(level, 0), 1);
+        this.targetValue = clamped;
+        this.phaseStartTime = time;
+
+        if (this.attack <= 0) {
+            this.value = clamped;
+            this.startValue = this.value;
+
+            if (this.decay <= 0) {
+                this.phase = 'sustain';
+            } else {
+                this.phase = 'decay';
+            }
+        } else {
+            this.phase = 'attack';
+            this.startValue = this.value;
+        }
+    }
+
+    releasePhase(time = this.#now()) {
+        if (this.phase === 'idle' || this.release === 0) {
+            this.reset();
+            return;
+        }
+
+        if (this.phase === 'release') {
+            return;
+        }
+
+        this.phase = 'release';
+        this.phaseStartTime = time;
+        this.startValue = this.value;
+    }
+
+    update(time = this.#now()) {
+        const now = time;
+        switch (this.phase) {
+            case 'attack':
+                this.value = this.#interpolate(this.startValue, this.targetValue, this.attack, now);
+                if (now - this.phaseStartTime >= this.attack) {
+                    this.phase = this.decay === 0 ? 'sustain' : 'decay';
+                    this.phaseStartTime = now;
+                    this.startValue = this.value;
+                }
+                break;
+            case 'decay':
+                {
+                    const target = this.targetValue * this.sustain;
+                    this.value = this.#interpolate(this.startValue, target, this.decay, now);
+                    if (now - this.phaseStartTime >= this.decay) {
+                        this.phase = 'sustain';
+                        this.phaseStartTime = now;
+                        this.startValue = this.value;
+                    }
+                }
+                break;
+            case 'sustain':
+                this.value = this.targetValue * this.sustain;
+                break;
+            case 'release':
+                this.value = this.#interpolate(this.startValue, 0, this.release, now);
+                if (now - this.phaseStartTime >= this.release) {
+                    this.reset();
+                }
+                break;
+            default:
+                this.value = 0;
+                break;
+        }
+
+        return this.value;
+    }
+
+    isActive() {
+        return this.phase !== 'idle';
+    }
+
+    clone() {
+        return new ADSREnvelope(this.attack, this.decay, this.sustain, this.release);
+    }
+
+    #interpolate(start, end, duration, now) {
+        if (duration <= 0) {
+            return end;
+        }
+        const progress = Math.min((now - this.phaseStartTime) / duration, 1);
+        return start + (end - start) * progress;
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default ADSREnvelope;

--- a/src/audio/AudioAnalyzer.js
+++ b/src/audio/AudioAnalyzer.js
@@ -1,0 +1,261 @@
+const DEFAULT_BANDS = [
+    { key: 'subBass', low: 20, high: 60 },
+    { key: 'bass', low: 60, high: 250 },
+    { key: 'lowMid', low: 250, high: 500 },
+    { key: 'mid', low: 500, high: 2000 },
+    { key: 'highMid', low: 2000, high: 4000 },
+    { key: 'high', low: 4000, high: 8000 },
+    { key: 'air', low: 8000, high: 20000 }
+];
+
+const DB_FLOOR = -100;
+
+export class AudioAnalyzer {
+    constructor(analyserNode, options = {}) {
+        if (!analyserNode) {
+            throw new Error('AudioAnalyzer requires an AnalyserNode instance.');
+        }
+
+        this.analyser = analyserNode;
+        this.context = analyserNode.context || null;
+
+        this.fftSize = options.fftSize || 2048;
+        this.minDecibels = options.minDecibels ?? -100;
+        this.maxDecibels = options.maxDecibels ?? -20;
+        this.smoothingConstant = options.frequencySmoothing ?? 0.7;
+        this.energySmoothing = options.energySmoothing ?? 0.8;
+        this.onsetThreshold = options.onsetThreshold ?? 0.15;
+        this.minimumOnsetInterval = options.minimumOnsetInterval ?? 120;
+        this.bandDefinitions = options.bands || DEFAULT_BANDS;
+
+        this.analyser.fftSize = this.fftSize;
+        this.analyser.minDecibels = this.minDecibels;
+        this.analyser.maxDecibels = this.maxDecibels;
+        this.analyser.smoothingTimeConstant = this.smoothingConstant;
+
+        this.frequencyData = new Float32Array(this.analyser.frequencyBinCount);
+        this.timeDomainData = new Float32Array(this.analyser.fftSize);
+        this.previousSpectrum = new Float32Array(this.analyser.frequencyBinCount);
+
+        this.sampleRate = options.sampleRate || this.context?.sampleRate || 44100;
+
+        this.bandValues = this.bandDefinitions.reduce((acc, band) => {
+            acc[band.key] = 0;
+            return acc;
+        }, {});
+        this.smoothedBands = { ...this.bandValues };
+
+        this.spectralCentroid = 0;
+        this.spectralRolloff = 0;
+        this.spectralFlux = 0;
+        this.rms = 0;
+        this.estimatedBPM = options.initialBPM || 120;
+
+        this.onsetHistory = [];
+        this.lastOnsetTime = 0;
+    }
+
+    analyze() {
+        this.#captureFrequencyData();
+        this.#captureTimeDomainData();
+
+        this.#analyzeBands();
+        this.#calculateSpectralCentroid();
+        this.#calculateSpectralRolloff();
+        this.#calculateSpectralFlux();
+        this.#calculateRMS();
+
+        const now = this.#now();
+        const onset = this.#detectOnset(now);
+        if (onset) {
+            this.#recordOnset(now);
+            this.#estimateBPM();
+        }
+
+        return {
+            bands: { ...this.smoothedBands },
+            spectralCentroid: this.spectralCentroid,
+            spectralRolloff: this.spectralRolloff,
+            spectralFlux: this.spectralFlux,
+            rms: this.rms,
+            onset,
+            bpm: this.estimatedBPM
+        };
+    }
+
+    #captureFrequencyData() {
+        if (typeof this.analyser.getFloatFrequencyData === 'function') {
+            this.analyser.getFloatFrequencyData(this.frequencyData);
+        } else {
+            const byteData = new Uint8Array(this.analyser.frequencyBinCount);
+            this.analyser.getByteFrequencyData(byteData);
+            for (let i = 0; i < byteData.length; i += 1) {
+                this.frequencyData[i] = (byteData[i] / 255) * (this.maxDecibels - this.minDecibels) + this.minDecibels;
+            }
+        }
+    }
+
+    #captureTimeDomainData() {
+        if (typeof this.analyser.getFloatTimeDomainData === 'function') {
+            this.analyser.getFloatTimeDomainData(this.timeDomainData);
+        } else {
+            const byteData = new Uint8Array(this.analyser.fftSize);
+            this.analyser.getByteTimeDomainData(byteData);
+            for (let i = 0; i < byteData.length; i += 1) {
+                this.timeDomainData[i] = (byteData[i] - 128) / 128;
+            }
+        }
+    }
+
+    #analyzeBands() {
+        const binSize = this.sampleRate / this.analyser.fftSize;
+        const smoothing = this.energySmoothing;
+
+        this.bandDefinitions.forEach((band) => {
+            const startBin = Math.max(0, Math.floor(band.low / binSize));
+            const endBin = Math.min(this.frequencyData.length - 1, Math.ceil(band.high / binSize));
+
+            if (endBin <= startBin) {
+                this.smoothedBands[band.key] *= smoothing;
+                return;
+            }
+
+            let sum = 0;
+            let count = 0;
+            for (let i = startBin; i <= endBin; i += 1) {
+                const amplitude = this.#dbToNormalized(this.frequencyData[i]);
+                sum += amplitude;
+                count += 1;
+            }
+
+            const average = count > 0 ? sum / count : 0;
+            this.smoothedBands[band.key] = (smoothing * this.smoothedBands[band.key]) + ((1 - smoothing) * average);
+        });
+    }
+
+    #calculateSpectralCentroid() {
+        let weightedSum = 0;
+        let total = 0;
+        const binSize = this.sampleRate / this.analyser.fftSize;
+
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.#dbToNormalized(this.frequencyData[i]);
+            const frequency = i * binSize;
+            weightedSum += frequency * magnitude;
+            total += magnitude;
+        }
+
+        const centroid = total > 0 ? weightedSum / total : 0;
+        this.spectralCentroid = centroid / (this.sampleRate / 2);
+    }
+
+    #calculateSpectralRolloff() {
+        const threshold = 0.85;
+        const binSize = this.sampleRate / this.analyser.fftSize;
+        let totalEnergy = 0;
+        const magnitudes = new Array(this.frequencyData.length);
+
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const magnitude = this.#dbToNormalized(this.frequencyData[i]);
+            magnitudes[i] = magnitude;
+            totalEnergy += magnitude;
+        }
+
+        const targetEnergy = totalEnergy * threshold;
+        let cumulative = 0;
+        let rolloffBin = 0;
+        for (let i = 0; i < magnitudes.length; i += 1) {
+            cumulative += magnitudes[i];
+            if (cumulative >= targetEnergy) {
+                rolloffBin = i;
+                break;
+            }
+        }
+
+        const rolloffFrequency = rolloffBin * binSize;
+        this.spectralRolloff = Math.min(rolloffFrequency / (this.sampleRate / 2), 1);
+    }
+
+    #calculateSpectralFlux() {
+        let flux = 0;
+        for (let i = 0; i < this.frequencyData.length; i += 1) {
+            const current = Math.max(0, this.#dbToNormalized(this.frequencyData[i]));
+            const previous = Math.max(0, this.previousSpectrum[i]);
+            const diff = current - previous;
+            if (diff > 0) {
+                flux += diff;
+            }
+            this.previousSpectrum[i] = current;
+        }
+
+        this.spectralFlux = flux / this.frequencyData.length;
+    }
+
+    #calculateRMS() {
+        let sumSquares = 0;
+        for (let i = 0; i < this.timeDomainData.length; i += 1) {
+            const sample = this.timeDomainData[i];
+            sumSquares += sample * sample;
+        }
+
+        const meanSquare = sumSquares / this.timeDomainData.length;
+        this.rms = Math.sqrt(meanSquare);
+    }
+
+    #detectOnset(now) {
+        const flux = this.spectralFlux;
+        const timeSinceLast = now - this.lastOnsetTime;
+
+        if (flux > this.onsetThreshold && timeSinceLast > this.minimumOnsetInterval) {
+            this.lastOnsetTime = now;
+            return true;
+        }
+
+        return false;
+    }
+
+    #recordOnset(timestamp) {
+        this.onsetHistory.push(timestamp);
+        const windowMs = 6000;
+        const cutoff = timestamp - windowMs;
+        this.onsetHistory = this.onsetHistory.filter((time) => time >= cutoff);
+    }
+
+    #estimateBPM() {
+        if (this.onsetHistory.length < 2) {
+            return;
+        }
+
+        const intervals = [];
+        for (let i = 1; i < this.onsetHistory.length; i += 1) {
+            intervals.push(this.onsetHistory[i] - this.onsetHistory[i - 1]);
+        }
+
+        if (intervals.length === 0) {
+            return;
+        }
+
+        const avgInterval = intervals.reduce((sum, value) => sum + value, 0) / intervals.length;
+        if (avgInterval === 0) {
+            return;
+        }
+
+        const bpm = 60000 / avgInterval;
+        const clampedBpm = Math.min(Math.max(bpm, 60), 200);
+        this.estimatedBPM = (this.estimatedBPM * 0.8) + (clampedBpm * 0.2);
+    }
+
+    #dbToNormalized(db) {
+        const normalized = (db - (this.minDecibels ?? DB_FLOOR)) / ((this.maxDecibels ?? -30) - (this.minDecibels ?? DB_FLOOR));
+        return Math.min(Math.max(normalized, 0), 1);
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default AudioAnalyzer;

--- a/src/audio/ParameterMapper.js
+++ b/src/audio/ParameterMapper.js
@@ -1,0 +1,141 @@
+import { ADSREnvelope } from './ADSREnvelope.js';
+
+const clamp01 = (value) => Math.min(Math.max(value, 0), 1);
+
+export class ParameterMapper {
+    constructor(mappings = {}) {
+        this.mappings = {};
+        this.envelopes = new Map();
+        this.lastValues = new Map();
+
+        Object.entries(mappings).forEach(([parameter, config]) => {
+            this.registerMapping(parameter, config);
+        });
+    }
+
+    registerMapping(parameter, config) {
+        if (!config) {
+            return;
+        }
+
+        const mapping = {
+            source: config.source,
+            curve: config.curve || 'linear',
+            range: config.range || [0, 1],
+            scale: config.scale || 1,
+            offset: config.offset || 0,
+            threshold: config.threshold ?? 0,
+            envelopeTrigger: config.envelopeTrigger ?? config.threshold ?? 0,
+            envelopeRelease: config.envelopeRelease ?? config.threshold ?? 0,
+            envelope: null
+        };
+
+        if (config.envelope instanceof ADSREnvelope) {
+            mapping.envelope = config.envelope.clone();
+            this.envelopes.set(parameter, mapping.envelope);
+        }
+
+        this.mappings[parameter] = mapping;
+        this.lastValues.set(parameter, 0);
+    }
+
+    removeMapping(parameter) {
+        delete this.mappings[parameter];
+        this.envelopes.delete(parameter);
+        this.lastValues.delete(parameter);
+    }
+
+    map(audioData, time = this.#now()) {
+        const result = {};
+        Object.entries(this.mappings).forEach(([parameter, config]) => {
+            const rawValue = clamp01(this.#resolveSource(config.source, audioData));
+            const curvedValue = clamp01(this.#applyCurve(rawValue, config));
+            let value = this.#applyRange(curvedValue, config);
+
+            const envelope = this.envelopes.get(parameter);
+            if (envelope) {
+                if (curvedValue >= config.envelopeTrigger) {
+                    envelope.trigger(curvedValue, time);
+                } else if (curvedValue <= config.envelopeRelease) {
+                    envelope.releasePhase(time);
+                }
+                const envelopeValue = envelope.update(time);
+                value = this.#applyRange(envelopeValue, config);
+            }
+
+            value = (value * config.scale) + config.offset;
+            result[parameter] = value;
+            this.lastValues.set(parameter, value);
+        });
+
+        return result;
+    }
+
+    #resolveSource(source, audioData) {
+        if (typeof source === 'function') {
+            try {
+                const resolved = source(audioData);
+                return typeof resolved === 'number' ? resolved : 0;
+            } catch (error) {
+                console.warn('ParameterMapper source function failed:', error);
+                return 0;
+            }
+        }
+
+        if (typeof source === 'string') {
+            const path = source.split('.');
+            let value = audioData;
+            for (let i = 0; i < path.length; i += 1) {
+                if (value == null) {
+                    return 0;
+                }
+                value = value[path[i]];
+            }
+
+            if (typeof value === 'number') {
+                return value;
+            }
+
+            if (value && typeof value.value === 'number') {
+                return value.value;
+            }
+        }
+
+        return 0;
+    }
+
+    #applyCurve(value, config) {
+        const curve = config.curve;
+        switch (curve) {
+            case 'exponential':
+                return Math.pow(value, config.exponent ?? 2);
+            case 'logarithmic':
+                return Math.log10(1 + value * 9) / Math.log10(10);
+            case 's-curve': {
+                const intensity = config.intensity ?? 1;
+                const x = (value - 0.5) * (1 + intensity * 4);
+                return 1 / (1 + Math.exp(-x * 5));
+            }
+            case 'threshold':
+                return value >= (config.threshold ?? 0.5) ? 1 : 0;
+            case 'power':
+                return Math.pow(value, config.power ?? 1.5);
+            default:
+                return value;
+        }
+    }
+
+    #applyRange(value, config) {
+        const [min, max] = config.range;
+        return min + (clamp01(value) * (max - min));
+    }
+
+    #now() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+}
+
+export default ParameterMapper;

--- a/src/color/ColorSystem.js
+++ b/src/color/ColorSystem.js
@@ -1,0 +1,535 @@
+/**
+ * VIB34D Advanced Color System
+ * Provides palette, gradient, and audio-reactive color generation utilities.
+ */
+
+const clamp01 = value => Math.min(Math.max(value, 0), 1);
+const mod360 = value => {
+    const wrapped = value % 360;
+    return wrapped < 0 ? wrapped + 360 : wrapped;
+};
+
+export const COLOR_MODES = Object.freeze([
+    'single',
+    'dual',
+    'triad',
+    'complementary',
+    'analogous',
+    'palette',
+    'gradient',
+    'reactive'
+]);
+
+export const GRADIENT_TYPES = Object.freeze([
+    'horizontal',
+    'vertical',
+    'radial',
+    'spiral',
+    'wave'
+]);
+
+export const DEFAULT_COLOR_CONFIG = {
+    colorMode: 'single',
+    baseHue: 210,
+    baseSaturation: 0.75,
+    baseIntensity: 0.65,
+    colorPalette: 'synthwave',
+    gradientType: 'horizontal',
+    gradientSpeed: 0.25,
+    colorReactivity: 0.65,
+    dualOffset: 180,
+    triadSpacing: 120,
+    analogousSpread: 30
+};
+
+export const COLOR_PALETTES = Object.freeze({
+    vaporwave: ['#ff71ce', '#01cdfe', '#05ffa1', '#b967ff'],
+    cyberpunk: ['#ff006e', '#fb5607', '#ffbe0b', '#8338ec'],
+    synthwave: ['#f72585', '#7209b7', '#3a0ca3', '#4361ee'],
+    holographic: ['#ff00ff', '#00ffff', '#ff00aa', '#00aaff'],
+    neon: ['#fe00fe', '#00fefe', '#fefe00', '#00fe00'],
+    fire: ['#ff0000', '#ff4400', '#ff8800', '#ffcc00'],
+    ocean: ['#001eff', '#0088ff', '#00ccff', '#00ffee'],
+    forest: ['#004d00', '#008800', '#00cc00', '#88ff00']
+});
+
+function hexToRgb(hex) {
+    const clean = hex.replace('#', '');
+    const value = parseInt(clean, 16);
+    return {
+        r: ((value >> 16) & 255) / 255,
+        g: ((value >> 8) & 255) / 255,
+        b: (value & 255) / 255
+    };
+}
+
+function rgbToHex({ r, g, b }) {
+    const toHex = component => {
+        const clamped = Math.round(clamp01(component) * 255);
+        return clamped.toString(16).padStart(2, '0');
+    };
+
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hsvToRgb(h, s, v) {
+    const hue = (mod360(h) / 60);
+    const c = v * s;
+    const x = c * (1 - Math.abs((hue % 2) - 1));
+    const m = v - c;
+    const sector = Math.floor(hue);
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    switch (sector) {
+        case 0:
+            r = c; g = x; b = 0;
+            break;
+        case 1:
+            r = x; g = c; b = 0;
+            break;
+        case 2:
+            r = 0; g = c; b = x;
+            break;
+        case 3:
+            r = 0; g = x; b = c;
+            break;
+        case 4:
+            r = x; g = 0; b = c;
+            break;
+        default:
+            r = c; g = 0; b = x;
+    }
+
+    return {
+        r: r + m,
+        g: g + m,
+        b: b + m
+    };
+}
+
+function rgbToHsl({ r, g, b }) {
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    let s = 0;
+    const l = (max + min) / 2;
+
+    if (delta !== 0) {
+        if (max === r) {
+            h = ((g - b) / delta) % 6;
+        } else if (max === g) {
+            h = (b - r) / delta + 2;
+        } else {
+            h = (r - g) / delta + 4;
+        }
+
+        s = delta / (1 - Math.abs(2 * l - 1));
+    }
+
+    h = (h * 60 + 360) % 360;
+
+    return { h, s, l };
+}
+
+function makeColorObject(h, s, v) {
+    const rgb = hsvToRgb(h, s, v);
+    const hsl = rgbToHsl(rgb);
+
+    return {
+        h: mod360(h),
+        s: clamp01(s),
+        v: clamp01(v),
+        rgb,
+        hex: rgbToHex(rgb),
+        hsl,
+        css: `hsl(${Math.round(hsl.h)}, ${Math.round(hsl.s * 100)}%, ${Math.round(hsl.l * 100)}%)`
+    };
+}
+
+function clonePalette(palette) {
+    return palette.map(color => ({ ...color, rgb: { ...color.rgb }, hsl: { ...color.hsl } }));
+}
+
+export class ColorSystem {
+    constructor(config = {}) {
+        this.config = { ...DEFAULT_COLOR_CONFIG, ...config };
+        this.gradientPhase = 0;
+        this.lastUpdateTime = null;
+
+        this.#paletteCache = new Map();
+
+        // Prime initial state so consumers have data immediately
+        const initialState = this.#computeColorState({});
+        this.lastState = { ...initialState, gradient: this.#buildGradient(initialState.palette) };
+    }
+
+    updateConfig(partial = {}) {
+        if (!partial || typeof partial !== 'object') {
+            return this.getState();
+        }
+
+        const nextConfig = { ...this.config, ...partial };
+
+        if (typeof partial.colorMode === 'string') {
+            nextConfig.colorMode = COLOR_MODES.includes(partial.colorMode)
+                ? partial.colorMode
+                : this.config.colorMode;
+        }
+
+        if (typeof partial.colorPalette === 'string') {
+            nextConfig.colorPalette = COLOR_PALETTES[partial.colorPalette]
+                ? partial.colorPalette
+                : this.config.colorPalette;
+        }
+
+        if (typeof partial.gradientType === 'string') {
+            nextConfig.gradientType = GRADIENT_TYPES.includes(partial.gradientType)
+                ? partial.gradientType
+                : this.config.gradientType;
+        }
+
+        if (partial.gradientSpeed !== undefined) {
+            const parsed = Number(partial.gradientSpeed);
+            nextConfig.gradientSpeed = Number.isFinite(parsed)
+                ? Math.min(Math.max(parsed, 0), 5)
+                : this.config.gradientSpeed;
+        }
+
+        if (partial.colorReactivity !== undefined) {
+            const parsed = Number(partial.colorReactivity);
+            nextConfig.colorReactivity = Number.isFinite(parsed)
+                ? clamp01(parsed)
+                : this.config.colorReactivity;
+        }
+
+        if (partial.baseHue !== undefined) {
+            const parsed = Number(partial.baseHue);
+            nextConfig.baseHue = Number.isFinite(parsed)
+                ? mod360(parsed)
+                : this.config.baseHue;
+        }
+
+        if (partial.baseSaturation !== undefined) {
+            const parsed = Number(partial.baseSaturation);
+            nextConfig.baseSaturation = Number.isFinite(parsed)
+                ? clamp01(parsed)
+                : this.config.baseSaturation;
+        }
+
+        if (partial.baseIntensity !== undefined) {
+            const parsed = Number(partial.baseIntensity);
+            nextConfig.baseIntensity = Number.isFinite(parsed)
+                ? clamp01(parsed)
+                : this.config.baseIntensity;
+        }
+
+        if (partial.dualOffset !== undefined) {
+            const parsed = Number(partial.dualOffset);
+            nextConfig.dualOffset = Number.isFinite(parsed) ? parsed : this.config.dualOffset;
+        }
+
+        if (partial.triadSpacing !== undefined) {
+            const parsed = Number(partial.triadSpacing);
+            nextConfig.triadSpacing = Number.isFinite(parsed) ? parsed : this.config.triadSpacing;
+        }
+
+        if (partial.analogousSpread !== undefined) {
+            const parsed = Number(partial.analogousSpread);
+            nextConfig.analogousSpread = Number.isFinite(parsed) ? parsed : this.config.analogousSpread;
+        }
+
+        this.config = nextConfig;
+
+        return this.update(Date.now(), {});
+    }
+
+    setMode(mode) {
+        if (typeof mode === 'string') {
+            this.updateConfig({ colorMode: mode });
+        }
+    }
+
+    setPalette(name) {
+        if (typeof name === 'string' && COLOR_PALETTES[name]) {
+            this.updateConfig({ colorPalette: name });
+        }
+    }
+
+    getAvailablePalettes() {
+        return Object.keys(COLOR_PALETTES);
+    }
+
+    getAvailableModes() {
+        return [...COLOR_MODES];
+    }
+
+    getAvailableGradients() {
+        return [...GRADIENT_TYPES];
+    }
+
+    getConfig() {
+        return { ...this.config };
+    }
+
+    /**
+     * Update the color system using the latest audio frame.
+     * @param {number} now - timestamp in milliseconds
+     * @param {object} audioData - analyzer output
+     * @param {object} reactive - mapped audio data
+     */
+    update(now = Date.now(), audioData = {}, reactive = {}) {
+        if (typeof now !== 'number') {
+            now = Date.now();
+        }
+
+        if (this.lastUpdateTime == null) {
+            this.lastUpdateTime = now;
+        }
+
+        const delta = Math.max(0, (now - this.lastUpdateTime) / 1000);
+        this.lastUpdateTime = now;
+
+        const modulation = (audioData?.spectralFlux ?? reactive.motion ?? 0) * this.config.colorReactivity;
+        const speed = this.config.gradientSpeed * (1 + modulation * 1.5);
+        this.gradientPhase = (this.gradientPhase + delta * speed) % 1;
+
+        const paletteInfo = this.#computeColorState(audioData, reactive);
+        const gradient = this.#buildGradient(paletteInfo.palette);
+
+        this.lastState = {
+            ...paletteInfo,
+            gradient: {
+                ...gradient,
+                phase: this.gradientPhase
+            }
+        };
+
+        return this.lastState;
+    }
+
+    reset() {
+        this.lastUpdateTime = null;
+        this.gradientPhase = 0;
+        return this.update(Date.now(), {});
+    }
+
+    getState() {
+        return this.lastState;
+    }
+
+    /**
+     * Build a normalized palette given the current configuration.
+     */
+    #computeColorState(audioData = {}, reactive = {}) {
+        const mode = this.config.colorMode;
+        const baseHue = this.#computeBaseHue(audioData, reactive);
+        const baseSaturation = this.#computeBaseSaturation(audioData, reactive);
+        const baseIntensity = this.#computeBaseIntensity(audioData, reactive);
+
+        const palette = this.#generatePalette(mode, baseHue, baseSaturation, baseIntensity, audioData, reactive);
+        const primary = palette[0];
+        const accent = palette[Math.min(1, palette.length - 1)];
+
+        const uniforms = {
+            palette: palette.slice(0, 4).map(color => [color.rgb.r, color.rgb.g, color.rgb.b]),
+            size: Math.min(palette.length, 4)
+        };
+
+        return {
+            mode,
+            baseHue,
+            palette,
+            primary,
+            accent,
+            uniforms,
+            saturation: baseSaturation,
+            intensity: baseIntensity,
+            paletteName: this.config.colorPalette
+        };
+    }
+
+    #computeBaseHue(audioData = {}, reactive = {}) {
+        const centroid = audioData?.spectralCentroid ?? 0;
+        const motion = reactive.motion ?? audioData?.spectralFlux ?? 0;
+        const onsetBoost = audioData?.onset ? 25 : 0;
+
+        const reactiveShift = (centroid * 220 + motion * 110 + onsetBoost) * this.config.colorReactivity;
+        return mod360(this.config.baseHue + reactiveShift);
+    }
+
+    #computeBaseSaturation(audioData = {}, reactive = {}) {
+        const sparkle = reactive.sparkle ?? audioData?.bands?.air ?? 0;
+        const flux = audioData?.spectralFlux ?? 0;
+        const adjustment = (sparkle * 0.35 + flux * 0.4) * this.config.colorReactivity;
+        return clamp01(this.config.baseSaturation + adjustment);
+    }
+
+    #computeBaseIntensity(audioData = {}, reactive = {}) {
+        const rms = audioData?.rms ?? 0;
+        const energy = reactive.energy ?? rms;
+        const adjustment = (energy * 0.55) * this.config.colorReactivity;
+        return clamp01(this.config.baseIntensity + adjustment);
+    }
+
+    #generatePalette(mode, baseHue, saturation, intensity, audioData = {}, reactive = {}) {
+        switch (mode) {
+            case 'dual':
+                return this.#buildHueSet([baseHue, baseHue + this.config.dualOffset], saturation, intensity, audioData, reactive);
+            case 'triad':
+                return this.#buildHueSet([
+                    baseHue,
+                    baseHue + this.config.triadSpacing,
+                    baseHue + this.config.triadSpacing * 2
+                ], saturation, intensity, audioData, reactive);
+            case 'complementary':
+                return this.#buildHueSet([baseHue, baseHue + 180], saturation, intensity, audioData, reactive);
+            case 'analogous':
+                return this.#buildHueSet([
+                    baseHue - this.config.analogousSpread,
+                    baseHue,
+                    baseHue + this.config.analogousSpread
+                ], saturation, intensity, audioData, reactive);
+            case 'palette':
+                return this.#buildPaletteMode(saturation, intensity, audioData, reactive);
+            case 'gradient':
+                return this.#buildGradientMode(baseHue, saturation, intensity, audioData, reactive);
+            case 'reactive':
+                return this.#buildReactivePalette(saturation, intensity, audioData, reactive);
+            case 'single':
+            default:
+                return this.#buildHueSet([baseHue], saturation, intensity, audioData, reactive);
+        }
+    }
+
+    #buildHueSet(hues, saturation, intensity, audioData, reactive) {
+        return hues.map(hue => this.#applyAudioModulation(hue, saturation, intensity, audioData, reactive));
+    }
+
+    #applyAudioModulation(h, s, v, audioData = {}, reactive = {}) {
+        const centroid = audioData?.spectralCentroid ?? 0;
+        const sparkle = reactive.sparkle ?? audioData?.bands?.air ?? 0;
+        const energy = reactive.energy ?? audioData?.rms ?? 0;
+
+        const hueShift = centroid * 45 * this.config.colorReactivity;
+        const saturationBoost = sparkle * 0.45 * this.config.colorReactivity;
+        const intensityBoost = energy * 0.55 * this.config.colorReactivity;
+
+        const hue = mod360(h + hueShift);
+        const saturation = clamp01(s + saturationBoost);
+        const intensityValue = clamp01(v + intensityBoost);
+
+        return makeColorObject(hue, saturation, intensityValue);
+    }
+
+    #buildPaletteMode(saturation, intensity, audioData, reactive) {
+        const paletteName = this.config.colorPalette;
+        const key = `${paletteName}|${Math.round(saturation * 100)}|${Math.round(intensity * 100)}`;
+
+        if (this.#paletteCache.has(key)) {
+            const cached = this.#paletteCache.get(key);
+            return clonePalette(cached);
+        }
+
+        const source = COLOR_PALETTES[paletteName] || COLOR_PALETTES.synthwave;
+        const palette = source.map(hex => {
+            const { r, g, b } = hexToRgb(hex);
+            const max = Math.max(r, g, b);
+            const min = Math.min(r, g, b);
+            const delta = max - min;
+
+            let hue = 0;
+            if (delta > 0) {
+                if (max === r) {
+                    hue = ((g - b) / delta) % 6;
+                } else if (max === g) {
+                    hue = (b - r) / delta + 2;
+                } else {
+                    hue = (r - g) / delta + 4;
+                }
+            }
+
+            hue = (hue * 60 + 360) % 360;
+            return makeColorObject(hue, saturation, intensity);
+        });
+
+        this.#paletteCache.set(key, palette);
+        return clonePalette(palette).map(color => this.#applyAudioModulation(color.h, color.s, color.v, audioData, reactive));
+    }
+
+    #buildGradientMode(baseHue, saturation, intensity, audioData, reactive) {
+        const hues = [baseHue, baseHue + 60, baseHue + 180];
+        return this.#buildHueSet(hues, saturation, intensity, audioData, reactive);
+    }
+
+    #buildReactivePalette(saturation, intensity, audioData = {}, reactive = {}) {
+        const bass = reactive.bass ?? audioData?.bands?.bass ?? 0;
+        const mid = reactive.mid ?? audioData?.bands?.mid ?? 0;
+        const high = reactive.high ?? audioData?.bands?.high ?? 0;
+
+        const bassHue = 20 + bass * 60;
+        const midHue = 160 + mid * 80;
+        const highHue = 260 + high * 80;
+
+        return this.#buildHueSet([bassHue, midHue, highHue], saturation, intensity, audioData, reactive);
+    }
+
+    #buildGradient(palette) {
+        if (!palette || palette.length === 0) {
+            return {
+                type: this.config.gradientType,
+                css: 'linear-gradient(90deg, #ffffff, #000000)',
+                stops: []
+            };
+        }
+
+        const stops = palette.map((color, index) => ({
+            offset: palette.length === 1 ? 0 : index / (palette.length - 1),
+            color
+        }));
+
+        const stopString = stops
+            .map(({ offset, color }) => `${color.css} ${(offset * 100).toFixed(1)}%`)
+            .join(', ');
+
+        const angle = Math.round(this.gradientPhase * 360);
+
+        switch (this.config.gradientType) {
+            case 'vertical':
+                return {
+                    type: 'vertical',
+                    css: `linear-gradient(180deg, ${stopString})`,
+                    stops
+                };
+            case 'radial':
+                return {
+                    type: 'radial',
+                    css: `radial-gradient(circle, ${stopString})`,
+                    stops
+                };
+            case 'spiral':
+                return {
+                    type: 'spiral',
+                    css: `conic-gradient(from ${angle}deg, ${stopString})`,
+                    stops
+                };
+            case 'wave':
+                return {
+                    type: 'wave',
+                    css: `linear-gradient(${angle}deg, ${stopString})`,
+                    stops
+                };
+            case 'horizontal':
+            default:
+                return {
+                    type: 'horizontal',
+                    css: `linear-gradient(90deg, ${stopString})`,
+                    stops
+                };
+        }
+    }
+}

--- a/src/core/Visualizer.js
+++ b/src/core/Visualizer.js
@@ -5,6 +5,28 @@
 
 import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
 
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const lerp = (current, target, factor) => current + (target - current) * factor;
+
+const COLOR_MODE_MAP = Object.freeze({
+    single: 0,
+    dual: 1,
+    triad: 2,
+    complementary: 3,
+    analogous: 4,
+    palette: 5,
+    gradient: 6,
+    reactive: 7
+});
+
+const GRADIENT_TYPE_MAP = Object.freeze({
+    horizontal: 0,
+    vertical: 1,
+    radial: 2,
+    spiral: 3,
+    wave: 4
+});
+
 export class IntegratedHolographicVisualizer {
     constructor(canvasId, role, reactivity, variant) {
         this.canvas = document.getElementById(canvasId);
@@ -55,7 +77,30 @@ export class IntegratedHolographicVisualizer {
             rot4dYW: 0.0,
             rot4dZW: 0.0
         };
-        
+
+        this.audioResponse = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hueShift: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+        this.onsetPulse = 0;
+
+        this.colorUniformBuffer = new Float32Array(12);
+        this.colorUniformState = {
+            mode: COLOR_MODE_MAP.single,
+            paletteSize: 0,
+            gradientType: GRADIENT_TYPE_MAP.horizontal,
+            gradientPhase: 0
+        };
+
         // Initialization now happens in ensureCanvasSizedThenInitWebGL after sizing
         // this.init(); // MOVED
     }
@@ -183,6 +228,74 @@ uniform float u_rot4dZW;
 uniform float u_mouseIntensity;
 uniform float u_clickIntensity;
 uniform float u_roleIntensity;
+uniform int u_colorMode;
+uniform int u_paletteSize;
+uniform vec3 u_palette[4];
+uniform int u_gradientType;
+uniform float u_gradientPhase;
+
+const int COLOR_MODE_SINGLE = 0;
+const int COLOR_MODE_DUAL = 1;
+const int COLOR_MODE_TRIAD = 2;
+const int COLOR_MODE_COMPLEMENTARY = 3;
+const int COLOR_MODE_ANALOGOUS = 4;
+const int COLOR_MODE_PALETTE = 5;
+const int COLOR_MODE_GRADIENT = 6;
+const int COLOR_MODE_REACTIVE = 7;
+
+const int GRADIENT_HORIZONTAL = 0;
+const int GRADIENT_VERTICAL = 1;
+const int GRADIENT_RADIAL = 2;
+const int GRADIENT_SPIRAL = 3;
+const int GRADIENT_WAVE = 4;
+
+float clamp01(float value) {
+    return clamp(value, 0.0, 1.0);
+}
+
+vec3 samplePaletteColor(float position) {
+    if (u_paletteSize <= 0) {
+        return vec3(1.0);
+    }
+
+    if (u_paletteSize == 1) {
+        return u_palette[0];
+    }
+
+    float clamped = clamp(position, 0.0, 0.9999);
+    float scaled = clamped * float(u_paletteSize - 1);
+    int index = int(floor(scaled));
+    int nextIndex = min(index + 1, u_paletteSize - 1);
+    float mixAmount = fract(scaled);
+    vec3 a = u_palette[index];
+    vec3 b = u_palette[nextIndex];
+    return mix(a, b, mixAmount);
+}
+
+float computeGradientPosition(vec2 uv, float geometryValue) {
+    vec2 normalized = uv * 0.5 + 0.5;
+    float base = fract(u_gradientPhase + geometryValue * 0.25);
+
+    if (u_colorMode == COLOR_MODE_GRADIENT) {
+        if (u_gradientType == GRADIENT_HORIZONTAL) {
+            base = clamp01(normalized.x);
+        } else if (u_gradientType == GRADIENT_VERTICAL) {
+            base = clamp01(normalized.y);
+        } else if (u_gradientType == GRADIENT_RADIAL) {
+            float dist = length(normalized - 0.5);
+            base = clamp(dist * 1.4142, 0.0, 1.0);
+        } else if (u_gradientType == GRADIENT_SPIRAL) {
+            float angle = atan(normalized.y - 0.5, normalized.x - 0.5) / (6.28318);
+            base = fract(angle + u_gradientPhase);
+        } else if (u_gradientType == GRADIENT_WAVE) {
+            base = fract(normalized.x + sin((normalized.y + u_gradientPhase) * 6.28318) * 0.2 + u_gradientPhase);
+        }
+    } else {
+        base = fract(u_gradientPhase + geometryValue * 0.3 + normalized.x * 0.25);
+    }
+
+    return clamp01(base);
+}
 
 // 4D rotation matrices
 mat4 rotateXW(float theta) {
@@ -308,18 +421,25 @@ void main() {
     float finalIntensity = geometryIntensity * u_intensity;
     
     float hue = u_hue / 360.0 + value * 0.1;
-    
+
     // Create color with saturation control
     vec3 baseColor = vec3(
         sin(hue * 6.28318 + 0.0) * 0.5 + 0.5,
         sin(hue * 6.28318 + 2.0943) * 0.5 + 0.5,
         sin(hue * 6.28318 + 4.1887) * 0.5 + 0.5
     );
-    
+
+    float palettePosition = computeGradientPosition(uv, value);
+    vec3 paletteColor = samplePaletteColor(palettePosition);
+    if (u_paletteSize > 0) {
+        float blendStrength = (u_colorMode == COLOR_MODE_SINGLE) ? 0.7 : 1.0;
+        baseColor = mix(baseColor, paletteColor, blendStrength);
+    }
+
     // Apply saturation (mix with grayscale)
     float gray = (baseColor.r + baseColor.g + baseColor.b) / 3.0;
     vec3 color = mix(vec3(gray), baseColor, u_saturation) * finalIntensity;
-    
+
     gl_FragColor = vec4(color, finalIntensity * u_roleIntensity);
 }`;
         
@@ -342,7 +462,12 @@ void main() {
             rot4dZW: this.gl.getUniformLocation(this.program, 'u_rot4dZW'),
             mouseIntensity: this.gl.getUniformLocation(this.program, 'u_mouseIntensity'),
             clickIntensity: this.gl.getUniformLocation(this.program, 'u_clickIntensity'),
-            roleIntensity: this.gl.getUniformLocation(this.program, 'u_roleIntensity')
+            roleIntensity: this.gl.getUniformLocation(this.program, 'u_roleIntensity'),
+            colorMode: this.gl.getUniformLocation(this.program, 'u_colorMode'),
+            palette: this.gl.getUniformLocation(this.program, 'u_palette[0]'),
+            paletteSize: this.gl.getUniformLocation(this.program, 'u_paletteSize'),
+            gradientType: this.gl.getUniformLocation(this.program, 'u_gradientType'),
+            gradientPhase: this.gl.getUniformLocation(this.program, 'u_gradientPhase')
         };
     }
     
@@ -537,12 +662,156 @@ void main() {
             this.mouseIntensity = 0.0;
             return;
         }
-        
+
         this.mouseX = x;
         this.mouseY = y;
         this.mouseIntensity = intensity;
     }
-    
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined' || !window.audioEnabled) {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels() || null;
+        }
+
+        return window.audioReactive || null;
+    }
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    prepareColorUniforms(colorState) {
+        const buffer = this.colorUniformBuffer;
+        buffer.fill(0);
+
+        let paletteSize = 0;
+        if (colorState?.uniforms?.palette && Array.isArray(colorState.uniforms.palette)) {
+            const palette = colorState.uniforms.palette;
+            paletteSize = Math.min(palette.length, 4);
+            for (let i = 0; i < paletteSize; i += 1) {
+                const color = palette[i] || [0, 0, 0];
+                const offset = i * 3;
+                buffer[offset] = color[0] ?? 0;
+                buffer[offset + 1] = color[1] ?? 0;
+                buffer[offset + 2] = color[2] ?? 0;
+            }
+        }
+
+        const gradientTypeKey = colorState?.gradient?.type || 'horizontal';
+        const gradientType = GRADIENT_TYPE_MAP[gradientTypeKey] ?? GRADIENT_TYPE_MAP.horizontal;
+        const gradientPhase = typeof colorState?.gradient?.phase === 'number'
+            ? colorState.gradient.phase
+            : 0;
+        const modeKey = colorState?.mode || 'single';
+        const mode = COLOR_MODE_MAP[modeKey] ?? COLOR_MODE_MAP.single;
+
+        this.colorUniformState.mode = mode;
+        this.colorUniformState.paletteSize = paletteSize;
+        this.colorUniformState.gradientType = gradientType;
+        this.colorUniformState.gradientPhase = gradientPhase;
+
+        return this.colorUniformState;
+    }
+
+    applyColorUniforms(uniformState) {
+        if (!this.gl || !this.uniforms) {
+            return;
+        }
+
+        if (this.uniforms.colorMode) {
+            this.gl.uniform1i(this.uniforms.colorMode, uniformState.mode);
+        }
+        if (this.uniforms.palette) {
+            this.gl.uniform3fv(this.uniforms.palette, this.colorUniformBuffer);
+        }
+        if (this.uniforms.paletteSize) {
+            this.gl.uniform1i(this.uniforms.paletteSize, uniformState.paletteSize);
+        }
+        if (this.uniforms.gradientType) {
+            this.gl.uniform1i(this.uniforms.gradientType, uniformState.gradientType);
+        }
+        if (this.uniforms.gradientPhase) {
+            this.gl.uniform1f(this.uniforms.gradientPhase, uniformState.gradientPhase);
+        }
+    }
+
+    updateAudioResponse(audioState) {
+        const smoothing = 0.18;
+        const target = {
+            gridDensity: 0,
+            morph: 0,
+            chaos: 0,
+            speed: 0,
+            hueShift: 0,
+            intensity: 0,
+            saturation: 0,
+            dimension: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.onsetPulse = (this.onsetPulse || 0) * 0.82;
+
+        if (audioState) {
+            const bass = clamp(audioState.bass ?? 0, 0, 1);
+            const mid = clamp(audioState.mid ?? 0, 0, 1);
+            const high = clamp(audioState.high ?? 0, 0, 1);
+            const sparkle = clamp(audioState.sparkle ?? audioState.bands?.air ?? 0, 0, 1);
+            const energy = clamp(audioState.energy ?? audioState.rms ?? 0, 0, 1);
+            const motion = clamp(audioState.motion ?? audioState.spectralFlux ?? 0, 0, 1);
+            const hueShiftNorm = clamp(audioState.hueShift ?? audioState.spectralCentroid ?? 0, 0, 1);
+            const intensityBoost = clamp(audioState.intensity ?? audioState.rms ?? 0, 0, 1);
+
+            if (audioState.onset) {
+                this.onsetPulse = 1;
+            }
+
+            target.gridDensity = (bass * 32) + (motion * 14);
+            target.morph = (motion * 0.9) + (energy * 0.4);
+            target.chaos = (motion * 0.6) + (energy * 0.45);
+            target.speed = (energy * 0.45) + (motion * 0.3);
+            target.hueShift = (hueShiftNorm * 240) + (sparkle * 60);
+            target.intensity = (intensityBoost * 0.6) + (sparkle * 0.4);
+            target.saturation = sparkle * 0.35;
+            target.dimension = (energy * 0.35) + (bass * 0.25);
+            target.rot4dXW = bass * 0.4;
+            target.rot4dYW = mid * 0.3;
+            target.rot4dZW = high * 0.25;
+        }
+
+        target.speed += this.onsetPulse * 0.45;
+
+        this.audioResponse.gridDensity = lerp(this.audioResponse.gridDensity, target.gridDensity, smoothing);
+        this.audioResponse.morph = lerp(this.audioResponse.morph, target.morph, smoothing);
+        this.audioResponse.chaos = lerp(this.audioResponse.chaos, target.chaos, smoothing);
+        this.audioResponse.speed = lerp(this.audioResponse.speed, target.speed, smoothing);
+        this.audioResponse.hueShift = lerp(this.audioResponse.hueShift, target.hueShift, smoothing);
+        this.audioResponse.intensity = lerp(this.audioResponse.intensity, target.intensity, smoothing);
+        this.audioResponse.saturation = lerp(this.audioResponse.saturation, target.saturation, smoothing);
+        this.audioResponse.dimension = lerp(this.audioResponse.dimension, target.dimension, smoothing);
+        this.audioResponse.rot4dXW = lerp(this.audioResponse.rot4dXW, target.rot4dXW, smoothing);
+        this.audioResponse.rot4dYW = lerp(this.audioResponse.rot4dYW, target.rot4dYW, smoothing);
+        this.audioResponse.rot4dZW = lerp(this.audioResponse.rot4dZW, target.rot4dZW, smoothing);
+
+        return this.audioResponse;
+    }
+
     /**
      * Render frame
      */
@@ -591,33 +860,61 @@ void main() {
         this.gl.uniform1f(this.uniforms.time, time);
         this.gl.uniform2f(this.uniforms.mouse, this.mouseX, this.mouseY);
         this.gl.uniform1f(this.uniforms.geometry, this.params.geometry);
-        // 🎵 DIRECT AUDIO REACTIVITY - Simple and works
-        let gridDensity = this.params.gridDensity;
-        let hue = this.params.hue;
-        let intensity = this.params.intensity;
-        
-        if (window.audioEnabled && window.audioReactive) {
-            // Faceted audio mapping: Bass affects grid density, Mid affects hue, High affects intensity
-            gridDensity += window.audioReactive.bass * 30;  // Bass makes patterns denser
-            hue += window.audioReactive.mid * 60;           // Mid frequencies shift colors
-            intensity += window.audioReactive.high * 0.4;   // High frequencies brighten
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+        const colorUniforms = this.prepareColorUniforms(colorState);
+
+        let gridDensity = this.params.gridDensity + audioResponse.gridDensity;
+        let morphFactor = this.params.morphFactor + audioResponse.morph;
+        let chaos = this.params.chaos + audioResponse.chaos;
+        let speed = this.params.speed + audioResponse.speed;
+        let hue = (this.params.hue + audioResponse.hueShift) % 360;
+        let intensity = this.params.intensity + audioResponse.intensity;
+        let saturation = this.params.saturation + audioResponse.saturation;
+        let dimension = this.params.dimension + audioResponse.dimension;
+        let rot4dXW = this.params.rot4dXW + audioResponse.rot4dXW;
+        let rot4dYW = this.params.rot4dYW + audioResponse.rot4dYW;
+        let rot4dZW = this.params.rot4dZW + audioResponse.rot4dZW;
+
+        if (colorState?.primary) {
+            hue = colorState.primary.h;
+            saturation = clamp(Math.max(saturation, colorState.primary.s), 0, 1);
+            intensity = clamp(intensity + (colorState.primary.v - 0.5) * 0.8, 0, 2);
         }
-        
-        this.gl.uniform1f(this.uniforms.gridDensity, Math.min(100, gridDensity));
-        this.gl.uniform1f(this.uniforms.morphFactor, this.params.morphFactor);
-        this.gl.uniform1f(this.uniforms.chaos, this.params.chaos);
-        this.gl.uniform1f(this.uniforms.speed, this.params.speed);
-        this.gl.uniform1f(this.uniforms.hue, hue % 360);
+
+        if (colorState?.accent && colorState.accent !== colorState.primary) {
+            saturation = clamp(Math.max(saturation, colorState.accent.s * 0.9), 0, 1);
+        }
+
+        gridDensity = clamp(gridDensity, 0, 120);
+        morphFactor = clamp(morphFactor, 0, 2.5);
+        chaos = clamp(chaos, 0, 1.4);
+        speed = clamp(speed, 0, 3.5);
+        intensity = clamp(intensity, 0, 1.4);
+        saturation = clamp(saturation, 0, 1);
+        dimension = clamp(dimension, 0, 6);
+        rot4dXW = clamp(rot4dXW, -4, 4);
+        rot4dYW = clamp(rot4dYW, -4, 4);
+        rot4dZW = clamp(rot4dZW, -4, 4);
+
+        this.gl.uniform1f(this.uniforms.gridDensity, gridDensity);
+        this.gl.uniform1f(this.uniforms.morphFactor, morphFactor);
+        this.gl.uniform1f(this.uniforms.chaos, chaos);
+        this.gl.uniform1f(this.uniforms.speed, speed);
+        this.gl.uniform1f(this.uniforms.hue, hue);
         this.gl.uniform1f(this.uniforms.intensity, Math.min(1, intensity));
-        this.gl.uniform1f(this.uniforms.saturation, this.params.saturation);
-        this.gl.uniform1f(this.uniforms.dimension, this.params.dimension);
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.params.rot4dXW);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.params.rot4dYW);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.params.rot4dZW);
+        this.gl.uniform1f(this.uniforms.saturation, saturation);
+        this.gl.uniform1f(this.uniforms.dimension, dimension);
+        this.gl.uniform1f(this.uniforms.rot4dXW, rot4dXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, rot4dYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, rot4dZW);
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.roleIntensity, roleIntensities[this.role] || 1.0);
-        
+
+        this.applyColorUniforms(colorUniforms);
+
         try {
             this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
             

--- a/src/holograms/HolographicVisualizer.js
+++ b/src/holograms/HolographicVisualizer.js
@@ -6,6 +6,28 @@ import {
     buildVariantParams
 } from './VariantCatalog.js';
 
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const lerp = (current, target, factor) => current + (target - current) * factor;
+
+const COLOR_MODE_MAP = Object.freeze({
+    single: 0,
+    dual: 1,
+    triad: 2,
+    complementary: 3,
+    analogous: 4,
+    palette: 5,
+    gradient: 6,
+    reactive: 7
+});
+
+const GRADIENT_TYPE_MAP = Object.freeze({
+    horizontal: 0,
+    vertical: 1,
+    radial: 2,
+    spiral: 3,
+    wave: 4
+});
+
 /**
  * Core Holographic Visualizer - Clean WebGL rendering engine
  * Extracted from working system, no debugging mess
@@ -96,7 +118,28 @@ export class HolographicVisualizer {
         this.audioSpeedBoost = 0.0;
         this.audioChaosBoost = 0.0;
         this.audioColorShift = 0.0;
-        
+
+        this.audioResponse = {
+            density: 0,
+            morph: 0,
+            speed: 0,
+            chaos: 0,
+            colorShift: 0,
+            intensity: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+        this.onsetPulse = 0;
+
+        this.colorUniformBuffer = new Float32Array(12);
+        this.colorUniformState = {
+            mode: COLOR_MODE_MAP.single,
+            paletteSize: 0,
+            gradientType: GRADIENT_TYPE_MAP.horizontal,
+            gradientPhase: 0
+        };
+
         this.startTime = Date.now();
         this.initShaders();
         this.initBuffers();
@@ -213,7 +256,75 @@ export class HolographicVisualizer {
             uniform float u_rot4dXW;
             uniform float u_rot4dYW;
             uniform float u_rot4dZW;
-            
+            uniform int u_colorMode;
+            uniform int u_paletteSize;
+            uniform vec3 u_palette[4];
+            uniform int u_gradientType;
+            uniform float u_gradientPhase;
+
+            const int COLOR_MODE_SINGLE = 0;
+            const int COLOR_MODE_DUAL = 1;
+            const int COLOR_MODE_TRIAD = 2;
+            const int COLOR_MODE_COMPLEMENTARY = 3;
+            const int COLOR_MODE_ANALOGOUS = 4;
+            const int COLOR_MODE_PALETTE = 5;
+            const int COLOR_MODE_GRADIENT = 6;
+            const int COLOR_MODE_REACTIVE = 7;
+
+            const int GRADIENT_HORIZONTAL = 0;
+            const int GRADIENT_VERTICAL = 1;
+            const int GRADIENT_RADIAL = 2;
+            const int GRADIENT_SPIRAL = 3;
+            const int GRADIENT_WAVE = 4;
+
+            float clamp01(float value) {
+                return clamp(value, 0.0, 1.0);
+            }
+
+            vec3 samplePaletteColor(float position) {
+                if (u_paletteSize <= 0) {
+                    return vec3(1.0);
+                }
+
+                if (u_paletteSize == 1) {
+                    return u_palette[0];
+                }
+
+                float clamped = clamp(position, 0.0, 0.9999);
+                float scaled = clamped * float(u_paletteSize - 1);
+                int index = int(floor(scaled));
+                int nextIndex = min(index + 1, u_paletteSize - 1);
+                float mixAmount = fract(scaled);
+                vec3 a = u_palette[index];
+                vec3 b = u_palette[nextIndex];
+                return mix(a, b, mixAmount);
+            }
+
+            float computePalettePosition(vec2 uv, float geometryValue) {
+                vec2 normalized = uv * 0.5 + 0.5;
+                float base = fract(u_gradientPhase + geometryValue * 0.25);
+
+                if (u_colorMode == COLOR_MODE_GRADIENT) {
+                    if (u_gradientType == GRADIENT_HORIZONTAL) {
+                        base = clamp01(normalized.x);
+                    } else if (u_gradientType == GRADIENT_VERTICAL) {
+                        base = clamp01(normalized.y);
+                    } else if (u_gradientType == GRADIENT_RADIAL) {
+                        float dist = length(normalized - 0.5);
+                        base = clamp(dist * 1.4142, 0.0, 1.0);
+                    } else if (u_gradientType == GRADIENT_SPIRAL) {
+                        float angle = atan(normalized.y - 0.5, normalized.x - 0.5) / (6.28318);
+                        base = fract(angle + u_gradientPhase);
+                    } else if (u_gradientType == GRADIENT_WAVE) {
+                        base = fract(normalized.x + sin((normalized.y + u_gradientPhase) * 6.28318) * 0.2 + u_gradientPhase);
+                    }
+                } else {
+                    base = fract(u_gradientPhase + geometryValue * 0.3 + normalized.x * 0.25);
+                }
+
+                return clamp01(base);
+            }
+
             // 4D rotation matrices
             mat4 rotateXW(float theta) {
                 float c = cos(theta);
@@ -438,7 +549,14 @@ export class HolographicVisualizer {
                 // Enhanced holographic color processing
                 vec3 baseColor = u_color;
                 float latticeIntensity = lattice * u_intensity;
-                
+
+                if (u_paletteSize > 0) {
+                    float palettePosition = computePalettePosition(uv, lattice);
+                    vec3 paletteColor = samplePaletteColor(palettePosition);
+                    float blendStrength = (u_colorMode == COLOR_MODE_SINGLE) ? 0.65 : 1.0;
+                    baseColor = mix(baseColor, paletteColor, blendStrength);
+                }
+
                 // Multi-layer color composition for higher fidelity
                 vec3 color = baseColor * (0.2 + latticeIntensity * 0.8);
                 
@@ -520,7 +638,12 @@ export class HolographicVisualizer {
             audioColorShift: this.gl.getUniformLocation(this.program, 'u_audioColorShift'),
             rot4dXW: this.gl.getUniformLocation(this.program, 'u_rot4dXW'),
             rot4dYW: this.gl.getUniformLocation(this.program, 'u_rot4dYW'),
-            rot4dZW: this.gl.getUniformLocation(this.program, 'u_rot4dZW')
+            rot4dZW: this.gl.getUniformLocation(this.program, 'u_rot4dZW'),
+            colorMode: this.gl.getUniformLocation(this.program, 'u_colorMode'),
+            palette: this.gl.getUniformLocation(this.program, 'u_palette[0]'),
+            paletteSize: this.gl.getUniformLocation(this.program, 'u_paletteSize'),
+            gradientType: this.gl.getUniformLocation(this.program, 'u_gradientType'),
+            gradientPhase: this.gl.getUniformLocation(this.program, 'u_gradientPhase')
         };
     }
     
@@ -655,56 +778,152 @@ export class HolographicVisualizer {
         this.scrollVelocity += deltaY * 0.001;
         this.scrollVelocity = Math.max(-2.0, Math.min(2.0, this.scrollVelocity));
     }
-    
-    // Audio reactivity now handled directly in render() loop
-    updateAudio_DISABLED() {
-        return; // No longer used - audio handled in render()
-        
-        // Musical visualization approach - responsive but controlled
-        const smoothing = 0.6; // Less smoothing for more reactivity
-        
-        // Initialize if needed
-        if (!this.audioSmooth) {
-            this.audioSmooth = {
-                density: 0, morph: 0, speed: 0, chaos: 0, color: 0, beat: 0
-            };
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined' || !window.audioEnabled) {
+            return null;
         }
-        
-        // Speed: More responsive to rhythm and bass
-        const targetSpeed = audioData.rhythm > 0 ? audioData.rhythm * 0.8 : 
-                           audioData.bass > 0.3 ? audioData.bass * 0.6 : 0;
-        this.audioSmooth.speed = this.audioSmooth.speed * smoothing + targetSpeed * (1 - smoothing);
-        this.audioSpeedBoost = this.audioSmooth.speed;
-        
-        // Density: More reactive to energy
-        const targetDensity = audioData.energy * 1.2 + audioData.bass * 0.8;
-        this.audioSmooth.density = this.audioSmooth.density * smoothing + targetDensity * (1 - smoothing);
-        this.audioDensityBoost = this.audioSmooth.density;
-        
-        // Morph: More flowing with melody and mid frequencies
-        const targetMorph = audioData.melody * 1.2 + audioData.mid * 0.8;
-        this.audioSmooth.morph = this.audioSmooth.morph * smoothing + targetMorph * (1 - smoothing);
-        this.audioMorphBoost = this.audioSmooth.morph;
-        
-        // Chaos: More responsive to bass and high frequencies
-        const targetChaos = audioData.bass > 0.4 ? audioData.bass * 0.8 : 
-                           audioData.high > 0.6 ? audioData.high * 0.6 : 0;
-        this.audioSmooth.chaos = this.audioSmooth.chaos * smoothing + targetChaos * (1 - smoothing);
-        this.audioChaosBoost = this.audioSmooth.chaos;
-        
-        // Color: More dynamic color shifting
-        const targetColor = (audioData.melody + audioData.high + audioData.mid) * 0.6;
-        this.audioSmooth.color = this.audioSmooth.color * smoothing + targetColor * (1 - smoothing);
-        this.audioColorShift = this.audioSmooth.color * Math.PI;
-        
-        // Beat detection creates sharp visual pulses
-        if (audioData.rhythm > 0.5) { // Lower threshold for beat detection
-            this.clickIntensity = Math.max(this.clickIntensity, 1.0);
-            this.audioSmooth.beat = 1.0;
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels() || null;
         }
-        this.audioSmooth.beat *= 0.8; // Faster beat decay for more responsive pulses
+
+        return window.audioReactive || null;
     }
-    
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    prepareColorUniforms(colorState) {
+        const buffer = this.colorUniformBuffer;
+        buffer.fill(0);
+
+        let paletteSize = 0;
+        if (colorState?.uniforms?.palette && Array.isArray(colorState.uniforms.palette)) {
+            const palette = colorState.uniforms.palette;
+            paletteSize = Math.min(palette.length, 4);
+            for (let i = 0; i < paletteSize; i += 1) {
+                const color = palette[i] || [0, 0, 0];
+                const offset = i * 3;
+                buffer[offset] = color[0] ?? 0;
+                buffer[offset + 1] = color[1] ?? 0;
+                buffer[offset + 2] = color[2] ?? 0;
+            }
+        }
+
+        const gradientTypeKey = colorState?.gradient?.type || 'horizontal';
+        const gradientType = GRADIENT_TYPE_MAP[gradientTypeKey] ?? GRADIENT_TYPE_MAP.horizontal;
+        const gradientPhase = typeof colorState?.gradient?.phase === 'number'
+            ? colorState.gradient.phase
+            : 0;
+        const modeKey = colorState?.mode || 'single';
+        const mode = COLOR_MODE_MAP[modeKey] ?? COLOR_MODE_MAP.single;
+
+        this.colorUniformState.mode = mode;
+        this.colorUniformState.paletteSize = paletteSize;
+        this.colorUniformState.gradientType = gradientType;
+        this.colorUniformState.gradientPhase = gradientPhase;
+
+        return this.colorUniformState;
+    }
+
+    applyColorUniforms(uniformState) {
+        if (!this.gl || !this.uniforms) {
+            return;
+        }
+
+        if (this.uniforms.colorMode) {
+            this.gl.uniform1i(this.uniforms.colorMode, uniformState.mode);
+        }
+        if (this.uniforms.palette) {
+            this.gl.uniform3fv(this.uniforms.palette, this.colorUniformBuffer);
+        }
+        if (this.uniforms.paletteSize) {
+            this.gl.uniform1i(this.uniforms.paletteSize, uniformState.paletteSize);
+        }
+        if (this.uniforms.gradientType) {
+            this.gl.uniform1i(this.uniforms.gradientType, uniformState.gradientType);
+        }
+        if (this.uniforms.gradientPhase) {
+            this.gl.uniform1f(this.uniforms.gradientPhase, uniformState.gradientPhase);
+        }
+    }
+
+    updateAudioResponse(audioState) {
+        const smoothing = 0.2;
+        const target = {
+            density: 0,
+            morph: 0,
+            speed: 0,
+            chaos: 0,
+            colorShift: 0,
+            intensity: 0,
+            rot4dXW: 0,
+            rot4dYW: 0,
+            rot4dZW: 0
+        };
+
+        this.onsetPulse = (this.onsetPulse || 0) * 0.82;
+
+        if (audioState) {
+            const bass = clamp(audioState.bass ?? 0, 0, 1);
+            const mid = clamp(audioState.mid ?? 0, 0, 1);
+            const high = clamp(audioState.high ?? 0, 0, 1);
+            const sparkle = clamp(audioState.sparkle ?? audioState.bands?.air ?? 0, 0, 1);
+            const energy = clamp(audioState.energy ?? audioState.rms ?? 0, 0, 1);
+            const motion = clamp(audioState.motion ?? audioState.spectralFlux ?? 0, 0, 1);
+            const centroid = clamp(audioState.hueShift ?? audioState.spectralCentroid ?? 0, 0, 1);
+            const intensityBoost = clamp(audioState.intensity ?? audioState.rms ?? 0, 0, 1);
+
+            if (audioState.onset) {
+                this.onsetPulse = 1;
+                this.clickIntensity = Math.min(1.0, this.clickIntensity + 0.35);
+            }
+
+            target.density = clamp((bass * 1.8) + (energy * 0.6), 0, 2.5);
+            target.morph = clamp((mid * 1.4) + (motion * 0.8), 0, 2.2);
+            target.speed = clamp((high * 1.1) + (energy * 0.5), 0, 2.8);
+            target.chaos = clamp((motion * 0.7) + (sparkle * 0.4) + (energy * 0.3), 0, 2.4);
+            target.colorShift = clamp((centroid * 240) + (sparkle * 90), 0, 360);
+            target.intensity = clamp((intensityBoost * 0.7) + (energy * 0.4), 0, 1.5);
+            target.rot4dXW = clamp(bass * 0.5, 0, 1.6);
+            target.rot4dYW = clamp(mid * 0.35, 0, 1.4);
+            target.rot4dZW = clamp(high * 0.3, 0, 1.2);
+        }
+
+        target.speed += this.onsetPulse * 1.1;
+
+        this.audioResponse.density = lerp(this.audioResponse.density, target.density, smoothing);
+        this.audioResponse.morph = lerp(this.audioResponse.morph, target.morph, smoothing);
+        this.audioResponse.speed = lerp(this.audioResponse.speed, target.speed, smoothing);
+        this.audioResponse.chaos = lerp(this.audioResponse.chaos, target.chaos, smoothing);
+        this.audioResponse.colorShift = lerp(this.audioResponse.colorShift, target.colorShift, smoothing);
+        this.audioResponse.intensity = lerp(this.audioResponse.intensity, target.intensity, smoothing);
+        this.audioResponse.rot4dXW = lerp(this.audioResponse.rot4dXW, target.rot4dXW, smoothing);
+        this.audioResponse.rot4dYW = lerp(this.audioResponse.rot4dYW, target.rot4dYW, smoothing);
+        this.audioResponse.rot4dZW = lerp(this.audioResponse.rot4dZW, target.rot4dZW, smoothing);
+
+        this.audioDensityBoost = this.audioResponse.density;
+        this.audioMorphBoost = this.audioResponse.morph;
+        this.audioSpeedBoost = this.audioResponse.speed;
+        this.audioChaosBoost = this.audioResponse.chaos;
+        this.audioColorShift = this.audioResponse.colorShift;
+
+        return this.audioResponse;
+    }
+
     updateScrollPhysics() {
         this.scrollPosition += this.scrollVelocity;
         this.scrollVelocity *= this.scrollDecay;
@@ -718,17 +937,35 @@ export class HolographicVisualizer {
         
         this.resize();
         this.gl.useProgram(this.program);
-        
+
         this.densityVariation += (this.densityTarget - this.densityVariation) * 0.05;
         this.clickIntensity *= this.clickDecay;
         this.updateScrollPhysics();
-        
+
         const time = Date.now() - this.startTime;
-        
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+        const colorUniforms = this.prepareColorUniforms(colorState);
+
         // Convert HSL to RGB for color uniform
-        const hue = (this.variantParams.hue || 0) / 360; // Convert to 0-1 range
-        const saturation = this.variantParams.saturation || 0.8;
-        const lightness = Math.max(0.2, Math.min(0.8, this.variantParams.intensity || 0.5)); // Use intensity for lightness
+        let hueDegrees = this.variantParams.hue || 0;
+        let saturation = this.variantParams.saturation ?? 0.8;
+        let lightness = Math.max(0.2, Math.min(0.8, this.variantParams.intensity || 0.5));
+
+        if (colorState?.primary) {
+            hueDegrees = colorState.primary.h;
+            saturation = Math.max(saturation, colorState.primary.s);
+            lightness = Math.min(0.85, Math.max(0.2, colorState.primary.v * 0.8 + 0.15));
+        }
+
+        if (colorState?.accent && colorState.accent !== colorState.primary) {
+            saturation = Math.max(saturation, colorState.accent.s * 0.85);
+        }
+
+        const hue = (hueDegrees % 360) / 360;
+        saturation = clamp(saturation, 0, 1);
+        lightness = clamp(lightness, 0, 1);
         
         // HSL to RGB conversion
         const hslToRgb = (h, s, l) => {
@@ -763,55 +1000,60 @@ export class HolographicVisualizer {
         this.gl.uniform1f(this.uniforms.density, this.variantParams.density || 1.0);
         // FIX: Controlled speed calculation - base speed controls main movement, audio provides subtle boost
         const baseSpeed = (this.variantParams.speed || 0.5) * 0.2; // Much slower base speed
-        const audioBoost = (this.audioSpeedBoost || 0.0) * 0.1; // Subtle audio boost only
+        const audioBoost = (audioResponse.speed || 0.0) * 0.12; // Subtle audio boost only
         this.gl.uniform1f(this.uniforms.speed, baseSpeed + audioBoost);
         this.gl.uniform3fv(this.uniforms.color, new Float32Array(rgbColor));
-        this.gl.uniform1f(this.uniforms.intensity, (this.variantParams.intensity || 0.5) * this.roleParams.intensity);
+        const baseIntensity = (this.variantParams.intensity || 0.5) * this.roleParams.intensity;
+        const colorIntensityBoost = colorState?.primary ? colorState.primary.v * 0.8 : 0;
+        const reactiveIntensity = clamp(baseIntensity * (1 + audioResponse.intensity) + colorIntensityBoost, 0, 3);
+        this.gl.uniform1f(this.uniforms.intensity, reactiveIntensity);
         this.gl.uniform1f(this.uniforms.roleDensity, this.roleParams.densityMult);
         this.gl.uniform1f(this.uniforms.roleSpeed, this.roleParams.speedMult);
-        this.gl.uniform1f(this.uniforms.colorShift, this.roleParams.colorShift + (this.variantParams.hue || 0) / 360);
-        this.gl.uniform1f(this.uniforms.chaosIntensity, this.variantParams.chaos || 0.0);
+        const baseColorShiftDegrees = (this.roleParams.colorShift || 0) + hueDegrees;
+        const gradientShift = colorState?.gradient ? colorState.gradient.phase * 180 : 0;
+        const totalColorShift = (baseColorShiftDegrees + (audioResponse.colorShift || 0) + gradientShift) % 360;
+        this.gl.uniform1f(this.uniforms.colorShift, totalColorShift / 360);
+        const chaosReactive = clamp((this.variantParams.chaos || 0.0) + audioResponse.chaos * 0.6, 0, 3);
+        this.gl.uniform1f(this.uniforms.chaosIntensity, chaosReactive);
         this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
         this.gl.uniform1f(this.uniforms.clickIntensity, this.clickIntensity);
         this.gl.uniform1f(this.uniforms.densityVariation, this.densityVariation);
         this.gl.uniform1f(this.uniforms.geometryType, this.variantParams.geometryType !== undefined ? this.variantParams.geometryType : this.variant || 0);
-        this.gl.uniform1f(this.uniforms.chaos, this.variantParams.chaos || 0.0);
+        this.gl.uniform1f(this.uniforms.chaos, chaosReactive);
         this.gl.uniform1f(this.uniforms.morph, this.variantParams.morph || 0.0);
-        
+
         // Touch and scroll uniforms
         this.gl.uniform1f(this.uniforms.touchMorph, this.touchMorph);
         this.gl.uniform1f(this.uniforms.touchChaos, this.touchChaos);
         this.gl.uniform1f(this.uniforms.scrollParallax, this.parallaxDepth);
         this.gl.uniform1f(this.uniforms.gridDensityShift, this.gridDensityShift);
         this.gl.uniform1f(this.uniforms.colorScrollShift, this.colorScrollShift);
-        
-        // 🎵 HOLOGRAPHIC AUDIO REACTIVITY - Direct and beautiful
-        let audioDensity = 0, audioMorph = 0, audioSpeed = 0, audioChaos = 0, audioColor = 0;
-        
-        if (window.audioEnabled && window.audioReactive) {
-            // Holographic audio mapping: Rich volumetric effects
-            audioDensity = window.audioReactive.bass * 1.5;     // Bass creates density in holographic layers
-            audioMorph = window.audioReactive.mid * 1.2;        // Mid frequencies morph the hologram
-            audioSpeed = window.audioReactive.high * 0.8;       // High frequencies speed up animation
-            audioChaos = window.audioReactive.energy * 0.6;     // Energy creates chaotic holographic distortion
-            audioColor = window.audioReactive.bass * 45;        // Bass affects holographic color shifts
-            
-            // Debug logging every 10 seconds to verify holographic audio reactivity
-            if (Date.now() % 10000 < 16) {
-                console.log(`✨ Holographic audio reactivity: Density+${audioDensity.toFixed(2)} Morph+${audioMorph.toFixed(2)} Speed+${audioSpeed.toFixed(2)} Chaos+${audioChaos.toFixed(2)} Color+${audioColor.toFixed(1)}`);
-            }
+
+        this.applyColorUniforms(colorUniforms);
+
+        // 🎵 HOLOGRAPHIC AUDIO REACTIVITY - powered by advanced analyzer
+        const audioDensity = audioResponse.density || 0;
+        const audioMorph = audioResponse.morph || 0;
+        const audioSpeed = audioResponse.speed || 0;
+        const audioChaos = audioResponse.chaos || 0;
+        const audioColor = audioResponse.colorShift || 0;
+
+        if (audioState && Date.now() % 10000 < 16) {
+            console.log(
+                `✨ Holographic audio reactivity: Density+${audioDensity.toFixed(2)} Morph+${audioMorph.toFixed(2)} Speed+${audioSpeed.toFixed(2)} Chaos+${audioChaos.toFixed(2)} Color+${audioColor.toFixed(1)}`
+            );
         }
-        
+
         this.gl.uniform1f(this.uniforms.audioDensityBoost, audioDensity);
         this.gl.uniform1f(this.uniforms.audioMorphBoost, audioMorph);
         this.gl.uniform1f(this.uniforms.audioSpeedBoost, audioSpeed);
         this.gl.uniform1f(this.uniforms.audioChaosBoost, audioChaos);
         this.gl.uniform1f(this.uniforms.audioColorShift, audioColor);
-        
+
         // 4D rotation uniforms
-        this.gl.uniform1f(this.uniforms.rot4dXW, this.variantParams.rot4dXW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dYW, this.variantParams.rot4dYW || 0.0);
-        this.gl.uniform1f(this.uniforms.rot4dZW, this.variantParams.rot4dZW || 0.0);
+        this.gl.uniform1f(this.uniforms.rot4dXW, (this.variantParams.rot4dXW || 0.0) + audioResponse.rot4dXW);
+        this.gl.uniform1f(this.uniforms.rot4dYW, (this.variantParams.rot4dYW || 0.0) + audioResponse.rot4dYW);
+        this.gl.uniform1f(this.uniforms.rot4dZW, (this.variantParams.rot4dZW || 0.0) + audioResponse.rot4dZW);
         
         this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
     }

--- a/src/polychora/PolychoraEngine.js
+++ b/src/polychora/PolychoraEngine.js
@@ -1,0 +1,157 @@
+import { ParameterManager } from '../core/Parameters.js';
+import { PolychoraVisualizer } from './PolychoraVisualizer.js';
+
+const LAYERS = [
+    { id: 'polychora-background-canvas', role: 'background' },
+    { id: 'polychora-shadow-canvas', role: 'shadow' },
+    { id: 'polychora-content-canvas', role: 'content' },
+    { id: 'polychora-highlight-canvas', role: 'highlight' },
+    { id: 'polychora-accent-canvas', role: 'accent' }
+];
+
+export class PolychoraEngine {
+    constructor() {
+        this.parameterManager = new ParameterManager();
+        this.parameters = this.parameterManager; // Legacy compatibility
+        this.visualizers = [];
+        this.isActive = false;
+        this.animationId = null;
+        this.clickPulse = 0;
+        this.audioSettings = {
+            bassToRotation: 2.0,
+            midToMorph: 1.2,
+            highToColor: 1.0
+        };
+
+        this.createVisualizers();
+        this.applyParametersToVisualizers();
+    }
+
+    createVisualizers() {
+        this.visualizers = [];
+        const params = this.parameterManager.getAllParameters();
+
+        LAYERS.forEach(layer => {
+            const visualizer = new PolychoraVisualizer(layer.id, layer.role, 1.0);
+            if (visualizer && visualizer.gl) {
+                visualizer.updateParameters(params);
+                this.visualizers.push(visualizer);
+            }
+        });
+    }
+
+    applyParametersToVisualizers() {
+        const snapshot = this.parameterManager.getAllParameters();
+        this.visualizers.forEach(visualizer => visualizer.updateParameters(snapshot));
+    }
+
+    startRenderLoop() {
+        if (this.animationId) {
+            cancelAnimationFrame(this.animationId);
+            this.animationId = null;
+        }
+
+        const render = () => {
+            if (!this.isActive) {
+                this.animationId = null;
+                return;
+            }
+
+            if (this.clickPulse > 0.001) {
+                const boost = this.clickPulse * 0.2;
+                const baseIntensity = this.parameterManager.getParameter('intensity') ?? 0.7;
+                const boosted = Math.min(1.5, baseIntensity + boost);
+                this.visualizers.forEach(visualizer => {
+                    visualizer.updateParameters({ intensity: boosted });
+                });
+                this.clickPulse *= 0.92;
+                if (this.clickPulse < 0.001) {
+                    this.applyParametersToVisualizers();
+                }
+            }
+
+            this.visualizers.forEach(visualizer => visualizer.render());
+            this.animationId = requestAnimationFrame(render);
+        };
+
+        this.animationId = requestAnimationFrame(render);
+    }
+
+    stopRenderLoop() {
+        if (this.animationId) {
+            cancelAnimationFrame(this.animationId);
+            this.animationId = null;
+        }
+    }
+
+    setActive(active) {
+        if (this.isActive === active) {
+            return;
+        }
+
+        this.isActive = active;
+        if (active) {
+            this.applyParametersToVisualizers();
+            this.startRenderLoop();
+        } else {
+            this.stopRenderLoop();
+        }
+    }
+
+    updateParameter(name, value) {
+        const result = this.parameterManager.setParameter(name, value);
+        if (result !== false) {
+            this.applyParametersToVisualizers();
+        }
+        return result;
+    }
+
+    updateParameters(params = {}) {
+        Object.entries(params).forEach(([key, value]) => {
+            this.parameterManager.setParameter(key, value);
+        });
+        this.applyParametersToVisualizers();
+    }
+
+    getParameters() {
+        return this.parameterManager.getAllParameters();
+    }
+
+    setParameters(params = {}) {
+        if (!params) return;
+        this.parameterManager.loadParameters?.(params);
+        Object.entries(params).forEach(([key, value]) => {
+            this.parameterManager.setParameter(key, value);
+        });
+        this.applyParametersToVisualizers();
+    }
+
+    triggerClick(strength = 1) {
+        this.clickPulse = Math.min(1.5, this.clickPulse + Math.max(0, strength));
+    }
+
+    updateAudioReactivity(settings = {}) {
+        if (settings && typeof settings === 'object') {
+            this.audioSettings = { ...this.audioSettings, ...settings };
+        }
+        return this.audioSettings;
+    }
+
+    start() {
+        this.setActive(true);
+    }
+
+    stop() {
+        this.setActive(false);
+    }
+
+    getParameter(name) {
+        return this.parameterManager.getParameter(name);
+    }
+
+    destroy() {
+        this.stopRenderLoop();
+        this.visualizers.forEach(visualizer => visualizer.cleanup());
+        this.visualizers = [];
+    }
+}

--- a/src/polychora/PolychoraVisualizer.js
+++ b/src/polychora/PolychoraVisualizer.js
@@ -1,0 +1,500 @@
+import { GeometryLibrary } from '../geometry/GeometryLibrary.js';
+
+const COLOR_MODE_MAP = Object.freeze({
+    single: 0,
+    dual: 1,
+    triad: 2,
+    complementary: 3,
+    analogous: 4,
+    palette: 5,
+    gradient: 6,
+    reactive: 7
+});
+
+const GRADIENT_TYPE_MAP = Object.freeze({
+    horizontal: 0,
+    vertical: 1,
+    radial: 2,
+    spiral: 3,
+    wave: 4
+});
+
+const ROLE_CONFIG = Object.freeze({
+    background: { intensity: 0.18, scale: 1.15, color: [0.08, 0.05, 0.16] },
+    shadow: { intensity: 0.32, scale: 1.08, color: [0.04, 0.05, 0.12] },
+    content: { intensity: 0.95, scale: 1.0, color: [0.42, 0.25, 0.72] },
+    highlight: { intensity: 0.72, scale: 0.94, color: [0.86, 0.65, 1.0] },
+    accent: { intensity: 0.55, scale: 0.88, color: [0.35, 0.78, 0.92] }
+});
+
+const DEFAULT_PARAMS = Object.freeze({
+    geometry: 1,
+    rot4dXW: 0,
+    rot4dYW: 0,
+    rot4dZW: 0,
+    gridDensity: 18,
+    morphFactor: 1.0,
+    chaos: 0.15,
+    speed: 1.0,
+    hue: 280,
+    intensity: 0.75,
+    saturation: 0.85,
+    colorMode: 'single',
+    colorPalette: 'holographic',
+    gradientType: 'horizontal',
+    gradientSpeed: 0.3,
+    colorReactivity: 0.65
+});
+
+export class PolychoraVisualizer {
+    constructor(canvasId, role = 'content', reactivity = 1.0) {
+        this.canvas = typeof document !== 'undefined' ? document.getElementById(canvasId) : null;
+        if (!this.canvas) {
+            console.warn(`[PolychoraVisualizer] Canvas not found: ${canvasId}`);
+            return;
+        }
+
+        this.role = role;
+        this.reactivity = reactivity;
+        this.contextOptions = {
+            alpha: true,
+            depth: false,
+            stencil: false,
+            antialias: false,
+            premultipliedAlpha: true,
+            preserveDrawingBuffer: false,
+            powerPreference: 'high-performance'
+        };
+
+        const roleConfig = ROLE_CONFIG[role] || ROLE_CONFIG.content;
+        this.layerIntensity = roleConfig.intensity;
+        this.layerScale = roleConfig.scale;
+        this.layerColor = roleConfig.color.slice();
+
+        this.params = { ...DEFAULT_PARAMS };
+        this.audioResponse = { bass: 0, mid: 0, high: 0, energy: 0 };
+        this.audioSmoothing = 0.18;
+
+        this.colorUniformBuffer = new Float32Array(12);
+        this.colorUniformState = {
+            mode: COLOR_MODE_MAP.single,
+            paletteSize: 0,
+            gradientType: GRADIENT_TYPE_MAP.horizontal,
+            gradientPhase: 0
+        };
+
+        this.time = 0;
+        this.startTime = Date.now();
+        this.handleResize = this.resize.bind(this);
+
+        this.initContext();
+        if (!this.gl) {
+            return;
+        }
+
+        if (!this.initShaders()) {
+            console.error('[PolychoraVisualizer] Failed to initialize shaders');
+            this.disposeContext();
+            return;
+        }
+
+        this.initBuffers();
+        this.cacheUniformLocations();
+        this.resize();
+
+        window.addEventListener('resize', this.handleResize);
+        GeometryLibrary.subscribe(() => {
+            if (this.params.geometry >= GeometryLibrary.getGeometryNames().length) {
+                this.params.geometry = Math.max(0, GeometryLibrary.getGeometryNames().length - 1);
+            }
+        });
+    }
+
+    initContext() {
+        this.gl = this.canvas.getContext('webgl2', this.contextOptions) ||
+                  this.canvas.getContext('webgl', this.contextOptions) ||
+                  this.canvas.getContext('experimental-webgl', this.contextOptions);
+
+        if (!this.gl) {
+            console.error('[PolychoraVisualizer] WebGL not supported');
+        }
+    }
+
+    disposeContext() {
+        this.gl = null;
+    }
+
+    initShaders() {
+        const vertexShaderSource = `attribute vec2 a_position;\nvarying vec2 v_uv;\n\nvoid main() {\n    v_uv = a_position * 0.5 + 0.5;\n    gl_Position = vec4(a_position, 0.0, 1.0);\n}`;
+
+        const fragmentShaderSource = `#ifdef GL_FRAGMENT_PRECISION_HIGH\n    precision highp float;\n#else\n    precision mediump float;\n#endif\n\nvarying vec2 v_uv;\n\nuniform float u_time;\nuniform vec2 u_resolution;\nuniform float u_geometry;\nuniform float u_rot4dXW;\nuniform float u_rot4dYW;\nuniform float u_rot4dZW;\nuniform float u_gridDensity;\nuniform float u_morphFactor;\nuniform float u_chaos;\nuniform float u_speed;\nuniform float u_hue;\nuniform float u_intensity;\nuniform float u_saturation;\nuniform float u_layerIntensity;\nuniform float u_layerScale;\nuniform vec3 u_layerColor;\nuniform float u_colorReactivity;\nuniform int u_colorMode;\nuniform int u_paletteSize;\nuniform vec3 u_palette[4];\nuniform int u_gradientType;\nuniform float u_gradientPhase;\nuniform float u_bass;\nuniform float u_mid;\nuniform float u_high;\n\nconst int COLOR_MODE_SINGLE = 0;\nconst int COLOR_MODE_DUAL = 1;\nconst int COLOR_MODE_TRIAD = 2;\nconst int COLOR_MODE_COMPLEMENTARY = 3;\nconst int COLOR_MODE_ANALOGOUS = 4;\nconst int COLOR_MODE_PALETTE = 5;\nconst int COLOR_MODE_GRADIENT = 6;\nconst int COLOR_MODE_REACTIVE = 7;\n\nconst int GRADIENT_HORIZONTAL = 0;\nconst int GRADIENT_VERTICAL = 1;\nconst int GRADIENT_RADIAL = 2;\nconst int GRADIENT_SPIRAL = 3;\nconst int GRADIENT_WAVE = 4;\n\nfloat clamp01(float value) {\n    return clamp(value, 0.0, 1.0);\n}\n\nmat4 rotateXW(float angle) {\n    float c = cos(angle);\n    float s = sin(angle);\n    return mat4(\n        c, 0.0, 0.0, -s,\n        0.0, 1.0, 0.0, 0.0,\n        0.0, 0.0, 1.0, 0.0,\n        s, 0.0, 0.0, c\n    );\n}\n\nmat4 rotateYW(float angle) {\n    float c = cos(angle);\n    float s = sin(angle);\n    return mat4(\n        1.0, 0.0, 0.0, 0.0,\n        0.0, c, 0.0, -s,\n        0.0, 0.0, 1.0, 0.0,\n        0.0, s, 0.0, c\n    );\n}\n\nmat4 rotateZW(float angle) {\n    float c = cos(angle);\n    float s = sin(angle);\n    return mat4(\n        1.0, 0.0, 0.0, 0.0,\n        0.0, 1.0, 0.0, 0.0,\n        0.0, 0.0, c, -s,\n        0.0, 0.0, s, c\n    );\n}\n\nfloat hash(vec4 p) {\n    vec4 h = vec4(37.0, 57.0, 113.0, 147.0);\n    return fract(sin(dot(p, h)) * 43758.5453);\n}\n\nvec3 hsv2rgb(vec3 c) {\n    vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);\n    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);\n    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);\n}\n\nvec3 samplePaletteColor(float position) {\n    if (u_paletteSize <= 0) {\n        return vec3(1.0);\n    }\n\n    if (u_paletteSize == 1) {\n        return u_palette[0];\n    }\n\n    float clamped = clamp(position, 0.0, 0.9999);\n    float scaled = clamped * float(u_paletteSize - 1);\n    int index = int(floor(scaled));\n    int nextIndex = min(index + 1, u_paletteSize - 1);\n    float mixAmount = fract(scaled);\n    vec3 a = u_palette[index];\n    vec3 b = u_palette[nextIndex];\n    return mix(a, b, mixAmount);\n}\n\nfloat computePalettePosition(vec2 uv, float geometryValue) {\n    vec2 normalized = uv * 0.5 + 0.5;\n    float base = fract(u_gradientPhase + geometryValue * 0.25);\n\n    if (u_colorMode == COLOR_MODE_GRADIENT) {\n        if (u_gradientType == GRADIENT_HORIZONTAL) {\n            base = clamp01(normalized.x);\n        } else if (u_gradientType == GRADIENT_VERTICAL) {\n            base = clamp01(normalized.y);\n        } else if (u_gradientType == GRADIENT_RADIAL) {\n            float dist = length(normalized - 0.5);\n            base = clamp(dist * 1.4142, 0.0, 1.0);\n        } else if (u_gradientType == GRADIENT_SPIRAL) {\n            float angle = atan(normalized.y - 0.5, normalized.x - 0.5) / (6.28318);\n            base = fract(angle + u_gradientPhase);\n        } else if (u_gradientType == GRADIENT_WAVE) {\n            base = fract(normalized.x + sin((normalized.y + u_gradientPhase) * 6.28318) * 0.2 + u_gradientPhase);\n        }\n    } else {\n        base = fract(u_gradientPhase + geometryValue * 0.3 + normalized.x * 0.25);\n    }\n\n    return clamp01(base);\n}\n\nfloat polytope5Cell(vec4 p) {\n    vec4 corners[5];\n    corners[0] = vec4(1, 1, 1, -1) / sqrt(4.0);\n    corners[1] = vec4(1, -1, -1, -1) / sqrt(4.0);\n    corners[2] = vec4(-1, 1, -1, -1) / sqrt(4.0);\n    corners[3] = vec4(-1, -1, 1, -1) / sqrt(4.0);\n    corners[4] = vec4(0, 0, 0, 1);\n\n    float dist = 1e9;\n    for (int i = 0; i < 5; i++) {\n        float d = length(p - corners[i]);\n        dist = min(dist, d);\n    }\n    return dist - 0.8;\n}\n\nfloat polytopeTesseract(vec4 p) {\n    vec4 q = abs(p);\n    return max(max(q.x, max(q.y, max(q.z, q.w))) - 1.0, 0.0);\n}\n\nfloat polytope16Cell(vec4 p) {\n    return (abs(p.x) + abs(p.y) + abs(p.z) + abs(p.w)) - 1.5;\n}\n\nfloat polytope24Cell(vec4 p) {\n    vec4 q = abs(p);\n    float max1 = max(q.x, max(q.y, q.z));\n    float min1 = min(q.x, min(q.y, q.z));\n    float s = q.x + q.y + q.z + q.w;\n    return max(max1 + q.w - 1.3, s * 0.5 - 1.5);\n}\n\nfloat polytope600Cell(vec4 p) {\n    vec4 q = abs(p);\n    float sum = q.x + q.y + q.z + q.w;\n    return sum * 0.57735 - 1.2;\n}\n\nfloat polytope120Cell(vec4 p) {\n    float phi = 1.618033988749895;\n    vec4 q = abs(p);\n    float d1 = length(q) - 2.0;\n    float d2 = max(max(max(q.x/phi, q.y*phi), q.z/phi), q.w*phi) - 1.5;\n    return max(d1, d2);\n}\n\nfloat polytopeHypersphere(vec4 p) {\n    return length(p) - 1.5;\n}\n\nfloat polytopeDuocylinder(vec4 p) {\n    float r1 = length(p.xy) - 1.0;\n    float r2 = length(p.zw) - 1.0;\n    return sqrt(r1*r1 + r2*r2) - 0.5;\n}\n\nfloat true4DGeometryFunction(vec4 p) {\n    int geomType = int(u_geometry);\n    float gridSize = max(0.0001, u_gridDensity * 0.1);\n\n    mat4 rotation = rotateXW(u_rot4dXW) * rotateYW(u_rot4dYW) * rotateZW(u_rot4dZW);\n    vec4 rotatedP = rotation * p;\n    vec4 tiledP = fract(rotatedP * gridSize) - 0.5;\n\n    float dist = 0.0;\n    if (geomType == 0) {\n        dist = polytope5Cell(tiledP);\n    } else if (geomType == 1) {\n        dist = polytopeTesseract(tiledP);\n    } else if (geomType == 2) {\n        dist = polytopeHypersphere(tiledP);\n    } else if (geomType == 3) {\n        dist = polytopeDuocylinder(tiledP);\n    } else if (geomType == 4) {\n        dist = polytope16Cell(tiledP);\n    } else if (geomType == 5) {\n        dist = polytope24Cell(tiledP);\n    } else if (geomType == 6) {\n        dist = polytope600Cell(tiledP);\n    } else {\n        dist = polytope120Cell(tiledP);\n    }\n\n    dist *= u_morphFactor;\n    if (u_chaos > 0.0) {\n        float noise = hash(rotatedP * 7.3);\n        dist += (noise - 0.5) * u_chaos * 0.3;\n    }\n\n    return dist;\n}\n\nvec3 applyColorMode(vec3 baseColor, vec3 paletteColor, float paletteStrength, vec3 reactiveColor) {\n    if (u_colorMode == COLOR_MODE_REACTIVE) {\n        return mix(baseColor, reactiveColor, clamp01(paletteStrength));\n    }\n\n    if (u_paletteSize <= 0) {\n        return baseColor;\n    }\n\n    float blend = 0.6 + paletteStrength * 0.4;\n    if (u_colorMode == COLOR_MODE_SINGLE) {\n        return mix(baseColor, paletteColor, blend * 0.6);\n    }\n    if (u_colorMode == COLOR_MODE_PALETTE || u_colorMode == COLOR_MODE_GRADIENT) {\n        return mix(baseColor, paletteColor, blend);\n    }\n    if (u_colorMode == COLOR_MODE_DUAL || u_colorMode == COLOR_MODE_COMPLEMENTARY) {\n        vec3 complementary = vec3(paletteColor.b, paletteColor.r, paletteColor.g);
+        return mix(baseColor, mix(paletteColor, complementary, 0.5), blend);
+    }
+    if (u_colorMode == COLOR_MODE_TRIAD) {
+        vec3 triadA = vec3(paletteColor.g, paletteColor.b, paletteColor.r);
+        vec3 triadB = vec3(paletteColor.b, paletteColor.r, paletteColor.g);
+        vec3 triad = (paletteColor + triadA + triadB) / 3.0;
+        return mix(baseColor, triad, blend);
+    }
+    if (u_colorMode == COLOR_MODE_ANALOGOUS) {
+        vec3 shifted = paletteColor * vec3(1.1, 0.95, 1.05);
+        return mix(baseColor, shifted, blend * 0.8);
+    }
+
+    return mix(baseColor, paletteColor, blend);
+}
+
+void main() {
+    vec2 uv = (gl_FragCoord.xy - u_resolution.xy * 0.5) / min(u_resolution.x, u_resolution.y);
+    float time = u_time * 0.001 * max(0.1, u_speed);
+
+    vec4 rayDir = vec4(uv * u_layerScale, sin(time * 0.5), cos(time * 0.3));
+    vec4 audioOffset = vec4(u_bass * 0.35, u_mid * 0.25, u_high * 0.2, (u_bass + u_high) * 0.15);
+    rayDir += audioOffset;
+
+    float dist = true4DGeometryFunction(rayDir);
+
+    float alpha = 0.0;
+    if (dist < 0.08) {
+        alpha = 1.0 - (dist / 0.08);
+        alpha = pow(alpha, 2.0);
+    } else {
+        alpha = exp(-dist * 6.5) * 0.35;
+    }
+
+    alpha *= u_layerIntensity * u_intensity;
+
+    float hue = u_hue / 360.0;
+    vec3 baseColor = hsv2rgb(vec3(hue, u_saturation, 1.0));
+    baseColor = mix(baseColor, u_layerColor, 0.3);
+
+    vec3 reactiveColor = clamp(vec3(
+        baseColor.r + u_high * 0.8,
+        baseColor.g + u_mid * 0.6,
+        baseColor.b + u_bass * 0.7
+    ), 0.0, 1.5);
+
+    float palettePos = computePalettePosition(uv, u_geometry);
+    vec3 paletteColor = samplePaletteColor(palettePos);
+
+    float paletteStrength = float(u_paletteSize > 0) * clamp01(0.35 + u_colorReactivity * 0.65);
+    vec3 finalColor = applyColorMode(baseColor, paletteColor, paletteStrength, reactiveColor);
+
+    gl_FragColor = vec4(finalColor, clamp(alpha, 0.0, 1.0));
+}
+`;
+
+        this.vertexShader = this.compileShader(this.gl.VERTEX_SHADER, vertexShaderSource);
+        this.fragmentShader = this.compileShader(this.gl.FRAGMENT_SHADER, fragmentShaderSource);
+
+        if (!this.vertexShader || !this.fragmentShader) {
+            return false;
+        }
+
+        this.program = this.gl.createProgram();
+        this.gl.attachShader(this.program, this.vertexShader);
+        this.gl.attachShader(this.program, this.fragmentShader);
+        this.gl.linkProgram(this.program);
+
+        if (!this.gl.getProgramParameter(this.program, this.gl.LINK_STATUS)) {
+            console.error('[PolychoraVisualizer] Shader link error:', this.gl.getProgramInfoLog(this.program));
+            return false;
+        }
+
+        this.gl.useProgram(this.program);
+
+        const positionBuffer = this.gl.createBuffer();
+        this.vertexBuffer = positionBuffer;
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, positionBuffer);
+        const vertices = new Float32Array([
+            -1, -1,  1, -1,  -1,  1,
+            -1,  1,  1, -1,   1,  1
+        ]);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
+
+        const positionLocation = this.gl.getAttribLocation(this.program, 'a_position');
+        this.gl.enableVertexAttribArray(positionLocation);
+        this.gl.vertexAttribPointer(positionLocation, 2, this.gl.FLOAT, false, 0, 0);
+
+        return true;
+    }
+
+    compileShader(type, source) {
+        const shader = this.gl.createShader(type);
+        this.gl.shaderSource(shader, source);
+        this.gl.compileShader(shader);
+
+        if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
+            console.error('[PolychoraVisualizer] Shader compile error:', this.gl.getShaderInfoLog(shader));
+            return null;
+        }
+
+        return shader;
+    }
+
+    initBuffers() {
+        if (!this.vertexBuffer) {
+            this.vertexBuffer = this.gl.createBuffer();
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+            const vertices = new Float32Array([
+                -1, -1,
+                 1, -1,
+                -1,  1,
+                -1,  1,
+                 1, -1,
+                 1,  1
+            ]);
+            this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
+            const positionLocation = this.gl.getAttribLocation(this.program, 'a_position');
+            this.gl.enableVertexAttribArray(positionLocation);
+            this.gl.vertexAttribPointer(positionLocation, 2, this.gl.FLOAT, false, 0, 0);
+        } else {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        }
+    }
+
+    cacheUniformLocations() {
+        const fetch = name => this.gl.getUniformLocation(this.program, name);
+        this.uniforms = {
+            time: fetch('u_time'),
+            resolution: fetch('u_resolution'),
+            geometry: fetch('u_geometry'),
+            rot4dXW: fetch('u_rot4dXW'),
+            rot4dYW: fetch('u_rot4dYW'),
+            rot4dZW: fetch('u_rot4dZW'),
+            gridDensity: fetch('u_gridDensity'),
+            morphFactor: fetch('u_morphFactor'),
+            chaos: fetch('u_chaos'),
+            speed: fetch('u_speed'),
+            hue: fetch('u_hue'),
+            intensity: fetch('u_intensity'),
+            saturation: fetch('u_saturation'),
+            layerIntensity: fetch('u_layerIntensity'),
+            layerScale: fetch('u_layerScale'),
+            layerColor: fetch('u_layerColor'),
+            colorMode: fetch('u_colorMode'),
+            palette: fetch('u_palette'),
+            paletteSize: fetch('u_paletteSize'),
+            gradientType: fetch('u_gradientType'),
+            gradientPhase: fetch('u_gradientPhase'),
+            colorReactivity: fetch('u_colorReactivity'),
+            bass: fetch('u_bass'),
+            mid: fetch('u_mid'),
+            high: fetch('u_high')
+        };
+    }
+
+    resize() {
+        if (!this.canvas || !this.gl) return;
+        const dpr = window.devicePixelRatio || 1;
+        const width = this.canvas.clientWidth * dpr;
+        const height = this.canvas.clientHeight * dpr;
+
+        if (this.canvas.width !== width || this.canvas.height !== height) {
+            this.canvas.width = width;
+            this.canvas.height = height;
+        }
+
+        this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    updateParameters(params = {}) {
+        Object.assign(this.params, params);
+    }
+
+    getCurrentAudioState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getAudioLevels === 'function') {
+            return window.audioEngine.getAudioLevels();
+        }
+
+        return window.audioReactive || null;
+    }
+
+    getCurrentColorState() {
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
+        if (window.audioEngine && typeof window.audioEngine.getColorState === 'function') {
+            const state = window.audioEngine.getColorState();
+            if (state) {
+                return state;
+            }
+        }
+
+        return window.colorState || window.audioReactive?.color || null;
+    }
+
+    prepareColorUniforms(colorState) {
+        const buffer = this.colorUniformBuffer;
+        buffer.fill(0);
+
+        let paletteSize = 0;
+        if (colorState?.uniforms?.palette && Array.isArray(colorState.uniforms.palette)) {
+            const palette = colorState.uniforms.palette;
+            paletteSize = Math.min(palette.length, 4);
+            for (let i = 0; i < paletteSize; i += 1) {
+                const color = palette[i] || [0, 0, 0];
+                const offset = i * 3;
+                buffer[offset] = color[0] ?? 0;
+                buffer[offset + 1] = color[1] ?? 0;
+                buffer[offset + 2] = color[2] ?? 0;
+            }
+        }
+
+        const gradientTypeKey = colorState?.gradient?.type || this.params.gradientType || 'horizontal';
+        const gradientType = GRADIENT_TYPE_MAP[gradientTypeKey] ?? GRADIENT_TYPE_MAP.horizontal;
+        const gradientPhase = typeof colorState?.gradient?.phase === 'number'
+            ? colorState.gradient.phase
+            : 0;
+        const modeKey = colorState?.mode || this.params.colorMode || 'single';
+        const mode = COLOR_MODE_MAP[modeKey] ?? COLOR_MODE_MAP.single;
+
+        this.colorUniformState.mode = mode;
+        this.colorUniformState.paletteSize = paletteSize;
+        this.colorUniformState.gradientType = gradientType;
+        this.colorUniformState.gradientPhase = gradientPhase;
+
+        return this.colorUniformState;
+    }
+
+    applyColorUniforms(uniformState) {
+        if (!this.gl || !this.uniforms) return;
+
+        if (this.uniforms.colorMode) {
+            this.gl.uniform1i(this.uniforms.colorMode, uniformState.mode);
+        }
+        if (this.uniforms.palette) {
+            this.gl.uniform3fv(this.uniforms.palette, this.colorUniformBuffer);
+        }
+        if (this.uniforms.paletteSize) {
+            this.gl.uniform1i(this.uniforms.paletteSize, uniformState.paletteSize);
+        }
+        if (this.uniforms.gradientType) {
+            this.gl.uniform1i(this.uniforms.gradientType, uniformState.gradientType);
+        }
+        if (this.uniforms.gradientPhase) {
+            this.gl.uniform1f(this.uniforms.gradientPhase, uniformState.gradientPhase);
+        }
+    }
+
+    updateAudioResponse(audioState) {
+        if (!audioState) {
+            this.audioResponse.bass *= 0.9;
+            this.audioResponse.mid *= 0.9;
+            this.audioResponse.high *= 0.9;
+            this.audioResponse.energy *= 0.9;
+            return this.audioResponse;
+        }
+
+        const bands = audioState.bands || audioState;
+        const targetBass = bands?.bass?.value ?? bands?.bass ?? 0;
+        const targetMid = bands?.mid?.value ?? bands?.mid ?? 0;
+        const targetHigh = bands?.high?.value ?? bands?.high ?? 0;
+        const targetEnergy = audioState.energy ?? audioState.rms ?? 0;
+
+        const smooth = this.audioSmoothing;
+        this.audioResponse.bass += (targetBass - this.audioResponse.bass) * smooth;
+        this.audioResponse.mid += (targetMid - this.audioResponse.mid) * smooth;
+        this.audioResponse.high += (targetHigh - this.audioResponse.high) * smooth;
+        this.audioResponse.energy += (targetEnergy - this.audioResponse.energy) * smooth;
+
+        return this.audioResponse;
+    }
+
+    render() {
+        if (!this.gl || !this.program) {
+            return;
+        }
+
+        this.resize();
+        this.gl.useProgram(this.program);
+        this.gl.enable(this.gl.BLEND);
+        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
+
+        this.time += 16;
+        const elapsed = Date.now() - this.startTime;
+        const audioState = this.getCurrentAudioState();
+        const audioResponse = this.updateAudioResponse(audioState);
+        const colorState = audioState?.color || this.getCurrentColorState();
+        const colorUniforms = this.prepareColorUniforms(colorState);
+
+        const params = this.params;
+        let hueDegrees = typeof params.hue === 'number' ? params.hue : DEFAULT_PARAMS.hue;
+        let saturation = params.saturation ?? DEFAULT_PARAMS.saturation;
+        let intensity = params.intensity ?? DEFAULT_PARAMS.intensity;
+
+        if (colorState?.primary) {
+            hueDegrees = colorState.primary.h;
+            saturation = Math.max(saturation, colorState.primary.s);
+            intensity = Math.max(intensity, colorState.primary.v);
+        }
+
+        if (colorState?.accent) {
+            saturation = Math.max(saturation, colorState.accent.s * 0.85);
+        }
+
+        const hue = (hueDegrees % 360 + 360) % 360;
+        const colorReactivity = typeof params.colorReactivity === 'number'
+            ? params.colorReactivity
+            : DEFAULT_PARAMS.colorReactivity;
+
+        this.gl.uniform2f(this.uniforms.resolution, this.canvas.width, this.canvas.height);
+        this.gl.uniform1f(this.uniforms.time, elapsed);
+        this.gl.uniform1f(this.uniforms.geometry, params.geometry ?? 0);
+        this.gl.uniform1f(this.uniforms.rot4dXW, params.rot4dXW ?? 0);
+        this.gl.uniform1f(this.uniforms.rot4dYW, params.rot4dYW ?? 0);
+        this.gl.uniform1f(this.uniforms.rot4dZW, params.rot4dZW ?? 0);
+        this.gl.uniform1f(this.uniforms.gridDensity, params.gridDensity ?? DEFAULT_PARAMS.gridDensity);
+        this.gl.uniform1f(this.uniforms.morphFactor, params.morphFactor ?? DEFAULT_PARAMS.morphFactor);
+        this.gl.uniform1f(this.uniforms.chaos, params.chaos ?? DEFAULT_PARAMS.chaos);
+        this.gl.uniform1f(this.uniforms.speed, params.speed ?? DEFAULT_PARAMS.speed);
+        this.gl.uniform1f(this.uniforms.hue, hue);
+        this.gl.uniform1f(this.uniforms.intensity, intensity);
+        this.gl.uniform1f(this.uniforms.saturation, saturation);
+        this.gl.uniform1f(this.uniforms.layerIntensity, this.layerIntensity);
+        this.gl.uniform1f(this.uniforms.layerScale, this.layerScale);
+        this.gl.uniform3fv(this.uniforms.layerColor, this.layerColor);
+        this.gl.uniform1f(this.uniforms.colorReactivity, colorReactivity);
+        this.gl.uniform1f(this.uniforms.bass, audioResponse.bass || 0);
+        this.gl.uniform1f(this.uniforms.mid, audioResponse.mid || 0);
+        this.gl.uniform1f(this.uniforms.high, audioResponse.high || 0);
+
+        this.applyColorUniforms(colorUniforms);
+
+        if (this.vertexBuffer) {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.vertexBuffer);
+        }
+
+        this.gl.drawArrays(this.gl.TRIANGLES, 0, 6);
+    }
+
+    cleanup() {
+        window.removeEventListener('resize', this.handleResize);
+        if (!this.gl) return;
+
+        if (this.vertexBuffer) {
+            this.gl.deleteBuffer(this.vertexBuffer);
+            this.vertexBuffer = null;
+        }
+
+        if (this.program) {
+            this.gl.deleteProgram(this.program);
+            this.program = null;
+        }
+
+        if (this.vertexShader) {
+            this.gl.deleteShader(this.vertexShader);
+            this.vertexShader = null;
+        }
+
+        if (this.fragmentShader) {
+            this.gl.deleteShader(this.fragmentShader);
+            this.fragmentShader = null;
+        }
+    }
+}

--- a/src/systems/faceted/FacetedSystem.js
+++ b/src/systems/faceted/FacetedSystem.js
@@ -1,0 +1,80 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { VIB34DIntegratedEngine } from '../../core/Engine.js';
+
+const FACETED_LAYERS = [
+    { id: 'background-canvas', role: 'background' },
+    { id: 'shadow-canvas', role: 'shadow' },
+    { id: 'content-canvas', role: 'content' },
+    { id: 'highlight-canvas', role: 'highlight' },
+    { id: 'accent-canvas', role: 'accent' }
+];
+
+export class FacetedSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'faceted',
+            name: 'Faceted Holographic Grid',
+            description: 'Five-layer holographic renderer with polychora geometry',
+            canvas: FACETED_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new VIB34DIntegratedEngine();
+        if (typeof window !== 'undefined') {
+            window.engine = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.engine = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+
+        if (typeof this.engine.stopRenderLoop === 'function') {
+            try {
+                this.engine.stopRenderLoop();
+            } catch (error) {
+                console.warn('[FacetedSystem] Failed to stop render loop', error);
+            }
+        }
+
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.engine === this.engine) {
+                window.engine = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.engine === this.engine) {
+            window.engine = null;
+        }
+    }
+}

--- a/src/systems/holographic/HolographicSystem.js
+++ b/src/systems/holographic/HolographicSystem.js
@@ -1,0 +1,71 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { RealHolographicSystem } from '../../holograms/RealHolographicSystem.js';
+
+const HOLOGRAPHIC_LAYERS = [
+    { id: 'holo-background-canvas', role: 'background' },
+    { id: 'holo-shadow-canvas', role: 'shadow' },
+    { id: 'holo-content-canvas', role: 'content' },
+    { id: 'holo-highlight-canvas', role: 'highlight' },
+    { id: 'holo-accent-canvas', role: 'accent' }
+];
+
+export class HolographicSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'holographic',
+            name: 'Real Holographic System',
+            description: 'Multi-layer holographic renderer with active variant catalog',
+            canvas: HOLOGRAPHIC_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new RealHolographicSystem();
+        if (typeof window !== 'undefined') {
+            window.holographicSystem = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.holographicSystem = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.holographicSystem === this.engine) {
+                window.holographicSystem = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.holographicSystem === this.engine) {
+            window.holographicSystem = null;
+        }
+    }
+}

--- a/src/systems/polychora/PolychoraSystem.js
+++ b/src/systems/polychora/PolychoraSystem.js
@@ -1,0 +1,71 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { PolychoraEngine } from '../../polychora/PolychoraEngine.js';
+
+const POLYCHORA_LAYERS = [
+    { id: 'polychora-background-canvas', role: 'background' },
+    { id: 'polychora-shadow-canvas', role: 'shadow' },
+    { id: 'polychora-content-canvas', role: 'content' },
+    { id: 'polychora-highlight-canvas', role: 'highlight' },
+    { id: 'polychora-accent-canvas', role: 'accent' }
+];
+
+export class PolychoraSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'polychora',
+            name: 'Polychora 4D Engine',
+            description: 'True 4D polytope renderer with advanced color + audio integration',
+            canvas: POLYCHORA_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new PolychoraEngine();
+        if (typeof window !== 'undefined') {
+            window.polychoraSystem = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.polychoraSystem = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.polychoraSystem === this.engine) {
+                window.polychoraSystem = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.polychoraSystem === this.engine) {
+            window.polychoraSystem = null;
+        }
+    }
+}

--- a/src/systems/quantum/QuantumSystem.js
+++ b/src/systems/quantum/QuantumSystem.js
@@ -1,0 +1,71 @@
+import { BaseSystem } from '../shared/BaseSystem.js';
+import { QuantumEngine } from '../../quantum/QuantumEngine.js';
+
+const QUANTUM_LAYERS = [
+    { id: 'quantum-background-canvas', role: 'background' },
+    { id: 'quantum-shadow-canvas', role: 'shadow' },
+    { id: 'quantum-content-canvas', role: 'content' },
+    { id: 'quantum-highlight-canvas', role: 'highlight' },
+    { id: 'quantum-accent-canvas', role: 'accent' }
+];
+
+export class QuantumSystem extends BaseSystem {
+    constructor(config = {}) {
+        super({
+            key: 'quantum',
+            name: 'Quantum Lattice Engine',
+            description: 'Volumetric quantum renderer with lattice fields and higher dimensional rotations',
+            canvas: QUANTUM_LAYERS,
+            containerId: config.containerId || 'vib34dLayers'
+        });
+    }
+
+    async onCreateEngine() {
+        const engine = new QuantumEngine();
+        if (typeof window !== 'undefined') {
+            window.quantumEngine = engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = engine;
+        }
+        return engine;
+    }
+
+    async onActivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(true);
+        } else {
+            this.engine.isActive = true;
+        }
+
+        if (typeof window !== 'undefined') {
+            window.quantumEngine = this.engine;
+            window.currentSystem = this.key;
+            window.currentSystemEngine = this.engine;
+        }
+    }
+
+    async onDeactivate() {
+        if (!this.engine) return;
+        if (typeof this.engine.setActive === 'function') {
+            this.engine.setActive(false);
+        } else {
+            this.engine.isActive = false;
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.quantumEngine === this.engine) {
+                window.quantumEngine = null;
+            }
+            if (window.currentSystemEngine === this.engine) {
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async onDestroy() {
+        if (typeof window !== 'undefined' && window.quantumEngine === this.engine) {
+            window.quantumEngine = null;
+        }
+    }
+}

--- a/src/systems/shared/BaseSystem.js
+++ b/src/systems/shared/BaseSystem.js
@@ -1,0 +1,218 @@
+/**
+ * BaseSystem - foundational lifecycle for all visualization engines
+ * Handles canvas creation, engine initialization, activation, and teardown
+ */
+
+export class BaseSystem {
+    constructor(config = {}) {
+        if (!config.key) {
+            throw new Error('BaseSystem requires a unique `key` identifier');
+        }
+
+        this.key = config.key;
+        this.name = config.name || config.key;
+        this.description = config.description || '';
+        this.canvasConfig = Array.isArray(config.canvas) ? config.canvas : [];
+        this.autoResize = config.autoResize !== false;
+        this.containerId = config.containerId || null;
+        this.metadata = config.metadata || {};
+
+        this.container = null;
+        this.canvasElements = [];
+        this.engine = null;
+        this.canvasManager = null;
+        this.isActive = false;
+        this.isInitialized = false;
+    }
+
+    /**
+     * Initialize the system with a container. Subclasses can override onInitialize
+     */
+    async initialize(options = {}) {
+        if (this.isInitialized) {
+            return;
+        }
+
+        const container = this.#resolveContainer(options.container || options.containerId || this.containerId);
+        if (!container) {
+            throw new Error(`[BaseSystem:${this.key}] Visualization container not found`);
+        }
+
+        this.container = container;
+        if (typeof this.onInitialize === 'function') {
+            await this.onInitialize(options);
+        }
+
+        this.isInitialized = true;
+    }
+
+    /**
+     * Activate the system, creating canvases and booting the engine
+     */
+    async activate(options = {}) {
+        const container = this.#resolveContainer(options.container || options.containerId || this.containerId);
+        if (!container) {
+            throw new Error(`[BaseSystem:${this.key}] Cannot activate without a container element`);
+        }
+
+        this.container = container;
+
+        if (!this.isInitialized) {
+            await this.initialize({ ...options, container });
+        }
+
+        this.#createCanvasElements(options);
+
+        this.engine = await this.createEngine(options) || null;
+        if (this.engine && typeof this.engine === 'object') {
+            this.canvasManager = this.engine.canvasManager || null;
+        }
+
+        if (typeof this.onAfterEngineCreated === 'function') {
+            await this.onAfterEngineCreated(options);
+        }
+
+        if (typeof this.onActivate === 'function') {
+            await this.onActivate(options);
+        }
+
+        this.isActive = true;
+        return this;
+    }
+
+    /**
+     * Deactivate the system without discarding initialization metadata
+     */
+    async deactivate(options = {}) {
+        if (!this.isActive) {
+            return this;
+        }
+
+        if (typeof this.onDeactivate === 'function') {
+            await this.onDeactivate(options);
+        }
+
+        await this.destroyEngine();
+
+        this.isActive = false;
+        return this;
+    }
+
+    /**
+     * Fully destroy the system (engine + canvases)
+     */
+    async destroy(options = {}) {
+        await this.deactivate(options);
+
+        this.#removeCanvasElements();
+
+        if (typeof this.onDestroy === 'function') {
+            await this.onDestroy(options);
+        }
+
+        this.container = null;
+        this.isInitialized = false;
+        return this;
+    }
+
+    /**
+     * Subclasses override to create their engine instance
+     */
+    async createEngine(options = {}) {
+        if (typeof this.onCreateEngine === 'function') {
+            return this.onCreateEngine(options);
+        }
+        return null;
+    }
+
+    /**
+     * Destroy the engine instance safely
+     */
+    async destroyEngine() {
+        if (this.engine && typeof this.engine.destroy === 'function') {
+            try {
+                this.engine.destroy();
+            } catch (error) {
+                console.warn(`[BaseSystem:${this.key}] Failed to destroy engine`, error);
+            }
+        }
+
+        this.engine = null;
+        this.canvasManager = null;
+    }
+
+    /**
+     * Create canvas elements for each configured layer
+     */
+    #createCanvasElements(options = {}) {
+        if (!this.container) return;
+
+        const layerClass = options.layerClass || 'system-layer';
+        const canvases = [];
+        const width = this.container.clientWidth || window.innerWidth;
+        const height = this.container.clientHeight || window.innerHeight;
+
+        this.canvasConfig.forEach((layer, index) => {
+            const id = layer.id || `${this.key}-layer-${index}`;
+            const safeId = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function')
+                ? CSS.escape(id)
+                : id.replace(/[^a-zA-Z0-9_-]/g, '_');
+            const existing = this.container.querySelector(`#${safeId}`);
+            if (existing) {
+                existing.remove();
+            }
+
+            const element = document.createElement(layer.tag || 'canvas');
+            element.id = id;
+            element.className = layer.className || layerClass;
+            if (layer.role) {
+                element.dataset.role = layer.role;
+            }
+
+            this.container.appendChild(element);
+
+            if (this.autoResize && typeof HTMLCanvasElement !== 'undefined' && element instanceof HTMLCanvasElement) {
+                element.width = width;
+                element.height = height;
+            }
+
+            canvases.push(element);
+        });
+
+        this.canvasElements = canvases;
+    }
+
+    /**
+     * Remove managed canvas elements from the DOM
+     */
+    #removeCanvasElements() {
+        if (!Array.isArray(this.canvasElements)) return;
+
+        this.canvasElements.forEach(canvas => {
+            if (canvas && canvas.parentElement) {
+                canvas.parentElement.removeChild(canvas);
+            }
+        });
+
+        this.canvasElements = [];
+    }
+
+    /**
+     * Resolve container element from selector, element, or default id
+     */
+    #resolveContainer(target) {
+        if (!target) {
+            return this.container || (this.containerId ? document.getElementById(this.containerId) : null);
+        }
+
+        if (typeof target === 'string') {
+            return document.getElementById(target) || document.querySelector(target);
+        }
+
+        if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+            return target;
+        }
+
+        return null;
+    }
+}

--- a/src/systems/shared/BaseVisualizer.js
+++ b/src/systems/shared/BaseVisualizer.js
@@ -1,0 +1,49 @@
+/**
+ * BaseVisualizer - shared interface for WebGL / Canvas visualizers
+ */
+
+export class BaseVisualizer {
+    constructor(config = {}) {
+        this.id = config.id || null;
+        this.role = config.role || 'content';
+        this.reactivity = config.reactivity ?? 1.0;
+        this.canvas = null;
+        this.gl = null;
+        this.contextType = config.contextType || 'webgl2';
+        this.isInitialized = false;
+    }
+
+    /**
+     * Resolve canvas and acquire rendering context
+     */
+    initializeCanvas() {
+        if (!this.id) {
+            throw new Error('BaseVisualizer requires a canvas id');
+        }
+
+        const canvas = document.getElementById(this.id);
+        if (!canvas) {
+            throw new Error(`BaseVisualizer could not find canvas with id ${this.id}`);
+        }
+
+        this.canvas = canvas;
+        this.gl = canvas.getContext(this.contextType) || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+        this.isInitialized = true;
+        return this.gl;
+    }
+
+    /** Override in subclasses */
+    updateFromAudio(_audioState) {}
+
+    /** Override in subclasses */
+    updateParameters(_params) {}
+
+    /** Override in subclasses */
+    render(_time) {}
+
+    destroy() {
+        this.canvas = null;
+        this.gl = null;
+        this.isInitialized = false;
+    }
+}

--- a/src/systems/shared/SystemAccess.js
+++ b/src/systems/shared/SystemAccess.js
@@ -1,0 +1,238 @@
+/**
+ * SystemAccess - shared helpers for working with the global SystemRegistry.
+ * Provides a single source of truth for resolving the active system, engine,
+ * and parameter manager so UI/export/timeline layers stay in sync.
+ */
+
+let registryRef = null;
+let registryUnsubscribe = null;
+let activeDescriptor = {
+    key: null,
+    system: null,
+    metadata: null
+};
+
+function toEngine(systemInstance) {
+    if (!systemInstance || typeof systemInstance !== 'object') {
+        return null;
+    }
+    if (systemInstance.engine && typeof systemInstance.engine === 'object') {
+        return systemInstance.engine;
+    }
+    return null;
+}
+
+function updateActiveDescriptor({ key = null, system = null, metadata = null } = {}) {
+    activeDescriptor = {
+        key,
+        system,
+        metadata
+    };
+
+    const engine = toEngine(system);
+    if (typeof window !== 'undefined') {
+        if (key) {
+            window.currentSystem = key;
+        }
+        if (engine) {
+            window.currentSystemEngine = engine;
+        }
+        if (engine?.parameterManager) {
+            window.parameterManager = engine.parameterManager;
+            window.activeParameterManager = engine.parameterManager;
+        } else if (window.activeParameterManager && key === null) {
+            window.activeParameterManager = null;
+        }
+
+        window.getActiveSystemEngine = getActiveEngine;
+        window.getActiveParameterManager = getActiveParameterManager;
+        window.getActiveSystemKey = getActiveSystemKey;
+        window.getActiveParameterSnapshot = getActiveParameterSnapshot;
+    }
+}
+
+function ensureRegistryListeners(registry) {
+    if (!registry || typeof registry.onChange !== 'function') {
+        return;
+    }
+
+    if (typeof registryUnsubscribe === 'function') {
+        try {
+            registryUnsubscribe();
+        } catch (error) {
+            console.warn('[SystemAccess] Failed to remove previous registry listener', error);
+        }
+        registryUnsubscribe = null;
+    }
+
+    registryUnsubscribe = registry.onChange(({ key, system, metadata }) => {
+        updateActiveDescriptor({ key, system, metadata });
+    });
+
+    if (typeof registry.getActiveKey === 'function') {
+        const key = registry.getActiveKey();
+        const system = typeof registry.getActiveSystem === 'function'
+            ? registry.getActiveSystem()
+            : null;
+        const metadata = typeof registry.getSystemMetadata === 'function'
+            ? registry.getSystemMetadata(key)
+            : null;
+        updateActiveDescriptor({ key, system, metadata });
+    }
+}
+
+export function registerSystemRegistry(registry) {
+    if (!registry) {
+        return null;
+    }
+
+    registryRef = registry;
+
+    if (typeof window !== 'undefined') {
+        window.systemRegistry = registry;
+        window.getSystemRegistry = getSystemRegistry;
+    }
+
+    ensureRegistryListeners(registry);
+    return registry;
+}
+
+export function getSystemRegistry() {
+    return registryRef || (typeof window !== 'undefined' ? window.systemRegistry || null : null);
+}
+
+export function syncActiveSystemState() {
+    const registry = getSystemRegistry();
+    if (!registry) {
+        updateActiveDescriptor({ key: window?.currentSystem ?? null, system: null, metadata: null });
+        return;
+    }
+
+    const key = typeof registry.getActiveKey === 'function' ? registry.getActiveKey() : null;
+    const system = typeof registry.getActiveSystem === 'function' ? registry.getActiveSystem() : null;
+    const metadata = typeof registry.getSystemMetadata === 'function'
+        ? registry.getSystemMetadata(key)
+        : null;
+    updateActiveDescriptor({ key, system, metadata });
+}
+
+export function onRegistryChange(callback, { emitCurrent = true } = {}) {
+    const registry = getSystemRegistry();
+    if (!registry || typeof registry.onChange !== 'function' || typeof callback !== 'function') {
+        return () => {};
+    }
+
+    const unsubscribe = registry.onChange(callback);
+    if (emitCurrent) {
+        const key = getActiveSystemKey();
+        const system = getActiveSystem();
+        const metadata = activeDescriptor.metadata
+            || (typeof registry.getSystemMetadata === 'function' ? registry.getSystemMetadata(key) : null);
+        if (key || system) {
+            callback({ key, system, metadata });
+        }
+    }
+    return unsubscribe;
+}
+
+export function getActiveSystemKey() {
+    if (activeDescriptor.key) {
+        return activeDescriptor.key;
+    }
+    if (typeof window !== 'undefined' && typeof window.currentSystem === 'string') {
+        return window.currentSystem;
+    }
+    const registry = getSystemRegistry();
+    if (registry && typeof registry.getActiveKey === 'function') {
+        return registry.getActiveKey();
+    }
+    return null;
+}
+
+export function getActiveSystem() {
+    if (activeDescriptor.system) {
+        return activeDescriptor.system;
+    }
+    const registry = getSystemRegistry();
+    if (registry && typeof registry.getActiveSystem === 'function') {
+        return registry.getActiveSystem();
+    }
+    return null;
+}
+
+export function getActiveEngine() {
+    const system = getActiveSystem();
+    const engine = toEngine(system);
+    if (engine) {
+        return engine;
+    }
+    if (typeof window !== 'undefined') {
+        return window.currentSystemEngine || window.engine || null;
+    }
+    return null;
+}
+
+export function getActiveParameterManager() {
+    const engine = getActiveEngine();
+    if (engine?.parameterManager) {
+        return engine.parameterManager;
+    }
+    if (typeof window !== 'undefined') {
+        return window.activeParameterManager || window.parameterManager || null;
+    }
+    return null;
+}
+
+export function getActiveParameterSnapshot() {
+    const manager = getActiveParameterManager();
+    if (manager?.getAllParameters) {
+        try {
+            return manager.getAllParameters();
+        } catch (error) {
+            console.warn('[SystemAccess] Active parameter manager snapshot failed', error);
+        }
+    }
+
+    const engine = getActiveEngine();
+    if (engine?.getParameters) {
+        try {
+            return engine.getParameters();
+        } catch (error) {
+            console.warn('[SystemAccess] Active engine parameter snapshot failed', error);
+        }
+    }
+
+    return null;
+}
+
+export function hasSystemRegistry() {
+    return !!getSystemRegistry();
+}
+
+export function getSystemMetadata(key = getActiveSystemKey()) {
+    const resolvedKey = key || getActiveSystemKey();
+    if (activeDescriptor.key && activeDescriptor.key === resolvedKey && activeDescriptor.metadata) {
+        return activeDescriptor.metadata;
+    }
+
+    const registry = getSystemRegistry();
+    if (registry && typeof registry.getSystemMetadata === 'function') {
+        return registry.getSystemMetadata(resolvedKey);
+    }
+
+    return null;
+}
+
+export function listRegisteredSystems() {
+    const registry = getSystemRegistry();
+    if (registry && typeof registry.listSystems === 'function') {
+        return registry.listSystems();
+    }
+    return [];
+}
+
+// Initialize from window globals if they already exist (e.g., legacy pages)
+if (typeof window !== 'undefined' && window.systemRegistry) {
+    registerSystemRegistry(window.systemRegistry);
+    syncActiveSystemState();
+}

--- a/src/systems/shared/SystemMetadata.js
+++ b/src/systems/shared/SystemMetadata.js
@@ -1,0 +1,804 @@
+/**
+ * Shared system metadata definitions for VIB34D engines.
+ * Provides descriptive text, accent colors, and adaptive control groups
+ * so UI layers can render consistent panels across registry-managed systems.
+ */
+
+const DEFAULT_TIMELINE_HINTS = Object.freeze([
+    'Timeline sequences establish base values that the audio engine continues to modulate in real-time.',
+    'Use presets as a launch pad, then fine-tune durations, geometry, and parameter envelopes inside the editor.'
+]);
+
+const DEFAULT_TIMELINE_PRESETS = Object.freeze([
+    {
+        id: 'cinematic-switch-up',
+        icon: '🎬',
+        label: 'Cinematic Switch-Up',
+        description: 'Auto-builds a multi-engine storyline with smooth hand-offs between systems.',
+        action: { type: 'choreographer', method: 'generateDefaultChoreography' }
+    },
+    {
+        id: 'blank-timeline',
+        icon: '🧼',
+        label: 'Blank Slate',
+        description: 'Clear all sequences and start composing choreography from scratch.',
+        action: { type: 'choreographer', method: 'clearTimeline' }
+    }
+]);
+
+const DEFAULT_TIMELINE_ACTIONS = Object.freeze([
+    {
+        id: 'add-sequence',
+        icon: '➕',
+        label: 'Add Sequence',
+        description: 'Insert a new sequence block using the current defaults.',
+        action: { type: 'global', name: 'addSequence' }
+    },
+    {
+        id: 'save-choreography',
+        icon: '💾',
+        label: 'Save Choreography',
+        description: 'Download the current timeline as a JSON choreography file.',
+        action: { type: 'global', name: 'saveChoreography' }
+    },
+    {
+        id: 'load-choreography',
+        icon: '📂',
+        label: 'Load Choreography',
+        description: 'Import a saved choreography JSON and merge it into the editor.',
+        action: { type: 'global', name: 'loadChoreography' }
+    },
+    {
+        id: 'toggle-editor',
+        icon: '📝',
+        label: 'Toggle Editor',
+        description: 'Show or hide the detailed sequence editor panel.',
+        action: { type: 'toggle', method: 'toggleTimelineEditor' }
+    }
+]);
+
+const SYSTEM_ICON_MAP = Object.freeze({
+    faceted: '🔷',
+    quantum: '🌌',
+    holographic: '✨',
+    polychora: '🔮'
+});
+
+const DEFAULT_TIMELINE_SEQUENCE_DEFAULTS = Object.freeze({
+    base: Object.freeze({
+        duration: 12,
+        spacing: 0,
+        geometry: 'cycle',
+        rotation: 'smooth',
+        chaos: 0.25,
+        speed: 1,
+        colorShift: 'medium',
+        geometryInterval: 4,
+        geometryCycles: 2,
+        geometryAudioAxis: 'energy',
+        geometryEnergyThreshold: 0.5
+    }),
+    perSystem: Object.freeze({
+        faceted: Object.freeze({
+            geometry: 'cycle',
+            rotation: 'smooth',
+            speed: 1,
+            chaos: 0.2,
+            colorShift: 'medium'
+        }),
+        quantum: Object.freeze({
+            duration: 14,
+            geometry: 'random',
+            rotation: 'accelerate',
+            speed: 1.6,
+            chaos: 0.45,
+            colorShift: 'fast'
+        }),
+        holographic: Object.freeze({
+            duration: 12,
+            geometry: 'morph',
+            rotation: 'minimal',
+            speed: 0.8,
+            chaos: 0.18,
+            colorShift: 'slow'
+        }),
+        polychora: Object.freeze({
+            duration: 16,
+            geometry: 'cycle',
+            rotation: 'smooth',
+            speed: 1.1,
+            chaos: 0.3,
+            colorShift: 'medium'
+        })
+    })
+});
+
+const DEFAULT_TIMELINE_FORM = Object.freeze({
+    systemOptions: Object.freeze([
+        Object.freeze({ value: 'faceted', icon: SYSTEM_ICON_MAP.faceted, label: 'Faceted Prism' }),
+        Object.freeze({ value: 'quantum', icon: SYSTEM_ICON_MAP.quantum, label: 'Quantum Lattice' }),
+        Object.freeze({ value: 'holographic', icon: SYSTEM_ICON_MAP.holographic, label: 'Holographic Wave' }),
+        Object.freeze({ value: 'polychora', icon: SYSTEM_ICON_MAP.polychora, label: 'Polychora 4D' })
+    ]),
+    geometryModes: Object.freeze([
+        Object.freeze({ value: 'hold', label: 'Hold' }),
+        Object.freeze({ value: 'cycle', label: 'Cycle' }),
+        Object.freeze({ value: 'morph', label: 'Morph' }),
+        Object.freeze({ value: 'random', label: 'Random' }),
+        Object.freeze({ value: 'explosive', label: 'Explosive' })
+    ]),
+    rotationModes: Object.freeze([
+        Object.freeze({ value: 'minimal', label: 'Minimal' }),
+        Object.freeze({ value: 'smooth', label: 'Smooth' }),
+        Object.freeze({ value: 'accelerate', label: 'Accelerate' }),
+        Object.freeze({ value: 'chaos', label: 'Chaos' }),
+        Object.freeze({ value: 'extreme', label: 'Extreme' })
+    ]),
+    colorShiftModes: Object.freeze([
+        Object.freeze({ value: 'freeze', label: 'Freeze' }),
+        Object.freeze({ value: 'slow', label: 'Slow' }),
+        Object.freeze({ value: 'medium', label: 'Medium' }),
+        Object.freeze({ value: 'fast', label: 'Fast' }),
+        Object.freeze({ value: 'rainbow', label: 'Rainbow' })
+    ]),
+    geometryAudioAxes: Object.freeze([
+        Object.freeze({ value: '', label: 'Auto (energy mix)' }),
+        Object.freeze({ value: 'bass', label: 'Bass Emphasis' }),
+        Object.freeze({ value: 'mid', label: 'Mid Focus' }),
+        Object.freeze({ value: 'high', label: 'High Sparkle' }),
+        Object.freeze({ value: 'energy', label: 'Energy Blend' })
+    ])
+});
+
+const DEFAULT_TIMELINE_DESCRIPTOR = Object.freeze({
+    presets: DEFAULT_TIMELINE_PRESETS,
+    actions: DEFAULT_TIMELINE_ACTIONS,
+    hints: DEFAULT_TIMELINE_HINTS,
+    sequenceDefaults: DEFAULT_TIMELINE_SEQUENCE_DEFAULTS,
+    form: DEFAULT_TIMELINE_FORM
+});
+
+const DEFAULT_QUICK_ACTIONS = Object.freeze([
+    {
+        id: 'randomize-parameters',
+        icon: '🎲',
+        label: 'Randomize Parameters',
+        description: 'Shuffle the active system controls for quick inspiration.',
+        action: { type: 'global', name: 'randomizeAll' }
+    },
+    {
+        id: 'randomize-everything',
+        icon: '🌀',
+        label: 'Randomize Everything',
+        description: 'Randomize parameters and geometry in one tap.',
+        action: { type: 'global', name: 'randomizeEverything' }
+    },
+    {
+        id: 'reset-defaults',
+        icon: '♻️',
+        label: 'Reset to Defaults',
+        description: 'Restore the system to its baseline parameter values.',
+        action: { type: 'global', name: 'resetAll' }
+    }
+]);
+
+const DEFAULT_CONTROL_GROUPS = Object.freeze({
+    faceted: [
+        {
+            id: 'geometry',
+            icon: '🔷',
+            title: 'Geometry Sculpting',
+            description: 'Shape prism density and morphing before layering extra energy.',
+            parameters: [
+                { parameter: 'gridDensity', label: 'Grid Density', displayId: 'densityValue', decimals: 1 },
+                { parameter: 'morphFactor', label: 'Morph Factor', displayId: 'morphValue', decimals: 2 },
+                { parameter: 'chaos', label: 'Chaos', displayId: 'chaosValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'motion',
+            icon: '⚡',
+            title: 'Motion & Energy',
+            description: 'Tune pacing and overall energy before audio boosts amplify the scene.',
+            parameters: [
+                { parameter: 'speed', label: 'Playback Speed', displayId: 'speedValue', decimals: 2 },
+                { parameter: 'intensity', label: 'Intensity', displayId: 'intensityValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'color',
+            icon: '🌈',
+            title: 'Color Weave',
+            description: 'Control the base hue and saturation that palettes blend around.',
+            parameters: [
+                { parameter: 'hue', label: 'Hue', displayId: 'hueValue', format: 'degrees' },
+                { parameter: 'saturation', label: 'Saturation', displayId: 'saturationValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'rotation',
+            icon: '🌀',
+            title: '4D Rotation',
+            description: 'Subtle 4D pivots that audio envelopes can stretch for dramatic reveals.',
+            parameters: [
+                { parameter: 'rot4dXW', label: 'X↔W Axis', displayId: 'xwValue', decimals: 2 },
+                { parameter: 'rot4dYW', label: 'Y↔W Axis', displayId: 'ywValue', decimals: 2 },
+                { parameter: 'rot4dZW', label: 'Z↔W Axis', displayId: 'zwValue', decimals: 2 }
+            ]
+        }
+    ],
+    quantum: [
+        {
+            id: 'lattice',
+            icon: '🌌',
+            title: 'Lattice Sculpting',
+            description: 'Dial how dense and fluid the lattice field feels on each beat.',
+            parameters: [
+                { parameter: 'gridDensity', label: 'Node Density', displayId: 'densityValue', decimals: 1 },
+                { parameter: 'morphFactor', label: 'Morph Factor', displayId: 'morphValue', decimals: 2 },
+                { parameter: 'chaos', label: 'Chaos Scatter', displayId: 'chaosValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'motion',
+            icon: '🎛️',
+            title: 'Orbital Motion',
+            description: 'Balance sweeping arcs with the perceived velocity of volumetric layers.',
+            parameters: [
+                { parameter: 'speed', label: 'Orbit Speed', displayId: 'speedValue', decimals: 2 },
+                { parameter: 'intensity', label: 'Lattice Intensity', displayId: 'intensityValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'color',
+            icon: '✨',
+            title: 'Spectral Bloom',
+            description: 'Anchor the hue center before spectral centroid sweeps add movement.',
+            parameters: [
+                { parameter: 'hue', label: 'Hue Center', displayId: 'hueValue', format: 'degrees' },
+                { parameter: 'saturation', label: 'Saturation', displayId: 'saturationValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'rotation',
+            icon: '🧭',
+            title: 'Hyper Rotation',
+            description: 'Use gentle 4D drifts to expose parallax and stereo depth.',
+            parameters: [
+                { parameter: 'rot4dXW', label: 'X↔W Axis', displayId: 'xwValue', decimals: 2 },
+                { parameter: 'rot4dYW', label: 'Y↔W Axis', displayId: 'ywValue', decimals: 2 },
+                { parameter: 'rot4dZW', label: 'Z↔W Axis', displayId: 'zwValue', decimals: 2 }
+            ]
+        }
+    ],
+    holographic: [
+        {
+            id: 'layers',
+            icon: '✨',
+            title: 'Layer Density',
+            description: 'Balance holographic sheet counts with morphing shimmer.',
+            parameters: [
+                { parameter: 'gridDensity', label: 'Layer Count', displayId: 'densityValue', decimals: 1 },
+                { parameter: 'morphFactor', label: 'Morph Flow', displayId: 'morphValue', decimals: 2 },
+                { parameter: 'chaos', label: 'Chaos Flicker', displayId: 'chaosValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'motion',
+            icon: '💫',
+            title: 'Ripple Motion',
+            description: 'Control ripple cadence and brightness before reactivity takes over.',
+            parameters: [
+                { parameter: 'speed', label: 'Ripple Speed', displayId: 'speedValue', decimals: 2 },
+                { parameter: 'intensity', label: 'Glow Intensity', displayId: 'intensityValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'color',
+            icon: '🌈',
+            title: 'Diffraction Color',
+            description: 'Dial the hologram tint and saturation baseline.',
+            parameters: [
+                { parameter: 'hue', label: 'Hue', displayId: 'hueValue', format: 'degrees' },
+                { parameter: 'saturation', label: 'Saturation', displayId: 'saturationValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'rotation',
+            icon: '🌀',
+            title: 'Multi-plane Twist',
+            description: 'Fine tune cross-plane twists that emphasise parallax streaks.',
+            parameters: [
+                { parameter: 'rot4dXW', label: 'X↔W Axis', displayId: 'xwValue', decimals: 2 },
+                { parameter: 'rot4dYW', label: 'Y↔W Axis', displayId: 'ywValue', decimals: 2 },
+                { parameter: 'rot4dZW', label: 'Z↔W Axis', displayId: 'zwValue', decimals: 2 }
+            ]
+        }
+    ],
+    polychora: [
+        {
+            id: 'dimension',
+            icon: '🔮',
+            title: 'Dimensional Shift',
+            description: 'Blend between projected 3D facets and deeper 4D tessellations.',
+            parameters: [
+                { parameter: 'dimension', label: 'Dimension Level', displayId: 'dimensionValue', decimals: 2 },
+                { parameter: 'gridDensity', label: 'Facet Density', displayId: 'densityValue', decimals: 1 }
+            ]
+        },
+        {
+            id: 'rotation',
+            icon: '🧭',
+            title: '4D Rotation',
+            description: 'Core rotational axes that audio envelopes will emphasise.',
+            parameters: [
+                { parameter: 'rot4dXW', label: 'X↔W Axis', displayId: 'xwValue', decimals: 2 },
+                { parameter: 'rot4dYW', label: 'Y↔W Axis', displayId: 'ywValue', decimals: 2 },
+                { parameter: 'rot4dZW', label: 'Z↔W Axis', displayId: 'zwValue', decimals: 2 }
+            ]
+        },
+        {
+            id: 'color',
+            icon: '🌌',
+            title: 'Hyper Color',
+            description: 'Tune baseline color before spectra refract through higher dimensions.',
+            parameters: [
+                { parameter: 'hue', label: 'Hue', displayId: 'hueValue', format: 'degrees' },
+                { parameter: 'saturation', label: 'Saturation', displayId: 'saturationValue', decimals: 2 },
+                { parameter: 'intensity', label: 'Intensity', displayId: 'intensityValue', decimals: 2 }
+            ]
+        }
+    ]
+});
+
+export const DEFAULT_SYSTEM_METADATA = Object.freeze({
+    faceted: {
+        key: 'faceted',
+        title: 'Faceted Prism Engine',
+        description: 'Crystal prisms pulse with bass-driven density while mid-band morphing sculpts razor-sharp silhouettes.',
+        audioFocus: 'Bass boosts grid density, mids morph facets, highs add chaos sparkle.',
+        bestFor: 'Crisp geometric edits and export-ready sequences.',
+        tags: ['Geometric', 'Prismatic', 'Export-ready'],
+        accentColor: '#00faff',
+        supportsGeometryGrid: true,
+        supportsTimeline: true,
+        controlGroups: DEFAULT_CONTROL_GROUPS.faceted,
+        quickActions: DEFAULT_QUICK_ACTIONS,
+        timeline: DEFAULT_TIMELINE_DESCRIPTOR
+    },
+    quantum: {
+        key: 'quantum',
+        title: 'Quantum Lattice Engine',
+        description: 'Volumetric lattice fields orbit through 3D space, bending with spectral energy and stereo depth.',
+        audioFocus: 'Spectral centroid sweeps hue while flux tensions the lattice.',
+        bestFor: 'Atmospheric sci-fi moments and cinematic build-ups.',
+        tags: ['Volumetric', 'Spatial', 'Spectral'],
+        accentColor: '#8b6bff',
+        supportsGeometryGrid: true,
+        supportsTimeline: true,
+        controlGroups: DEFAULT_CONTROL_GROUPS.quantum,
+        quickActions: DEFAULT_QUICK_ACTIONS,
+        timeline: DEFAULT_TIMELINE_DESCRIPTOR
+    },
+    holographic: {
+        key: 'holographic',
+        title: 'Holographic Wave Engine',
+        description: 'Layered holograms ripple with diffused color diffraction and multi-plane bloom.',
+        audioFocus: 'RMS drives intensity while high-mids shimmer across the layers.',
+        bestFor: 'Performance overlays and light-trail choreography.',
+        tags: ['Layered', 'Luminous', 'Performance'],
+        accentColor: '#ff6bff',
+        supportsGeometryGrid: true,
+        supportsTimeline: true,
+        controlGroups: DEFAULT_CONTROL_GROUPS.holographic,
+        quickActions: DEFAULT_QUICK_ACTIONS,
+        timeline: DEFAULT_TIMELINE_DESCRIPTOR
+    },
+    polychora: {
+        key: 'polychora',
+        title: 'Polychora 4D Engine',
+        description: 'High-dimensional polytopes rotate through projected space with evolving tessellation.',
+        audioFocus: 'Bass anchors rotation speed as spectral flux fractures the geometry.',
+        bestFor: 'Future-forward narratives and math-inspired sequences.',
+        tags: ['4D', 'Experimental', 'Immersive'],
+        accentColor: '#7cfcc5',
+        supportsGeometryGrid: true,
+        supportsTimeline: true,
+        controlGroups: DEFAULT_CONTROL_GROUPS.polychora,
+        quickActions: DEFAULT_QUICK_ACTIONS,
+        timeline: DEFAULT_TIMELINE_DESCRIPTOR
+    }
+});
+
+function mergeUniqueArrays(...arrays) {
+    const seen = new Set();
+    const result = [];
+    arrays.forEach(arr => {
+        if (!Array.isArray(arr)) return;
+        arr.forEach(value => {
+            if (value === undefined || value === null) return;
+            const key = String(value).trim();
+            if (!key || seen.has(key.toLowerCase())) return;
+            seen.add(key.toLowerCase());
+            result.push(key);
+        });
+    });
+    return result;
+}
+
+function cloneParameterConfig(config = {}) {
+    if (!config || typeof config !== 'object') {
+        return null;
+    }
+    const parameter = config.parameter || config.name || config.id;
+    if (!parameter) {
+        return null;
+    }
+    return {
+        parameter,
+        label: config.label || config.title || parameter,
+        icon: config.icon || null,
+        displayId: config.displayId || `${parameter}Value`,
+        min: config.min,
+        max: config.max,
+        step: config.step,
+        decimals: config.decimals,
+        format: config.format,
+        unit: config.unit,
+        hint: config.hint,
+        defaultValue: config.defaultValue
+    };
+}
+
+function cloneControlGroup(group = {}) {
+    const parameters = Array.isArray(group.parameters)
+        ? group.parameters.map(cloneParameterConfig).filter(Boolean)
+        : [];
+
+    return {
+        id: group.id || group.key || group.title || '',
+        title: group.title || group.name || '',
+        icon: group.icon || null,
+        description: group.description || '',
+        parameters
+    };
+}
+
+function cloneActionHandler(handler) {
+    if (!handler) {
+        return null;
+    }
+
+    if (typeof handler === 'function' || typeof handler === 'string') {
+        return handler;
+    }
+
+    if (typeof handler === 'object') {
+        return {
+            type: handler.type,
+            name: handler.name,
+            method: handler.method,
+            args: Array.isArray(handler.args) ? [...handler.args] : undefined,
+            requireMode: handler.requireMode,
+            event: handler.event,
+            payload: handler.payload,
+            toggle: handler.toggle
+        };
+    }
+
+    return null;
+}
+
+function cloneActionDescriptor(action = {}) {
+    const handler = cloneActionHandler(action.action ?? action.handler ?? null);
+    const label = action.label || action.title || null;
+
+    if (!label || !handler) {
+        return null;
+    }
+
+    return {
+        id: action.id || action.key || '',
+        label,
+        icon: action.icon || null,
+        description: action.description || action.hint || '',
+        action: handler,
+        kind: action.kind || action.category || null,
+        size: action.size || null,
+        disabled: action.disabled === true,
+        requireMode: action.requireMode
+    };
+}
+
+function mergeActionList(baseActions = [], overrideActions = []) {
+    const result = new Map();
+
+    const push = (actions) => {
+        actions.forEach(action => {
+            const cloned = cloneActionDescriptor(action);
+            if (!cloned) {
+                return;
+            }
+            const key = cloned.id || cloned.label;
+            result.set(key, cloned);
+        });
+    };
+
+    if (Array.isArray(baseActions)) {
+        push(baseActions);
+    }
+
+    if (Array.isArray(overrideActions)) {
+        push(overrideActions);
+    }
+
+    return Array.from(result.values());
+}
+
+function cloneHints(hints, fallback = []) {
+    const source = Array.isArray(hints) && hints.length ? hints : fallback;
+    return source
+        .map(hint => {
+            if (typeof hint === 'string') {
+                return hint.trim();
+            }
+            if (hint && typeof hint === 'object' && typeof hint.text === 'string') {
+                return hint.text.trim();
+            }
+            return null;
+        })
+        .filter(Boolean);
+}
+
+function cloneOption(option, { allowEmpty = false } = {}) {
+    if (option === null || option === undefined) {
+        return null;
+    }
+
+    if (typeof option === 'string' || typeof option === 'number') {
+        const raw = String(option);
+        const trimmed = raw.trim();
+        if (!trimmed && !allowEmpty) {
+            return null;
+        }
+        const value = trimmed || (allowEmpty ? '' : trimmed);
+        const label = trimmed || raw || (allowEmpty ? 'Auto' : '');
+        return {
+            value,
+            label,
+            icon: null
+        };
+    }
+
+    if (typeof option === 'object') {
+        const rawValue = option.value ?? option.key ?? option.id ?? option.name ?? option.label;
+        const stringValue = rawValue === undefined || rawValue === null ? '' : String(rawValue);
+        const trimmed = stringValue.trim();
+        if (!trimmed && !allowEmpty) {
+            return null;
+        }
+        const value = trimmed || (allowEmpty ? '' : trimmed);
+        let label = option.label || option.title || option.name || '';
+        label = label && typeof label === 'string' ? label.trim() : '';
+        if (!label) {
+            label = trimmed || (allowEmpty && !value ? 'Auto' : '');
+        }
+        const normalized = {
+            value,
+            label,
+            icon: option.icon || null
+        };
+        if (option.description || option.hint) {
+            normalized.description = option.description || option.hint;
+        }
+        if (option.dataset && typeof option.dataset === 'object') {
+            normalized.dataset = { ...option.dataset };
+        }
+        return normalized;
+    }
+
+    return null;
+}
+
+function cloneOptionList(list, fallback = [], options = {}) {
+    const { allowEmpty = false } = options;
+    const result = [];
+    const seen = new Set();
+
+    const push = source => {
+        if (!source) {
+            return;
+        }
+        const array = Array.isArray(source) ? source : [source];
+        array.forEach(entry => {
+            const option = cloneOption(entry, { allowEmpty });
+            if (!option) {
+                return;
+            }
+            const value = option.value ?? '';
+            const normalizedValue = value.toLowerCase();
+            if (!normalizedValue && allowEmpty) {
+                if (result.some(opt => opt.value === '')) {
+                    return;
+                }
+                result.push(option);
+                return;
+            }
+            if (seen.has(normalizedValue)) {
+                return;
+            }
+            seen.add(normalizedValue);
+            result.push(option);
+        });
+    };
+
+    push(list);
+    push(fallback);
+
+    return result;
+}
+
+function cloneSequenceDefaults(defaults = {}) {
+    const baseSource = defaults && typeof defaults === 'object' && !Array.isArray(defaults)
+        ? (typeof defaults.base === 'object' ? defaults.base : defaults)
+        : {};
+    const base = { ...DEFAULT_TIMELINE_SEQUENCE_DEFAULTS.base };
+
+    Object.entries(baseSource).forEach(([key, value]) => {
+        base[key] = value;
+    });
+
+    const fallbackPerSystem = DEFAULT_TIMELINE_SEQUENCE_DEFAULTS.perSystem || {};
+    const perSystem = {};
+    Object.entries(fallbackPerSystem).forEach(([key, value]) => {
+        perSystem[key] = { ...value };
+    });
+
+    const perSystemSource = defaults && typeof defaults === 'object'
+        ? (defaults.perSystem || defaults.systems || {})
+        : {};
+
+    Object.entries(perSystemSource).forEach(([key, value]) => {
+        if (!key || typeof value !== 'object') {
+            return;
+        }
+        const normalizedKey = key.toLowerCase();
+        perSystem[normalizedKey] = {
+            ...(perSystem[normalizedKey] || {}),
+            ...value
+        };
+    });
+
+    return {
+        base,
+        perSystem
+    };
+}
+
+function mergeSequenceDefaults(baseDefaults, overrideDefaults) {
+    const base = baseDefaults && typeof baseDefaults === 'object' ? baseDefaults : {};
+    const override = overrideDefaults && typeof overrideDefaults === 'object' ? overrideDefaults : {};
+
+    const combinedBase = {
+        ...(typeof base.base === 'object' ? base.base : base),
+        ...(typeof override.base === 'object' ? override.base : override)
+    };
+
+    const basePerSystem = base.perSystem || base.systems || {};
+    const overridePerSystem = override.perSystem || override.systems || {};
+    const combinedPerSystem = {};
+
+    Object.entries(basePerSystem).forEach(([key, value]) => {
+        if (!key || typeof value !== 'object') {
+            return;
+        }
+        combinedPerSystem[key.toLowerCase()] = { ...value };
+    });
+
+    Object.entries(overridePerSystem).forEach(([key, value]) => {
+        if (!key || typeof value !== 'object') {
+            return;
+        }
+        const normalizedKey = key.toLowerCase();
+        combinedPerSystem[normalizedKey] = {
+            ...(combinedPerSystem[normalizedKey] || {}),
+            ...value
+        };
+    });
+
+    return cloneSequenceDefaults({ base: combinedBase, perSystem: combinedPerSystem });
+}
+
+function mergeTimelineForm(baseForm, overrideForm) {
+    const base = baseForm && typeof baseForm === 'object' ? baseForm : {};
+    const override = overrideForm && typeof overrideForm === 'object' ? overrideForm : {};
+
+    return {
+        systemOptions: cloneOptionList(override.systemOptions, base.systemOptions || DEFAULT_TIMELINE_FORM.systemOptions),
+        geometryModes: cloneOptionList(override.geometryModes, base.geometryModes || DEFAULT_TIMELINE_FORM.geometryModes),
+        rotationModes: cloneOptionList(override.rotationModes, base.rotationModes || DEFAULT_TIMELINE_FORM.rotationModes),
+        colorShiftModes: cloneOptionList(override.colorShiftModes, base.colorShiftModes || DEFAULT_TIMELINE_FORM.colorShiftModes),
+        geometryAudioAxes: cloneOptionList(
+            override.geometryAudioAxes,
+            base.geometryAudioAxes || DEFAULT_TIMELINE_FORM.geometryAudioAxes,
+            { allowEmpty: true }
+        )
+    };
+}
+
+function cloneTimelineDescriptor(descriptor = {}) {
+    const presets = mergeActionList(DEFAULT_TIMELINE_DESCRIPTOR.presets, descriptor.presets);
+    const actions = mergeActionList(DEFAULT_TIMELINE_DESCRIPTOR.actions, descriptor.actions);
+    const hints = cloneHints(descriptor.hints, DEFAULT_TIMELINE_DESCRIPTOR.hints);
+    const sequenceDefaults = mergeSequenceDefaults(DEFAULT_TIMELINE_DESCRIPTOR.sequenceDefaults, descriptor.sequenceDefaults);
+    const form = mergeTimelineForm(DEFAULT_TIMELINE_DESCRIPTOR.form, descriptor.form);
+
+    return {
+        presets,
+        actions,
+        hints,
+        sequenceDefaults,
+        form
+    };
+}
+
+function mergeControlGroups(baseGroups = [], overrideGroups) {
+    const source = Array.isArray(overrideGroups) && overrideGroups.length
+        ? overrideGroups
+        : baseGroups;
+    return source.map(cloneControlGroup);
+}
+
+/**
+ * Resolve a descriptor for a given system key, merging overrides with defaults
+ * and cloning nested structures to avoid shared references.
+ */
+export function resolveSystemDescriptor(key, overrides = {}) {
+    const normalizedKey = typeof key === 'string' ? key.toLowerCase() : '';
+    const base = DEFAULT_SYSTEM_METADATA[normalizedKey] || {};
+
+    const combinedTimeline = {
+        presets: [
+            ...(Array.isArray(base.timeline?.presets) ? base.timeline.presets : []),
+            ...(Array.isArray(overrides.timeline?.presets) ? overrides.timeline.presets : [])
+        ],
+        actions: [
+            ...(Array.isArray(base.timeline?.actions) ? base.timeline.actions : []),
+            ...(Array.isArray(overrides.timeline?.actions) ? overrides.timeline.actions : [])
+        ],
+        hints: overrides.timeline?.hints ?? base.timeline?.hints,
+        sequenceDefaults: mergeSequenceDefaults(
+            base.timeline?.sequenceDefaults,
+            overrides.timeline?.sequenceDefaults
+        ),
+        form: mergeTimelineForm(base.timeline?.form, overrides.timeline?.form)
+    };
+
+    const quickActions = mergeActionList(
+        Array.isArray(base.quickActions) ? base.quickActions : DEFAULT_QUICK_ACTIONS,
+        overrides.quickActions
+    );
+
+    const descriptor = {
+        key: normalizedKey || overrides.key || base.key || '',
+        title: overrides.title || base.title || '',
+        panelTitle: overrides.panelTitle || base.panelTitle || overrides.title || base.title || '',
+        panelSubtitle: overrides.panelSubtitle || base.panelSubtitle || '',
+        description: overrides.description || base.description || '',
+        audioFocus: overrides.audioFocus || base.audioFocus || '',
+        visualFocus: overrides.visualFocus || base.visualFocus || '',
+        bestFor: overrides.bestFor || base.bestFor || '',
+        accentColor: overrides.accentColor || base.accentColor || '#00faff',
+        supportsGeometryGrid: overrides.supportsGeometryGrid ?? base.supportsGeometryGrid ?? true,
+        supportsTimeline: overrides.supportsTimeline ?? base.supportsTimeline ?? false,
+        tags: mergeUniqueArrays(base.tags, overrides.tags),
+        keywords: mergeUniqueArrays(base.keywords, overrides.keywords),
+        moods: mergeUniqueArrays(base.moods, overrides.moods),
+        capabilities: mergeUniqueArrays(base.capabilities, overrides.capabilities),
+        controlGroups: mergeControlGroups(base.controlGroups, overrides.controlGroups),
+        quickActions,
+        timeline: cloneTimelineDescriptor(combinedTimeline)
+    };
+
+    return descriptor;
+}

--- a/src/systems/shared/SystemRegistry.js
+++ b/src/systems/shared/SystemRegistry.js
@@ -1,0 +1,205 @@
+/**
+ * SystemRegistry - orchestrates BaseSystem lifecycles and switching
+ */
+
+export class SystemRegistry {
+    constructor(options = {}) {
+        this.containerId = options.containerId || null;
+        this.container = this.#resolveContainer(options.container || this.containerId);
+        this.autoClear = options.autoClear !== false;
+        this.destroyOnSwitch = options.destroyOnSwitch !== false;
+
+        this.systems = new Map(); // key => { factory, instance, metadata }
+        this.activeKey = null;
+        this.listeners = new Set();
+    }
+
+    register(key, factory, metadata = {}) {
+        if (!key) {
+            throw new Error('SystemRegistry.register requires a unique key');
+        }
+        if (typeof factory !== 'function') {
+            throw new Error(`SystemRegistry.register(${key}) requires a factory function`);
+        }
+
+        this.systems.set(key, {
+            factory,
+            instance: null,
+            metadata
+        });
+    }
+
+    has(key) {
+        return this.systems.has(key);
+    }
+
+    getSystemMetadata(key = this.activeKey) {
+        if (!key || !this.systems.has(key)) {
+            return null;
+        }
+
+        const entry = this.systems.get(key);
+        return entry?.metadata || null;
+    }
+
+    listSystems() {
+        return Array.from(this.systems.entries()).map(([key, entry]) => ({
+            key,
+            metadata: entry?.metadata || null,
+            isActive: key === this.activeKey
+        }));
+    }
+
+    getActiveKey() {
+        return this.activeKey;
+    }
+
+    getActiveSystem() {
+        const entry = this.activeKey ? this.systems.get(this.activeKey) : null;
+        return entry?.instance || null;
+    }
+
+    onChange(callback) {
+        if (typeof callback === 'function') {
+            this.listeners.add(callback);
+        }
+        return () => this.listeners.delete(callback);
+    }
+
+    async activate(key, options = {}) {
+        if (!this.systems.has(key)) {
+            throw new Error(`SystemRegistry could not find system: ${key}`);
+        }
+
+        const entry = this.systems.get(key);
+        const container = this.#prepareContainer(options);
+
+        if (this.activeKey && this.activeKey !== key) {
+            await this.#deactivateCurrent({ reason: 'switch', next: key });
+        }
+
+        if (this.autoClear && container && options.clearContainer !== false) {
+            container.innerHTML = '';
+        }
+
+        const system = await this.#ensureInstance(entry, { container });
+        await system.activate({ ...options, container });
+
+        this.activeKey = key;
+        if (typeof window !== 'undefined') {
+            window.currentSystem = key;
+            window.currentSystemEngine = system.engine || null;
+        }
+
+        this.listeners.forEach(listener => {
+            try {
+                listener({ key, system, metadata: entry.metadata });
+            } catch (error) {
+                console.warn('[SystemRegistry] listener error', error);
+            }
+        });
+
+        return system;
+    }
+
+    async deactivate(key, options = {}) {
+        if (!this.systems.has(key)) return;
+        const entry = this.systems.get(key);
+        if (!entry.instance) return;
+
+        await entry.instance.deactivate({ ...options, reason: options.reason || 'manual' });
+        if (this.destroyOnSwitch || options.destroy !== false) {
+            await entry.instance.destroy({ ...options, reason: options.reason || 'manual' });
+            entry.instance = null;
+        }
+
+        if (this.activeKey === key) {
+            this.activeKey = null;
+            if (typeof window !== 'undefined' && window.currentSystem === key) {
+                window.currentSystem = null;
+                window.currentSystemEngine = null;
+            }
+        }
+    }
+
+    async destroyAll(options = {}) {
+        const keys = Array.from(this.systems.keys());
+        for (const key of keys) {
+            await this.deactivate(key, { ...options, destroy: true, reason: 'registry-destroy' });
+        }
+        this.systems.clear();
+        this.activeKey = null;
+    }
+
+    #resolveContainer(target) {
+        if (!target) return null;
+        if (typeof target === 'string') {
+            return document.getElementById(target) || document.querySelector(target);
+        }
+        if (typeof HTMLElement !== 'undefined' && target instanceof HTMLElement) {
+            return target;
+        }
+        return null;
+    }
+
+    #prepareContainer(options = {}) {
+        if (options.container) {
+            return options.container;
+        }
+
+        if (!this.container || options.containerId) {
+            this.container = this.#resolveContainer(options.containerId || this.containerId);
+        }
+
+        if (!this.container) {
+            this.container = this.#resolveContainer('vib34dLayers');
+        }
+
+        if (!this.container) {
+            throw new Error('SystemRegistry could not resolve a visualization container');
+        }
+
+        return this.container;
+    }
+
+    async #ensureInstance(entry, context = {}) {
+        if (entry.instance) {
+            return entry.instance;
+        }
+
+        const instance = await entry.factory({ metadata: entry.metadata, container: context.container });
+        if (!instance) {
+            throw new Error('SystemRegistry factory did not return a system instance');
+        }
+
+        if (context.container) {
+            await instance.initialize({ container: context.container });
+        }
+
+        entry.instance = instance;
+        return instance;
+    }
+
+    async #deactivateCurrent(options = {}) {
+        if (!this.activeKey) return;
+        const currentKey = this.activeKey;
+        const currentEntry = this.systems.get(currentKey);
+        if (!currentEntry?.instance) {
+            this.activeKey = null;
+            return;
+        }
+
+        await currentEntry.instance.deactivate({ reason: options.reason || 'switch', nextSystem: options.next });
+        if (this.destroyOnSwitch) {
+            await currentEntry.instance.destroy({ reason: options.reason || 'switch', nextSystem: options.next });
+            currentEntry.instance = null;
+        }
+
+        if (typeof window !== 'undefined' && window.currentSystem === currentKey) {
+            window.currentSystem = null;
+            window.currentSystemEngine = null;
+        }
+
+        this.activeKey = null;
+    }
+}

--- a/styles/controls.css
+++ b/styles/controls.css
@@ -2,93 +2,115 @@
 
 .control-panel {
     position: fixed;
-    top: 50px;
+    top: 80px;
     right: 0;
-    bottom: 0;
-    width: 300px;
-    background: rgba(0, 0, 0, 0.95);
-    border-left: 2px solid #00ffff;
+    bottom: 20px;
+    width: 320px;
+    background: rgba(0, 0, 0, 0.92);
+    border-left: 2px solid var(--control-accent, #00ffff);
     padding: 20px;
     overflow-y: auto;
-    backdrop-filter: blur(10px);
-    z-index: 100;
-    transition: transform 0.3s ease;
+    backdrop-filter: blur(12px);
+    z-index: 1200;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    --control-accent: #00ffff;
+    --control-accent-soft: rgba(0, 255, 255, 0.25);
+    --control-accent-strong: rgba(0, 255, 255, 0.6);
+    --control-text-muted: rgba(255, 255, 255, 0.65);
+}
+
+.control-panel.hidden {
+    display: none;
+}
+
+.control-panel.collapsed {
+    transform: translateX(260px);
+    opacity: 0.45;
+}
+
+.control-panel.collapsed #controlPanelContent {
+    pointer-events: none;
 }
 
 .panel-header {
-    font-size: 1.1rem;
-    color: #ff00ff;
-    margin-bottom: 20px;
-    text-align: center;
-    text-shadow: 0 0 10px #ff00ff;
+    font-size: 1.05rem;
+    color: var(--control-accent, #00ffff);
+    margin-bottom: 18px;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    text-shadow: 0 0 14px var(--control-accent-strong, rgba(0, 255, 255, 0.6));
 }
 
 .mobile-collapse-btn {
-    background: rgba(255, 0, 255, 0.2);
-    border: 1px solid #ff00ff;
-    color: #ff00ff;
-    padding: 8px 12px;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--control-accent, #00ffff);
+    color: var(--control-accent, #00ffff);
+    padding: 6px 12px;
     cursor: pointer;
-    font-size: 1.2rem;
-    border-radius: 5px;
+    font-size: 1.1rem;
+    border-radius: 6px;
     transition: all 0.3s ease;
 }
 
 .mobile-collapse-btn:hover {
-    background: rgba(255, 0, 255, 0.4);
+    background: var(--control-accent-soft, rgba(0, 255, 255, 0.25));
 }
 
 .control-section {
-    margin-bottom: 25px;
+    margin-bottom: 24px;
     padding-bottom: 20px;
-    border-bottom: 1px solid rgba(0, 255, 255, 0.2);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .control-section:last-child {
     border-bottom: none;
 }
 
+.control-section.inactive {
+    opacity: 0.55;
+}
+
 .section-title {
-    font-size: 0.9rem;
-    color: #00ffff;
-    margin-bottom: 10px;
+    font-size: 0.85rem;
+    color: var(--control-accent, #00ffff);
+    margin-bottom: 12px;
     text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.geometry-readout {
+    font-size: 0.72rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.65));
+    margin-bottom: 8px;
 }
 
 /* Geometry Grid */
 .geometry-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 5px;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
 }
 
 .geom-btn {
     background: rgba(0, 255, 255, 0.1);
-    border: 1px solid rgba(0, 255, 255, 0.3);
-    color: #00ffff;
+    border: 1px solid var(--control-accent-soft, rgba(0, 255, 255, 0.25));
+    color: var(--control-accent, #00ffff);
     padding: 8px;
     cursor: pointer;
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     transition: all 0.3s;
-    
-    /* FIXED: Handle long text like HYPERTETRAHEDRON */
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     line-height: 1.1;
     min-height: 40px;
-    
-    /* Allow text wrapping for long geometry names */
     word-wrap: break-word;
     overflow-wrap: break-word;
     hyphens: auto;
 }
 
-/* SPECIAL: HyperTetrahedron button - split into two lines */
 .geom-btn[data-name*="HYPERTETRAHEDRON"],
 .geom-btn[title*="HYPERTETRAHEDRON"] {
     font-size: 0.6rem;
@@ -103,52 +125,88 @@
     text-align: center;
 }
 
-/* Alternative: CSS-only line break for HYPERTETRAHEDRON */
-.geom-btn-text {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.1;
-}
-
-.geom-btn-line {
-    font-size: 0.65rem;
-}
-
 .geom-btn:hover {
-    background: rgba(0, 255, 255, 0.2);
+    background: var(--control-accent-soft, rgba(0, 255, 255, 0.25));
 }
 
 .geom-btn.active {
-    background: rgba(0, 255, 255, 0.4);
-    border-color: #00ffff;
-    box-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+    background: var(--control-accent, #00ffff);
+    color: #000;
+    border-color: var(--control-accent, #00ffff);
+    box-shadow: 0 0 6px var(--control-accent-strong, rgba(0, 255, 255, 0.6));
+}
+
+/* Adaptive Control Groups */
+.control-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.control-collection {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.control-group-title {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--control-accent, #00ffff);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.control-group-icon {
+    font-size: 0.9rem;
+}
+
+.control-group-description {
+    font-size: 0.7rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.6));
+    line-height: 1.4;
+}
+
+.control-hint {
+    font-size: 0.65rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.5));
+    margin-top: 4px;
+    line-height: 1.4;
+}
+
+.control-empty {
+    font-size: 0.75rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.6));
 }
 
 /* Parameter Controls */
 .control-group {
-    margin-bottom: 15px;
+    margin-bottom: 12px;
 }
 
 .control-label {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 5px;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.8);
+    margin-bottom: 6px;
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.82);
 }
 
 .control-value {
-    color: #00ffff;
+    color: var(--control-accent, #00ffff);
     font-weight: bold;
+    margin-left: 10px;
 }
 
 .control-slider {
     width: 100%;
     height: 6px;
-    background: rgba(0, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.15);
     outline: none;
-    opacity: 0.9;
+    opacity: 0.95;
     transition: opacity 0.2s;
     appearance: none;
     border-radius: 3px;
@@ -162,141 +220,161 @@
     appearance: none;
     width: 16px;
     height: 16px;
-    background: #00ffff;
+    background: var(--control-accent, #00ffff);
     cursor: pointer;
     border-radius: 50%;
-    box-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+    box-shadow: 0 0 5px var(--control-accent-strong, rgba(0, 255, 255, 0.6));
 }
 
 .control-slider::-moz-range-thumb {
     width: 16px;
     height: 16px;
-    background: #00ffff;
+    background: var(--control-accent, #00ffff);
     cursor: pointer;
     border-radius: 50%;
     border: none;
-    box-shadow: 0 0 5px rgba(0, 255, 255, 0.5);
+    box-shadow: 0 0 5px var(--control-accent-strong, rgba(0, 255, 255, 0.6));
 }
 
 /* Action Buttons */
 .panel-btn {
-    background: rgba(255, 0, 255, 0.1);
-    border: 2px solid rgba(255, 0, 255, 0.3);
-    color: #ff00ff;
-    padding: 10px 20px;
-    margin: 5px 0;
+    background: rgba(0, 0, 0, 0.2);
+    border: 2px solid var(--control-accent-soft, rgba(0, 255, 255, 0.3));
+    color: var(--control-accent, #00ffff);
+    padding: 10px 16px;
+    margin: 6px 0;
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     width: 100%;
     transition: all 0.3s;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-radius: 6px;
 }
 
 .panel-btn:hover {
-    background: rgba(255, 0, 255, 0.3);
-    box-shadow: 0 0 10px rgba(255, 0, 255, 0.5);
+    background: var(--control-accent-soft, rgba(0, 255, 255, 0.25));
+    box-shadow: 0 0 12px var(--control-accent-soft, rgba(0, 255, 255, 0.35));
 }
 
-.panel-btn.wide {
+.panel-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.panel-btn.compact {
+    padding: 8px 12px;
+    font-size: 0.75rem;
+    text-transform: none;
+    letter-spacing: 0.02em;
+}
+
+/* Timeline Section */
+.timeline-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.timeline-track {
     width: 100%;
-    margin-bottom: 10px;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
 }
 
-/* System Selector Panel (moved from top bar) */
-.system-selector-panel {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+.timeline-progress {
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--control-accent, #00ffff), rgba(255, 0, 255, 0.65));
+    transition: width 0.1s linear;
+}
+
+.timeline-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.72rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.6));
+}
+
+.timeline-actions {
+    display: flex;
     gap: 8px;
-    margin-bottom: 10px;
 }
 
-.system-selector-panel .system-btn {
-    background: rgba(0, 255, 255, 0.1);
-    border: 1px solid rgba(0, 255, 255, 0.3);
-    color: #00ffff;
-    padding: 10px 8px;
-    cursor: pointer;
-    font-family: 'Orbitron', monospace;
-    font-size: 0.8rem;
-    transition: all 0.3s;
-    text-align: center;
-    line-height: 1.2;
+.timeline-presets {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 8px;
+    margin-top: 4px;
 }
 
-.system-selector-panel .system-btn:hover {
-    background: rgba(0, 255, 255, 0.2);
-    border-color: #00ffff;
-    box-shadow: 0 0 10px rgba(0, 255, 255, 0.3);
+.timeline-hints {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
-.system-selector-panel .system-btn.active {
-    background: rgba(0, 255, 255, 0.3);
-    border-color: #00ffff;
-    box-shadow: 0 0 15px rgba(0, 255, 255, 0.5);
+.timeline-hint {
+    font-size: 0.68rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.6));
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px dashed var(--control-accent-soft, rgba(0, 255, 255, 0.25));
+    padding: 6px 8px;
+    border-radius: 6px;
+    line-height: 1.4;
 }
 
-/* Professional Action Buttons */
-.panel-btn.action-randomize {
-    background: rgba(100, 255, 100, 0.1);
-    border-color: rgba(100, 255, 100, 0.3);
-    color: #64ff64;
-    font-weight: 700;
-    letter-spacing: 1px;
+.timeline-editor-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
 }
 
-.panel-btn.action-reset {
-    background: rgba(255, 100, 100, 0.1);
-    border-color: rgba(255, 100, 100, 0.3);
-    color: #ff6464;
-    font-weight: 700;
-    letter-spacing: 1px;
+.timeline-editor-actions .panel-btn {
+    flex: 1 1 calc(50% - 8px);
 }
 
-.panel-btn.action-save {
-    background: rgba(0, 255, 255, 0.1);
-    border-color: rgba(0, 255, 255, 0.3);
-    color: #00ffff;
-    font-weight: 700;
-    letter-spacing: 1px;
+.timeline-empty {
+    font-size: 0.7rem;
+    color: var(--control-text-muted, rgba(255, 255, 255, 0.5));
+    padding: 6px 4px;
 }
 
-.panel-btn.action-card {
-    background: rgba(255, 200, 0, 0.1);
-    border-color: rgba(255, 200, 0, 0.3);
-    color: #ffc800;
-    font-weight: 700;
-    letter-spacing: 1px;
+.timeline-preset-btn {
+    font-size: 0.72rem;
 }
 
-.panel-btn.action-randomize:hover {
-    background: rgba(100, 255, 100, 0.2);
-    box-shadow: 0 0 10px rgba(100, 255, 100, 0.5);
+.timeline-editor-btn {
+    font-size: 0.74rem;
 }
 
-.panel-btn.action-reset:hover {
-    background: rgba(255, 100, 100, 0.2);
-    box-shadow: 0 0 10px rgba(255, 100, 100, 0.5);
+.timeline-section.inactive {
+    opacity: 0.55;
 }
 
-.panel-btn.action-save:hover {
-    background: rgba(0, 255, 255, 0.2);
-    box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+.timeline-section.inactive .panel-btn {
+    pointer-events: none;
 }
 
-.panel-btn.action-card:hover {
-    background: rgba(255, 200, 0, 0.2);
-    box-shadow: 0 0 10px rgba(255, 200, 0, 0.5);
+.action-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
-/* Randomize Lite Button */
-.panel-btn.action-randomize-lite {
-    background: rgba(150, 255, 150, 0.1);
-    border-color: rgba(150, 255, 150, 0.3);
-    color: #96ff96;
-    font-weight: 700;
-    letter-spacing: 1px;
+/* Geometry button long label helpers */
+.geom-btn-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.1;
 }
 
-.panel-btn.action-randomize-lite:hover {
-    background: rgba(150, 255, 150, 0.2);
-    box-shadow: 0 0 10px rgba(150, 255, 150, 0.5);
+.geom-btn-line {
+    font-size: 0.65rem;
 }

--- a/tests/timeline-adaptive-panel.spec.js
+++ b/tests/timeline-adaptive-panel.spec.js
@@ -1,0 +1,56 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Timeline Adaptive Panel Coverage
+ *
+ * Ensures the metadata-driven timeline editor toggles correctly and
+ * that newly added sequences adopt the shared SystemMetadata defaults.
+ */
+
+test.describe('Timeline adaptive panel', () => {
+  test('toggles timeline editor and applies metadata defaults to new sequences', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const hybridModeButton = page.getByRole('button', { name: /HYBRID MODE/i });
+    await expect(hybridModeButton).toBeVisible();
+    await hybridModeButton.click();
+
+    const timelineEditor = page.locator('#timeline-editor');
+    await expect(timelineEditor).toHaveClass(/active/);
+
+    const toggleButton = page.locator('#timelineEditorToggle');
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+
+    // Toggle closed then reopen to confirm accessibility hooks remain intact
+    await toggleButton.click();
+    await expect(timelineEditor).not.toHaveClass(/active/);
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'false');
+
+    await toggleButton.click();
+    await expect(timelineEditor).toHaveClass(/active/);
+    await expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+
+    const blankTimelineButton = page.locator('#timelinePresetList button[data-action-id="blank-timeline"]');
+    await expect(blankTimelineButton).toBeVisible();
+    await blankTimelineButton.click();
+
+    const sequenceItems = page.locator('#sequence-list .sequence-item');
+    await expect(sequenceItems).toHaveCount(0, { timeout: 15000 });
+
+    const addSequenceButton = page.locator('#timelineEditorActions button[data-action-id="add-sequence"]');
+    await expect(addSequenceButton).toBeVisible();
+    await addSequenceButton.click();
+
+    await expect(sequenceItems).toHaveCount(1, { timeout: 15000 });
+
+    const sequence = sequenceItems.first();
+
+    await expect(sequence.locator('label:has-text("Start Time") + input')).toHaveValue(/^(0|0\.0+)$/);
+    await expect(sequence.locator('label:has-text("Duration") + input')).toHaveValue(/^12(\.0+)?$/);
+    await expect(sequence.locator('label:has-text("System") + select')).toHaveValue('faceted');
+    await expect(sequence.locator('label:has-text("Geometry") + select')).toHaveValue('cycle');
+    await expect(sequence.locator('label:has-text("Geometry Audio Axis") + select')).toHaveValue('energy');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the choreographer deep-clones metadata defaults, sanitizes timeline summaries, and builds new sequences from shared descriptors
- update the global timeline handler to rely on metadata-driven defaults and document the architecture milestone in the refactor plan
- add Playwright coverage that toggles the adaptive panel and verifies metadata-seeded defaults after clearing the timeline

## Testing
- npx playwright test tests/timeline-adaptive-panel.spec.js *(fails: `playwright: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e8cb2e8c8329811e9f0b4c6836c9